### PR TITLE
Delete CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,0 @@
-hbc <bcxxxxxx+github@gmail.com>
-Jimmy Zelinskie <jimmy.zelinskie+git@gmail.com>
-Peter Edge <pedge@uber.com>

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,6 @@ license:
 	@go install ./vendor/go.uber.org/tools/update-license
 	update-license $(SRCS)
 
-.PHONY: contributors
-contributors:
-	git log --format='%aN <%aE>' | sort -fu > CONTRIBUTORS
-
 .PHONY: golden
 golden: install
 	for file in $(shell find internal/x/cmd/testdata/format -name '*.proto.golden'); do \
@@ -72,7 +68,7 @@ internalgen: install
 	prototool init etc/config/example --uncomment
 
 .PHONY: generate
-generate: license contributors golden example internalgen
+generate: license golden example internalgen
 
 .PHONY: checknodiffgenerated
 checknodiffgenerated:

--- a/README.md
+++ b/README.md
@@ -278,8 +278,6 @@ Prototool is under active development, if you want to help, here's some places t
 
 Over the coming months, we hope to push to a v1.0.
 
-If sending a PR, make sure to run `make contributors` before submitting.
-
 A note on package layout: all Golang code except for `cmd/prototool/main.go` is purposefully under the `internal` package to not expose any API for the time being. Within the internal package, anything under `internal/x` has not been reviewed, and is especially unstable. Any package in `internal` not in `internal/x` has been fully reviewed and is more stable.
 
 ## Special Thanks


### PR DESCRIPTION
This file is causing more issues than problems it solves because it causes diffs to be generated, which fails CI. It's especially confusing for people submitting PRs We can see contributors on GitHub anyways.

Merging this will fix #32 and #33.