### PR TITLE
Add linter to make sure package is declared

### DIFF
--- a/internal/x/cmd/cmd_test.go
+++ b/internal/x/cmd/cmd_test.go
@@ -129,6 +129,14 @@ func TestLint(t *testing.T) {
 	assertDoLintFile(
 		t,
 		false,
+		`1:1:FILE_OPTIONS_REQUIRE_GO_PACKAGE
+		1:1:FILE_OPTIONS_REQUIRE_JAVA_PACKAGE
+		1:1:PACKAGE_IS_DECLARED`,
+		"testdata/lint/base_file.proto",
+	)
+	assertDoLintFile(
+		t,
+		false,
 		`5:1:FILE_OPTIONS_EQUAL_GO_PACKAGE_PB_SUFFIX
 		8:1:FILE_OPTIONS_EQUAL_JAVA_PACKAGE_COM_PB`,
 		"testdata/lint/file_options_incorrect.proto",

--- a/internal/x/cmd/testdata/lint/base_file.proto
+++ b/internal/x/cmd/testdata/lint/base_file.proto
@@ -1,0 +1,1 @@
+syntax = "proto3";

--- a/internal/x/lint/check_package_lower_snake_case.go
+++ b/internal/x/lint/check_package_lower_snake_case.go
@@ -21,8 +21,6 @@
 package lint
 
 import (
-	"text/scanner"
-
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/x/strs"
 	"github.com/uber/prototool/internal/x/text"
@@ -60,12 +58,10 @@ func (v *packageLowerSnakeCaseVisitor) VisitPackage(pkg *proto.Package) {
 }
 
 func (v *packageLowerSnakeCaseVisitor) Finally() error {
-	if v.pkg == nil {
-		v.AddFailuref(scanner.Position{}, "No package declaration found.")
-		return nil
-	}
-	if !strs.IsLowerSnakeCase(v.pkg.Name, '.') {
-		v.AddFailuref(v.pkg.Position, "Package should be lower_snake.case but was %q.", v.pkg.Name)
+	if v.pkg != nil {
+		if !strs.IsLowerSnakeCase(v.pkg.Name, '.') {
+			v.AddFailuref(v.pkg.Position, "Package should be lower_snake.case but was %q.", v.pkg.Name)
+		}
 	}
 	return nil
 }

--- a/internal/x/lint/lint.go
+++ b/internal/x/lint/lint.go
@@ -59,6 +59,7 @@ var (
 		messagesHaveCommentsChecker,
 		messagesHaveCommentsExceptRequestResponseTypesChecker,
 		oneofNamesLowerSnakeCaseChecker,
+		packageIsDeclaredChecker,
 		packageLowerSnakeCaseChecker,
 		packagesSameInDirChecker,
 		rpcsHaveCommentsChecker,


### PR DESCRIPTION
This fixes the two issues raised in #39.

- A separate linter `PACKAGE_IS_DECLARED` is added to verify that the package is declared.
- The check for this is removed from `PACKAGE_LOWER_SNAKE_CASE` and `PACKAGES_SAME_IN_DIR`.
- The filename is added to the outputted failure.

Given this proto file `b.proto`:

```
syntax = "proto3";
```

Before this change, `prototool lint b.proto` outputs:

```
$ prototool lint b.proto
<input>:1:1:No package declaration found.
<input>:1:1:No package declaration found.
b.proto:1:1:File option "go_package" is required.
b.proto:1:1:File option "java_package" is required.
```

After this change, `prototool lint b.proto` outputs:

```
$ prototool lint b.proto
b.proto:1:1:File option "go_package" is required.
b.proto:1:1:File option "java_package" is required.
b.proto:1:1:No package declaration found.
```

This also adds testing to verify that this works as intended in the future.