### PR TITLE
Update vendor and fix glide

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 59b2aadad3480a5d3d670672699ac2d3311d13744253beafbaa312b035f6f92b
-updated: 2018-04-10T15:23:27.83890945+02:00
+hash: 5cf950ed3c5b236f5dd3e6071c2af4ed4f45505577bf979963b56e88b8208627
+updated: 2018-04-24T15:58:59.418159873+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -38,7 +38,7 @@ imports:
   - ptypes/timestamp
   - ptypes/wrappers
 - name: github.com/grpc-ecosystem/grpc-gateway
-  version: 3189c0c0c638bd69bf223a1411ba20c4427647d5
+  version: e8bd377da7395186f2f042ee6b366fa5a11d2b39
   subpackages:
   - runtime
   - runtime/internal
@@ -46,7 +46,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jhump/protoreflect
-  version: cfdba734743d6b9685ff2e8d78c7e6c7e6ddad65
+  version: 5cc2142026378ce11af191cffef661ec20dc6384
   subpackages:
   - desc
   - desc/internal
@@ -73,7 +73,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a
+  version: e5b036cc37a466a0af27d604d1ee500211d16d6a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -87,11 +87,11 @@ imports:
 - name: github.com/russross/blackfriday
   version: 55d61fa8aa702f59229e6cff85793c22e580eaf5
 - name: github.com/spf13/cobra
-  version: cd30c2a7e91a1d63fd9a0027accf18a681e9d50b
+  version: 7ee208b09f12c42bb7f5b0e14cd071706ee17993
   subpackages:
   - doc
 - name: github.com/spf13/pflag
-  version: 1ce0cc6db4029d97571db82f85092fccedb572ce
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/uber-go/atomic
   version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
   subpackages:
@@ -110,11 +110,11 @@ imports:
 - name: go.uber.org/atomic
   version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: go.uber.org/dig
-  version: d100de9c8cc8358591507951141bc107713ba671
+  version: 15c67344e48b1b3317399a647b0ec0069c34321d
   subpackages:
   - internal/digreflect
 - name: go.uber.org/fx
-  version: 35bf66c87beb2c8ec1a68cf00b54542e2d169c0b
+  version: ed7e99834c0a7099c6cb6434fe5a7b007ac00db9
   subpackages:
   - internal/fxlog
   - internal/fxreflect
@@ -132,7 +132,7 @@ imports:
   subpackages:
   - version
 - name: go.uber.org/yarpc
-  version: b505f97615337afa5879d5bbc5fe2dec2b992848
+  version: fda61a0e595df6082db1e318df658917dec8e3e9
   subpackages:
   - api/encoding
   - api/middleware
@@ -154,7 +154,7 @@ imports:
   - pkg/procedure
   - yarpcerrors
 - name: go.uber.org/zap
-  version: 35aad584952c3e7020db7b839f6b102de6271f89
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool
@@ -162,10 +162,11 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: 61147c48b25b599e5b561d2e9c4f3e1ef489ca41
+  version: 5f9ae10d9af5b1c89ae6904293b14b064d4ada23
   subpackages:
   - bpf
   - context
+  - http/httpguts
   - http2
   - http2/hpack
   - idna
@@ -177,24 +178,25 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/text
-  version: 367d765ae293e2b5781a597dd9d433117e82fc51
+  version: 7922cc490dd5a7dbaa7fd5d6196b49db59ac042f
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: 51d0944304c3cbce4afe9e5247e21100037bff78
+  version: 7fd901a49ba6a7f87732eb344f6e3c5b19d1b200
   subpackages:
   - googleapis/api/annotations
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: d11072e7ca9811b1100b80ca0269ac831f06d024
+  version: 4166ea7dad0fc934a2bb0b99eb0750f8e3d3400f
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
   - balancer/base
   - balancer/roundrobin
+  - channelz
   - codes
   - connectivity
   - credentials
@@ -247,10 +249,8 @@ testImports:
   version: ce2550dad7144b81ae2f67dc5e55597643f6902b
   subpackages:
   - update-license
-- name: golang.org/x/lint
-  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
 - name: golang.org/x/tools
-  version: 5dfd8930f264888dd5fe26820a0ac605a384dd33
+  version: c1def519f03ddf76f16b3e444ee1095d73afa01b
   subpackages:
   - cmd/cover
 - name: honnef.co/go/tools

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5cf950ed3c5b236f5dd3e6071c2af4ed4f45505577bf979963b56e88b8208627
-updated: 2018-04-24T15:58:59.418159873+02:00
+hash: 7496dc3ea34fb0c74b5331db91859a636a7f696cda08075d90c24f6b69eb8df6
+updated: 2018-04-24T16:05:31.221862347+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -110,7 +110,7 @@ imports:
 - name: go.uber.org/atomic
   version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: go.uber.org/dig
-  version: 15c67344e48b1b3317399a647b0ec0069c34321d
+  version: d100de9c8cc8358591507951141bc107713ba671
   subpackages:
   - internal/digreflect
 - name: go.uber.org/fx
@@ -249,6 +249,9 @@ testImports:
   version: ce2550dad7144b81ae2f67dc5e55597643f6902b
   subpackages:
   - update-license
+- name: golang.org/x/lint
+  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
+  repo: https://github.com/golang/lint
 - name: golang.org/x/tools
   version: c1def519f03ddf76f16b3e444ee1095d73afa01b
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/uber/prototool
 import:
   - package: github.com/emicklei/proto
+    version: ff6be386c301eb22b1d738ffe54727e3a51d9bdb
   - package: github.com/fullstorydev/grpcurl
   - package: github.com/gogo/protobuf/protoc-gen-gogoslick
   - package: github.com/golang/protobuf/protoc-gen-go
@@ -12,6 +13,7 @@ import:
   - package: go.uber.org/zap
   - package: google.golang.org/grpc
     repo: https://github.com/grpc/grpc-go
+    version: master
   - package: gopkg.in/yaml.v2
 testImport:
   - package: github.com/golang/glog
@@ -23,7 +25,6 @@ testImport:
   - package: github.com/wadey/gocovmerge
   - package: go.uber.org/tools/update-license
   - package: go.uber.org/yarpc/encoding/protobuf/protoc-gen-yarpc-go
-  - package: golang.org/x/lint
   - package: golang.org/x/tools/cmd/cover
   - package: google.golang.org/genproto/googleapis/api/annotations
   - package: honnef.co/go/tools/cmd/staticcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,6 +25,8 @@ testImport:
   - package: github.com/wadey/gocovmerge
   - package: go.uber.org/tools/update-license
   - package: go.uber.org/yarpc/encoding/protobuf/protoc-gen-yarpc-go
+  - package: golang.org/x/lint
+    repo: https://github.com/golang/lint
   - package: golang.org/x/tools/cmd/cover
   - package: google.golang.org/genproto/googleapis/api/annotations
   - package: honnef.co/go/tools/cmd/staticcheck


### PR DESCRIPTION
Vendor is broken due to https://github.com/golang/lint/issues/397. This also locks `google.golang.org/grpc` to `master` due to new packages introduced that break `glide update`, and locks `github.com/emicklei/proto` to a commit due to https://github.com/emicklei/proto/issues/82.
