### PR TITLE
Move internal/x/wkt to internal/wkt

### DIFF
--- a/internal/wkt/wkt.go
+++ b/internal/wkt/wkt.go
@@ -18,6 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// Package wkt contains the list of the Google Well-Known Types as well
+// as the Golang package mappings for the generated code for
+// github.com/golang/protobuf and github.com/gogo/protobuf.
+//
+// https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
 package wkt
 
 var (

--- a/internal/wkt/wkt.go
+++ b/internal/wkt/wkt.go
@@ -27,27 +27,20 @@ package wkt
 
 var (
 	// Filenames contains the Google Well-Known Types filenames.
-	//
-	// These are alphabetically ordered.
-	Filenames = []string{
-		"google/protobuf/any.proto",
-		"google/protobuf/api.proto",
-		"google/protobuf/compiler/plugin.proto",
-		"google/protobuf/descriptor.proto",
-		"google/protobuf/duration.proto",
-		"google/protobuf/empty.proto",
-		"google/protobuf/field_mask.proto",
-		"google/protobuf/source_context.proto",
-		"google/protobuf/struct.proto",
-		"google/protobuf/timestamp.proto",
-		"google/protobuf/type.proto",
-		"google/protobuf/wrappers.proto",
+	Filenames = map[string]struct{}{
+		"google/protobuf/any.proto":             struct{}{},
+		"google/protobuf/api.proto":             struct{}{},
+		"google/protobuf/compiler/plugin.proto": struct{}{},
+		"google/protobuf/descriptor.proto":      struct{}{},
+		"google/protobuf/duration.proto":        struct{}{},
+		"google/protobuf/empty.proto":           struct{}{},
+		"google/protobuf/field_mask.proto":      struct{}{},
+		"google/protobuf/source_context.proto":  struct{}{},
+		"google/protobuf/struct.proto":          struct{}{},
+		"google/protobuf/timestamp.proto":       struct{}{},
+		"google/protobuf/type.proto":            struct{}{},
+		"google/protobuf/wrappers.proto":        struct{}{},
 	}
-
-	// FilenameMap contains the Google Well-Known Types filenames in a map.
-	//
-	// This is populated with the filenames in Filenames in the init function.
-	FilenameMap map[string]struct{}
 
 	// FilenameToGoModifierMap is a map from filename to package for github.com/golang/protobuf.
 	FilenameToGoModifierMap = map[string]string{
@@ -81,10 +74,3 @@ var (
 		"google/protobuf/wrappers.proto":        "github.com/gogo/protobuf/types",
 	}
 )
-
-func init() {
-	FilenameMap = make(map[string]struct{}, len(Filenames))
-	for _, filename := range Filenames {
-		FilenameMap[filename] = struct{}{}
-	}
-}

--- a/internal/x/format/first_pass_visitor.go
+++ b/internal/x/format/first_pass_visitor.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
+	"github.com/uber/prototool/internal/wkt"
 	"github.com/uber/prototool/internal/x/settings"
 	"github.com/uber/prototool/internal/x/text"
-	"github.com/uber/prototool/internal/x/wkt"
 )
 
 type firstPassVisitor struct {

--- a/internal/x/format/first_pass_visitor.go
+++ b/internal/x/format/first_pass_visitor.go
@@ -119,7 +119,7 @@ func (v *firstPassVisitor) VisitImport(element *proto.Import) {
 	v.haveHitNonComment = true
 	// this won't hit filenames that aren't imported with "google/protobuf"
 	// prefix directly, but this should be caught by the linter
-	if _, ok := wkt.FilenameMap[element.Filename]; ok {
+	if _, ok := wkt.Filenames[element.Filename]; ok {
 		v.WKTImports = append(v.WKTImports, element)
 	} else {
 		v.Imports = append(v.Imports, element)

--- a/internal/x/lint/check_wkt_directly_imported.go
+++ b/internal/x/lint/check_wkt_directly_imported.go
@@ -48,7 +48,7 @@ type wktDirectlyImportedVisitor struct {
 }
 
 func (v wktDirectlyImportedVisitor) VisitImport(element *proto.Import) {
-	for _, wktFilename := range wkt.Filenames {
+	for wktFilename := range wkt.Filenames {
 		if strings.HasSuffix(element.Filename, wktFilename) && element.Filename != wktFilename {
 			v.AddFailuref(element.Position, "Import %q is a Well-Known Type import but should be imported using google/protobuf as the base.", element.Filename)
 		}

--- a/internal/x/lint/check_wkt_directly_imported.go
+++ b/internal/x/lint/check_wkt_directly_imported.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
+	"github.com/uber/prototool/internal/wkt"
 	"github.com/uber/prototool/internal/x/text"
-	"github.com/uber/prototool/internal/x/wkt"
 )
 
 // TODO: This will not detect things like "timestamp.proto" or "protobuf/timestamp.proto"

--- a/internal/x/protoc/compiler.go
+++ b/internal/x/protoc/compiler.go
@@ -36,10 +36,10 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/wkt"
 	"github.com/uber/prototool/internal/x/file"
 	"github.com/uber/prototool/internal/x/settings"
 	"github.com/uber/prototool/internal/x/text"
-	"github.com/uber/prototool/internal/x/wkt"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
This is to review the `wkt` package, which is very easy. A package comment was added for more explanation.