### PR TITLE
Move internal/x/vars to internal/vars

### DIFF
--- a/internal/vars/vars.go
+++ b/internal/vars/vars.go
@@ -18,6 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// Package vars contains static variables used in Prototool.
+//
+// Some variables are populated at build time using ldflags.
 package vars
 
 const (

--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/vars"
 	"github.com/uber/prototool/internal/x/cfginit"
 	"github.com/uber/prototool/internal/x/diff"
 	"github.com/uber/prototool/internal/x/extract"
@@ -49,7 +50,6 @@ import (
 	"github.com/uber/prototool/internal/x/reflect"
 	"github.com/uber/prototool/internal/x/settings"
 	"github.com/uber/prototool/internal/x/text"
-	"github.com/uber/prototool/internal/x/vars"
 	"go.uber.org/zap"
 )
 

--- a/internal/x/protoc/downloader.go
+++ b/internal/x/protoc/downloader.go
@@ -35,8 +35,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/uber/prototool/internal/vars"
 	"github.com/uber/prototool/internal/x/settings"
-	"github.com/uber/prototool/internal/x/vars"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
This is to review the `vars` package, which is very easy. A package comment was added for more explanation.