### PR TITLE
Add harbormaster output option

### DIFF
--- a/internal/x/cmd/cmd.go
+++ b/internal/x/cmd/cmd.go
@@ -324,7 +324,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 	flags.bindCachePath(rootCmd.PersistentFlags())
 	flags.bindProtocURL(rootCmd.PersistentFlags())
 	flags.bindPrintFields(rootCmd.PersistentFlags())
-	flags.bindHarbormasterOutput(rootCmd.PersistentFlags())
+	flags.bindHarbormaster(rootCmd.PersistentFlags())
 
 	rootCmd.SetArgs(args)
 	rootCmd.SetOutput(stdout)
@@ -384,10 +384,10 @@ func getRunner(stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags
 			exec.RunnerWithDirMode(),
 		)
 	}
-	if flags.harbormasterOutput {
+	if flags.harbormaster {
 		runnerOptions = append(
 			runnerOptions,
-			exec.RunnerWithHarbormasterOutput(),
+			exec.RunnerWithHarbormaster(),
 		)
 	}
 	workDirPath, err := os.Getwd()
@@ -424,23 +424,23 @@ func printAndGetErrorExitCode(err error, stdout io.Writer) int {
 }
 
 type flags struct {
-	debug              bool
-	cachePath          string
-	protocURL          string
-	printFields        string
-	dirMode            bool
-	overwrite          bool
-	diffMode           bool
-	lintMode           bool
-	disableFormat      bool
-	disableLint        bool
-	gen                bool
-	headers            []string
-	callTimeout        string
-	connectTimeout     string
-	keepaliveTime      string
-	uncomment          bool
-	harbormasterOutput bool
+	debug          bool
+	cachePath      string
+	protocURL      string
+	printFields    string
+	dirMode        bool
+	overwrite      bool
+	diffMode       bool
+	lintMode       bool
+	disableFormat  bool
+	disableLint    bool
+	gen            bool
+	headers        []string
+	callTimeout    string
+	connectTimeout string
+	keepaliveTime  string
+	uncomment      bool
+	harbormaster   bool
 }
 
 func (f *flags) bindDebug(flagSet *pflag.FlagSet) {
@@ -507,6 +507,6 @@ func (f *flags) bindUncomment(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.uncomment, "uncomment", false, "Uncomment the example config settings.")
 }
 
-func (f *flags) bindHarbormasterOutput(flagSet *pflag.FlagSet) {
-	flagSet.BoolVar(&f.harbormasterOutput, "harbormaster-output", false, "Print failures in JSON compatible with the Harbormaster API.")
+func (f *flags) bindHarbormaster(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.harbormaster, "harbormaster", false, "Print failures in JSON compatible with the Harbormaster API.")
 }

--- a/internal/x/cmd/cmd.go
+++ b/internal/x/cmd/cmd.go
@@ -324,6 +324,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 	flags.bindCachePath(rootCmd.PersistentFlags())
 	flags.bindProtocURL(rootCmd.PersistentFlags())
 	flags.bindPrintFields(rootCmd.PersistentFlags())
+	flags.bindHarbormasterOutput(rootCmd.PersistentFlags())
 
 	rootCmd.SetArgs(args)
 	rootCmd.SetOutput(stdout)
@@ -383,6 +384,12 @@ func getRunner(stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags
 			exec.RunnerWithDirMode(),
 		)
 	}
+	if flags.harbormasterOutput {
+		runnerOptions = append(
+			runnerOptions,
+			exec.RunnerWithHarbormasterOutput(),
+		)
+	}
 	workDirPath, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -417,22 +424,23 @@ func printAndGetErrorExitCode(err error, stdout io.Writer) int {
 }
 
 type flags struct {
-	debug          bool
-	cachePath      string
-	protocURL      string
-	printFields    string
-	dirMode        bool
-	overwrite      bool
-	diffMode       bool
-	lintMode       bool
-	disableFormat  bool
-	disableLint    bool
-	gen            bool
-	headers        []string
-	callTimeout    string
-	connectTimeout string
-	keepaliveTime  string
-	uncomment      bool
+	debug              bool
+	cachePath          string
+	protocURL          string
+	printFields        string
+	dirMode            bool
+	overwrite          bool
+	diffMode           bool
+	lintMode           bool
+	disableFormat      bool
+	disableLint        bool
+	gen                bool
+	headers            []string
+	callTimeout        string
+	connectTimeout     string
+	keepaliveTime      string
+	uncomment          bool
+	harbormasterOutput bool
 }
 
 func (f *flags) bindDebug(flagSet *pflag.FlagSet) {
@@ -497,4 +505,8 @@ func (f *flags) bindKeepaliveTime(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindUncomment(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.uncomment, "uncomment", false, "Uncomment the example config settings.")
+}
+
+func (f *flags) bindHarbormasterOutput(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.harbormasterOutput, "harbormaster-output", false, "Print failures in JSON compatible with the Harbormaster API.")
 }

--- a/internal/x/exec/exec.go
+++ b/internal/x/exec/exec.go
@@ -105,6 +105,16 @@ func RunnerWithDirMode() RunnerOption {
 	}
 }
 
+// RunnerWithHarbormasterOutput returns a RunnerOption that will print
+// failures as Harbormaster compatible JSON.
+//
+// https://secure.phabricator.com/conduit/method/harbormaster.sendmessage
+func RunnerWithHarbormasterOutput() RunnerOption {
+	return func(runner *runner) {
+		runner.harbormasterOutput = true
+	}
+}
+
 // NewRunner returns a new Runner.
 func NewRunner(workDirPath string, input io.Reader, output io.Writer, options ...RunnerOption) Runner {
 	return newRunner(workDirPath, input, output, options...)

--- a/internal/x/exec/exec.go
+++ b/internal/x/exec/exec.go
@@ -105,13 +105,13 @@ func RunnerWithDirMode() RunnerOption {
 	}
 }
 
-// RunnerWithHarbormasterOutput returns a RunnerOption that will print
+// RunnerWithHarbormaster returns a RunnerOption that will print
 // failures as Harbormaster compatible JSON.
 //
 // https://secure.phabricator.com/conduit/method/harbormaster.sendmessage
-func RunnerWithHarbormasterOutput() RunnerOption {
+func RunnerWithHarbormaster() RunnerOption {
 	return func(runner *runner) {
-		runner.harbormasterOutput = true
+		runner.harbormaster = true
 	}
 }
 

--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -815,7 +815,11 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 		}
 		if shouldPrint {
 			if r.harbormasterOutput {
-				data, err := json.Marshal(phab.TextFailureToHarbormasterLintResult(failure))
+				harbormasterLintResult, err := phab.TextFailureToHarbormasterLintResult(failure)
+				if err != nil {
+					return err
+				}
+				data, err := json.Marshal(harbormasterLintResult)
 				if err != nil {
 					return err
 				}

--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -819,7 +819,7 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 				if err != nil {
 					return err
 				}
-				if err := r.println(string(data)); err != nil {
+				if _, err := fmt.Fprintln(bufWriter, string(data)); err != nil {
 					return err
 				}
 			} else if err := failure.Fprintln(bufWriter, failureFields...); err != nil {

--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -58,17 +58,17 @@ import (
 var jsonMarshaler = &jsonpb.Marshaler{Indent: "  "}
 
 type runner struct {
-	configProvider     settings.ConfigProvider
-	protoSetProvider   file.ProtoSetProvider
-	workDirPath        string
-	input              io.Reader
-	output             io.Writer
-	logger             *zap.Logger
-	cachePath          string
-	protocURL          string
-	printFields        string
-	dirMode            bool
-	harbormasterOutput bool
+	configProvider   settings.ConfigProvider
+	protoSetProvider file.ProtoSetProvider
+	workDirPath      string
+	input            io.Reader
+	output           io.Writer
+	logger           *zap.Logger
+	cachePath        string
+	protocURL        string
+	printFields      string
+	dirMode          bool
+	harbormaster     bool
 }
 
 func newRunner(workDirPath string, input io.Reader, output io.Writer, options ...RunnerOption) *runner {
@@ -814,7 +814,7 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 			}
 		}
 		if shouldPrint {
-			if r.harbormasterOutput {
+			if r.harbormaster {
 				harbormasterLintResult, err := phab.TextFailureToHarbormasterLintResult(failure)
 				if err != nil {
 					return err

--- a/internal/x/phab/phab.go
+++ b/internal/x/phab/phab.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package phab provides functionality to interact with Phabricator.
+//
+// The primary purpose is to convert failures to JSON that is compatible
+// with the Harbormaster API.
+//
+// https://secure.phabricator.com/conduit/method/harbormaster.sendmessage
+package phab
+
+import "github.com/uber/prototool/internal/x/text"
+
+const (
+	// DefaultHarbormasterLintResultName is the default name
+	// used when populating a HarbormasterLintResult.
+	DefaultHarbormasterLintResultName = "PROTOTOOL"
+	// DefaultHarbormasterLintResultCode is the default code
+	// used when populating a HarbormasterLintResult.
+	DefaultHarbormasterLintResultCode = "PROTOTOOL"
+	// DefaultHarbormasterLintResultSeverity is the default severity
+	// used when populating a HarbormasterLintResult.
+	DefaultHarbormasterLintResultSeverity = "error"
+)
+
+// HarbormasterLintResult represents a text.Failure in a structure
+// compatible with a Harbormaster Lint Result. It is meant to be
+// encoded to JSON.
+//
+// https://secure.phabricator.com/conduit/method/harbormaster.sendmessage
+type HarbormasterLintResult struct {
+	Name        string `json:"name,omitempty"`
+	Code        string `json:"code,omitempty"`
+	Severity    string `json:"severity,omitempty"`
+	Path        string `json:"path,omitempty"`
+	Line        int    `json:"line,omitempty"`
+	Char        int    `json:"char,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// TextFailureToHarbormasterLintResult converts a text.Failure to a HarbormasterLintResult.
+func TextFailureToHarbormasterLintResult(textFailure *text.Failure) *HarbormasterLintResult {
+	if textFailure == nil {
+		return nil
+	}
+	harbormasterLintResult := &HarbormasterLintResult{
+		Name:     DefaultHarbormasterLintResultName,
+		Code:     textFailure.ID,
+		Severity: DefaultHarbormasterLintResultSeverity,
+		// TODO: Filename is not a required field on text.Failure
+		// but Path is a required field for a Harbormaster Lint Result
+		// There are no good options here
+		Path:        textFailure.Filename,
+		Line:        textFailure.Line,
+		Char:        textFailure.Column,
+		Description: textFailure.Message,
+	}
+	if harbormasterLintResult.Code == "" {
+		harbormasterLintResult.Code = DefaultHarbormasterLintResultCode
+	}
+	return harbormasterLintResult
+}

--- a/internal/x/phab/phab_test.go
+++ b/internal/x/phab/phab_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package phab provides functionality to interact with Phabricator.
+//
+// The primary purpose is to convert failures to JSON that is compatible
+// with the Harbormaster API.
+//
+// https://secure.phabricator.com/conduit/method/harbormaster.sendmessage
+package phab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/prototool/internal/x/text"
+)
+
+func TestTextFailureToHarbormasterLintResult(t *testing.T) {
+	assert.Equal(
+		t,
+		&HarbormasterLintResult{
+			Name:        DefaultHarbormasterLintResultName,
+			Code:        DefaultHarbormasterLintResultCode,
+			Severity:    DefaultHarbormasterLintResultSeverity,
+			Path:        "path/to/foo.proto",
+			Line:        2,
+			Description: "Foo is a foo.",
+		},
+		TextFailureToHarbormasterLintResult(
+			&text.Failure{
+				Filename: "path/to/foo.proto",
+				Line:     2,
+				Message:  "Foo is a foo.",
+			},
+		),
+	)
+	assert.Equal(
+		t,
+		&HarbormasterLintResult{
+			Name:        DefaultHarbormasterLintResultName,
+			Code:        "FOO",
+			Severity:    DefaultHarbormasterLintResultSeverity,
+			Path:        "path/to/foo.proto",
+			Line:        2,
+			Description: "Foo is a foo.",
+		},
+		TextFailureToHarbormasterLintResult(
+			&text.Failure{
+				Filename: "path/to/foo.proto",
+				Line:     2,
+				ID:       "FOO",
+				Message:  "Foo is a foo.",
+			},
+		),
+	)
+}

--- a/internal/x/phab/phab_test.go
+++ b/internal/x/phab/phab_test.go
@@ -18,12 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package phab provides functionality to interact with Phabricator.
-//
-// The primary purpose is to convert failures to JSON that are compatible
-// with the Harbormaster API.
-//
-// https://secure.phabricator.com/conduit/method/harbormaster.sendmessage
 package phab
 
 import (

--- a/internal/x/phab/phab_test.go
+++ b/internal/x/phab/phab_test.go
@@ -20,7 +20,7 @@
 
 // Package phab provides functionality to interact with Phabricator.
 //
-// The primary purpose is to convert failures to JSON that is compatible
+// The primary purpose is to convert failures to JSON that are compatible
 // with the Harbormaster API.
 //
 // https://secure.phabricator.com/conduit/method/harbormaster.sendmessage

--- a/internal/x/phab/phab_test.go
+++ b/internal/x/phab/phab_test.go
@@ -28,6 +28,14 @@ import (
 )
 
 func TestTextFailureToHarbormasterLintResult(t *testing.T) {
+	harbormasterLintResult, err := TextFailureToHarbormasterLintResult(
+		&text.Failure{
+			Filename: "path/to/foo.proto",
+			Line:     2,
+			Message:  "Foo is a foo.",
+		},
+	)
+	assert.NoError(t, err)
 	assert.Equal(
 		t,
 		&HarbormasterLintResult{
@@ -38,14 +46,17 @@ func TestTextFailureToHarbormasterLintResult(t *testing.T) {
 			Line:        2,
 			Description: "Foo is a foo.",
 		},
-		TextFailureToHarbormasterLintResult(
-			&text.Failure{
-				Filename: "path/to/foo.proto",
-				Line:     2,
-				Message:  "Foo is a foo.",
-			},
-		),
+		harbormasterLintResult,
 	)
+	harbormasterLintResult, err = TextFailureToHarbormasterLintResult(
+		&text.Failure{
+			Filename: "path/to/foo.proto",
+			Line:     2,
+			ID:       "FOO",
+			Message:  "Foo is a foo.",
+		},
+	)
+	assert.NoError(t, err)
 	assert.Equal(
 		t,
 		&HarbormasterLintResult{
@@ -56,13 +67,6 @@ func TestTextFailureToHarbormasterLintResult(t *testing.T) {
 			Line:        2,
 			Description: "Foo is a foo.",
 		},
-		TextFailureToHarbormasterLintResult(
-			&text.Failure{
-				Filename: "path/to/foo.proto",
-				Line:     2,
-				ID:       "FOO",
-				Message:  "Foo is a foo.",
-			},
-		),
+		harbormasterLintResult,
 	)
 }


### PR DESCRIPTION
Per a conversation I had with @AlexAPB. We need a way to produce Harbormaster compatible output, and it seems overkill to create a new wrapper binary for this, especially as Harbormaster is OSS. This adds a flag `--harbormaster` that will output Harbormaster compatible JSON for failures instead of the standard `filename:line:column:message`. Alex, see if this looks good and if you want alternative naming, or if this is not a path you'd want to pursue.

https://secure.phabricator.com/conduit/method/harbormaster.sendmessage