### PR TITLE
fix a typo in the example

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -18,7 +18,7 @@ no_default_excludes: true
 # By default, the directory of the config file is included,
 # or the current directory if there is no config file.
 protoc_includes:
-  - ../../vendor/github.com/grpc-ecosystem/grpc-gateweay/third_party/googleapis
+  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 
 # Include the Well-Known Types when compiling with protoc.
 # For example, this allows you to do import "google/protobuf/timestamp.proto" in your Protobuf files.


### PR DESCRIPTION
trivial typo, will go figure out where it is done in the proto init and change it there too

Thanks for your pull request! We really appreciate all OSS efforts, big or small.

Before submitting, make sure to:

- Run `make init` if you have not already to download dependencies to `vendor`.
- Run `make generate` to make sure there is no diff.
- Run `make` to make sure all tests pass. This is functionally equivalent to the tests run on CI.
