### PR TITLE
fix typo in cfginit

### DIFF
--- a/internal/x/cfginit/cfginit.go
+++ b/internal/x/cfginit/cfginit.go
@@ -45,7 +45,7 @@ protoc_version: {{.ProtocVersion}}
 # By default, the directory of the config file is included,
 # or the current directory if there is no config file.
 {{.V}}protoc_includes:
-{{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateweay/third_party/googleapis
+{{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 
 # Include the Well-Known Types when compiling with protoc.
 # For example, this allows you to do import "google/protobuf/timestamp.proto" in your Protobuf files.


### PR DESCRIPTION
Thanks for your pull request! We really appreciate all OSS efforts, big or small.

Before submitting, make sure to:

- Run `make init` if you have not already to download dependencies to `vendor`.
- Run `make generate` to make sure there is no diff.
- Run `make` to make sure all tests pass. This is functionally equivalent to the tests run on CI.
