### PR TITLE
fix typo in 'gateweay'

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -18,7 +18,7 @@ no_default_excludes: true
 # By default, the directory of the config file is included,
 # or the current directory if there is no config file.
 protoc_includes:
-  - ../../vendor/github.com/grpc-ecosystem/grpc-gateweay/third_party/googleapis
+  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 
 # Include the Well-Known Types when compiling with protoc.
 # For example, this allows you to do import "google/protobuf/timestamp.proto" in your Protobuf files.

--- a/internal/x/cfginit/cfginit.go
+++ b/internal/x/cfginit/cfginit.go
@@ -45,7 +45,7 @@ protoc_version: {{.ProtocVersion}}
 # By default, the directory of the config file is included,
 # or the current directory if there is no config file.
 {{.V}}protoc_includes:
-{{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateweay/third_party/googleapis
+{{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 
 # Include the Well-Known Types when compiling with protoc.
 # For example, this allows you to do import "google/protobuf/timestamp.proto" in your Protobuf files.


### PR DESCRIPTION
The cfginit and example have a typo in the spelling of gateway.

Travis appears to be comparing against a golden version somewhere and failing, so will need somebody with access to override that.

FWIW, your make instructions fail on my system (ubuntu 16.10 with go 1.8.1):

```
-ldflags "-X 'github.com/uber/prototool/internal/x/vars.GitCommit=28cfbc7facbb23518f7fd95809a62484f39b75e0' -X 'github.com/uber/prototool/internal/x/vars.BuiltTimestamp=Wed May  2 20:49:23 UTC 2018'" \
	github.com/uber/prototool/cmd/prototool
# github.com/uber/prototool/vendor/go.uber.org/zap
vendor/go.uber.org/zap/field.go:33: syntax error: unexpected = in type declaration
Makefile:25: recipe for target 'install' failed
make[1]: *** [install] Error 2
make[1]: Leaving directory '/home/termie/go/src/github.com/uber/prototool'
Makefile:69: recipe for target 'checknodiffgenerated' failed
make: *** [checknodiffgenerated] Error 2
```
