### PR TITLE
Fix typo in cfginit and update README.md to reflect development only on Golang 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Prototool is under active development, if you want to help, here's some places t
 
 Over the coming months, we hope to push to a v1.0.
 
-On initially cloning the repository, run `make init` if you have not already to download dependencies to `vendor`.
+Note that development of Prototool will only work with Golang 1.10 or newer. On initially cloning the repository, run `make init` if you have not already to download dependencies to `vendor`.
 
 Before submitting a PR, make sure to:
 

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -18,7 +18,7 @@ no_default_excludes: true
 # By default, the directory of the config file is included,
 # or the current directory if there is no config file.
 protoc_includes:
-  - ../../vendor/github.com/grpc-ecosystem/grpc-gateweay/third_party/googleapis
+  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 
 # Include the Well-Known Types when compiling with protoc.
 # For example, this allows you to do import "google/protobuf/timestamp.proto" in your Protobuf files.

--- a/internal/x/cfginit/cfginit.go
+++ b/internal/x/cfginit/cfginit.go
@@ -45,7 +45,7 @@ protoc_version: {{.ProtocVersion}}
 # By default, the directory of the config file is included,
 # or the current directory if there is no config file.
 {{.V}}protoc_includes:
-{{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateweay/third_party/googleapis
+{{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 
 # Include the Well-Known Types when compiling with protoc.
 # For example, this allows you to do import "google/protobuf/timestamp.proto" in your Protobuf files.


### PR DESCRIPTION
See #56.

- Fixes a typo in `cfginit`.
- Updates the `README.md` to reflect that Prototool development will only work on Golang 1.10