### PR TITLE
Handle nested options in the formatter

### DIFF
--- a/example/idl/uber/foo/foo.proto
+++ b/example/idl/uber/foo/foo.proto
@@ -91,7 +91,9 @@ service HelloService {
   rpc Foo(sub.Dep) returns (FooResponse) {}
   // Bar does a bar.
   rpc Bar(BarRequest) returns (foo.Dep) {
-    option (google.api.http) = { get: "/bar/{id}" };
+    option (google.api.http) = {
+      get: "/bar/{id}"
+    };
   }
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7496dc3ea34fb0c74b5331db91859a636a7f696cda08075d90c24f6b69eb8df6
-updated: 2018-04-24T16:05:31.221862347+02:00
+hash: 279ab5f6a82b352754728ac6a1b061537653aca77ac269f1defef967f0979ab6
+updated: 2018-05-04T13:08:16.519777472+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -10,7 +10,7 @@ imports:
   subpackages:
   - md2man
 - name: github.com/emicklei/proto
-  version: ff6be386c301eb22b1d738ffe54727e3a51d9bdb
+  version: 0cbee195654dd0aab66561d51e08d37554fd8cfe
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/fullstorydev/grpcurl
@@ -24,7 +24,7 @@ imports:
   - sortkeys
   - types
 - name: github.com/golang/protobuf
-  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
+  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
   - jsonpb
   - proto
@@ -38,7 +38,7 @@ imports:
   - ptypes/timestamp
   - ptypes/wrappers
 - name: github.com/grpc-ecosystem/grpc-gateway
-  version: e8bd377da7395186f2f042ee6b366fa5a11d2b39
+  version: 31596c443932b6c7fc12249f8d1a5f515b6971ca
   subpackages:
   - runtime
   - runtime/internal
@@ -46,7 +46,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jhump/protoreflect
-  version: 5cc2142026378ce11af191cffef661ec20dc6384
+  version: 2970d65171506756b3068ab51390f50a0614f076
   subpackages:
   - desc
   - desc/internal
@@ -73,7 +73,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: e5b036cc37a466a0af27d604d1ee500211d16d6a
+  version: d811d2e9bf898806ecfb6ef6296774b13ffc314c
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -85,15 +85,15 @@ imports:
   - nfs
   - xfs
 - name: github.com/russross/blackfriday
-  version: 55d61fa8aa702f59229e6cff85793c22e580eaf5
+  version: 11635eb403ff09dbc3a6b5a007ab5ab09151c229
 - name: github.com/spf13/cobra
-  version: 7ee208b09f12c42bb7f5b0e14cd071706ee17993
+  version: ef82de70bb3f60c65fb8eebacbb2d122ef517385
   subpackages:
   - doc
 - name: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/uber-go/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
   subpackages:
   - utils
 - name: github.com/uber-go/tally
@@ -108,7 +108,7 @@ imports:
   - trand
   - typed
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
   version: d100de9c8cc8358591507951141bc107713ba671
   subpackages:
@@ -132,7 +132,7 @@ imports:
   subpackages:
   - version
 - name: go.uber.org/yarpc
-  version: fda61a0e595df6082db1e318df658917dec8e3e9
+  version: a4cbd4cc9573c09ef730430e8c4fc2a665677188
   subpackages:
   - api/encoding
   - api/middleware
@@ -162,7 +162,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: 5f9ae10d9af5b1c89ae6904293b14b064d4ada23
+  version: 640f4622ab692b87c2f3a94265e6f579fe38263d
   subpackages:
   - bpf
   - context
@@ -185,12 +185,12 @@ imports:
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: 7fd901a49ba6a7f87732eb344f6e3c5b19d1b200
+  version: 86e600f69ee4704c6efbf6a2a40a5c10700e76c2
   subpackages:
   - googleapis/api/annotations
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 4166ea7dad0fc934a2bb0b99eb0750f8e3d3400f
+  version: b412d5aa54a1f82a55b21f3a8862d6d73baee3d9
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
@@ -224,10 +224,12 @@ testImports:
   version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
+- name: github.com/ghodss/yaml
+  version: e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/lint
-  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
+  version: 470b6b0bb3005eda157f0275e2e4895055396a81
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
@@ -250,10 +252,10 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/lint
-  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
+  version: 470b6b0bb3005eda157f0275e2e4895055396a81
   repo: https://github.com/golang/lint
 - name: golang.org/x/tools
-  version: c1def519f03ddf76f16b3e444ee1095d73afa01b
+  version: ae8027637c91c400af8a3e006c35c7011b3ca1fe
   subpackages:
   - cmd/cover
 - name: honnef.co/go/tools

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/uber/prototool
 import:
   - package: github.com/emicklei/proto
-    version: ff6be386c301eb22b1d738ffe54727e3a51d9bdb
+    version: 0cbee195654dd0aab66561d51e08d37554fd8cfe
   - package: github.com/fullstorydev/grpcurl
   - package: github.com/gogo/protobuf/protoc-gen-gogoslick
   - package: github.com/golang/protobuf/protoc-gen-go
@@ -18,6 +18,7 @@ import:
 testImport:
   - package: github.com/golang/glog
   - package: github.com/golang/lint/golint
+  - package: github.com/ghodss/yaml
   - package: github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
   - package: github.com/kisielk/errcheck
   - package: github.com/kisielk/gotool

--- a/internal/x/cmd/testdata/format/bar/bar.proto
+++ b/internal/x/cmd/testdata/format/bar/bar.proto
@@ -13,6 +13,7 @@ option java_package = "com.bar.pb";
 message Dep {
   int64 hello = 1;
   int64 bar = 2;
+  Dep recursive = 3;
 }
 
 extend google.protobuf.MessageOptions {

--- a/internal/x/cmd/testdata/format/bar/bar.proto.golden
+++ b/internal/x/cmd/testdata/format/bar/bar.proto.golden
@@ -13,6 +13,7 @@ option java_package = "com.bar.pb";
 message Dep {
 	int64 hello = 1;
 	int64 bar = 2;
+	Dep recursive = 3;
 }
 
 extend google.protobuf.MessageOptions {
@@ -28,6 +29,7 @@ extend google.protobuf.FileOptions {
 extend google.protobuf.FieldOptions {
 	bool field_option = 80006;
 	Dep field_dep_option = 80007;
+	repeated int64 list_int_option = 80017;
 }
 
 extend google.protobuf.OneofOptions {

--- a/internal/x/cmd/testdata/format/bar/bar.proto.golden
+++ b/internal/x/cmd/testdata/format/bar/bar.proto.golden
@@ -29,7 +29,6 @@ extend google.protobuf.FileOptions {
 extend google.protobuf.FieldOptions {
 	bool field_option = 80006;
 	Dep field_dep_option = 80007;
-	repeated int64 list_int_option = 80017;
 }
 
 extend google.protobuf.OneofOptions {

--- a/internal/x/cmd/testdata/format/foo/foo.proto
+++ b/internal/x/cmd/testdata/format/foo/foo.proto
@@ -124,7 +124,7 @@ service Daylight {
   hello: 1 };// inline comment30
   rpc Hello(Bat) returns (Empty) {
     //option (bar.method_option) = true;
-    option (bar.method_dep_option) = { hello: 1, bar: 2 }; // inline comment22
+    option (bar.method_dep_option) = { hello: 1, bar: 2, recursive: { hello: 3, recursive: { bar: 2 } } }; // inline comment22
   } // inline comment23
   rpc Foo(Empty) returns (Bat); // inline comment24
 }

--- a/internal/x/cmd/testdata/format/foo/foo.proto.golden
+++ b/internal/x/cmd/testdata/format/foo/foo.proto.golden
@@ -131,6 +131,12 @@ service Daylight {
 		option (bar.method_dep_option) = {
 			hello: 1
 			bar: 2
+			recursive: {
+				hello: 3
+				recursive: {
+					bar: 2
+				}
+			}
 		}; // inline comment22
 	} // inline comment23
 	rpc Foo(Empty) returns (Bat); // inline comment24

--- a/internal/x/cmd/testdata/format/foo/foo.proto.golden
+++ b/internal/x/cmd/testdata/format/foo/foo.proto.golden
@@ -23,7 +23,9 @@ option java_outer_classname = "FooProto"; // inline comment5
 // comment12
 option java_package = "com.foo.pb"; // inline comment23
 // comment16
-option (bar.file_dep_option) = { hello: 1 }; // inline comment16
+option (bar.file_dep_option) = {
+	hello: 1
+}; // inline comment16
 // comment6
 option (bar.file_option) = true; // inline comment6
 // comment7
@@ -44,7 +46,9 @@ message Baz {
 	//  
 	option (bar.message_option_proto2) = true;
 	// comment15
-	option (bar.message_dep_option) = { hello: 1 }; // inline comment15
+	option (bar.message_dep_option) = {
+		hello: 1
+	}; // inline comment15
 	int64 hello = 1;
 	// unassociated comment
 
@@ -58,23 +62,31 @@ message Baz {
 	];
 	// comment17
 	int64 woot2 = 6 [
-		(bar.field_dep_option) = { hello: 1 },
+		(bar.field_dep_option) = {
+			hello: 1
+		},
 		(bar.field_option) = true
 	]; // inline comment17
 	map<string, int64> m = 11;
 	map<string, int64> m2 = 12 [
-		(bar.field_dep_option) = { hello: 1 },
+		(bar.field_dep_option) = {
+			hello: 1
+		},
 		(bar.field_option) = true
 	];
 	oneof test_oneof {
 		// TODO: readd when oneof options handled
 		option (bar.oneof_option) = true; // inline comment18
-		option (bar.oneof_dep_option) = { hello: 1 }; // inline comment19
+		option (bar.oneof_dep_option) = {
+			hello: 1
+		}; // inline comment19
 		int64 foo1 = 8;
 		string foo2 = 9;
 		// comment18
 		int64 woot3 = 10 [
-			(bar.field_dep_option) = { hello: 1 },
+			(bar.field_dep_option) = {
+				hello: 1
+			},
 			(bar.field_option) = true
 		]; // inline comment18
 		// comment21
@@ -112,7 +124,9 @@ enum Something {
 // Daylight is the daylight service.
 service Daylight {
 	option (bar.service_option) = true; // inline comment29
-	option (bar.service_dep_option) = { hello: 1 }; // inline comment30
+	option (bar.service_dep_option) = {
+		hello: 1
+	}; // inline comment30
 	rpc Hello(Bat) returns (Empty) {
 		option (bar.method_dep_option) = {
 			hello: 1

--- a/internal/x/cmd/testdata/format/foo/foo_proto2.proto.golden
+++ b/internal/x/cmd/testdata/format/foo/foo_proto2.proto.golden
@@ -21,7 +21,9 @@ option java_outer_classname = "FooProto"; // inline comment5
 // comment12
 option java_package = "com.foo.pb"; // inline comment23
 // comment16
-option (bar.file_dep_option) = { hello: 1 }; // inline comment16
+option (bar.file_dep_option) = {
+	hello: 1
+}; // inline comment16
 // comment6
 option (bar.file_option) = true; // inline comment6
 // comment7

--- a/internal/x/format/base_visitor.go
+++ b/internal/x/format/base_visitor.go
@@ -138,7 +138,7 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 		if len(o.Constant.Array) == 0 && len(o.Constant.OrderedMap) == 0 {
 			v.PWithInlineComment(o.InlineComment, prefix, o.Name, ` = `, o.Constant.SourceRepresentation(), suffix)
 		} else if len(o.Constant.Array) > 0 { // both Array and OrderedMap should not be set simultaneously, need more followup with emicklei/proto
-			// TODO
+			// TODO https://github.com/uber/prototool/issues/59
 		} else { // len(o.Constant.OrderedMap) > 0
 			v.P(prefix, o.Name, ` = {`)
 			v.In()
@@ -153,11 +153,24 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 
 // should only be called by Poptions
 func (v *baseVisitor) pInnerLiteral(name string, literal proto.Literal) {
-	if name == "" {
-		v.P(literal.SourceRepresentation())
-		return
+	prefix := ""
+	if name != "" {
+		prefix = name + ": "
 	}
-	v.P(name, `: `, literal.SourceRepresentation())
+	// TODO: this is a good example of the reasoning for https://github.com/uber/prototool/issues/1
+	if len(literal.Array) == 0 && len(literal.OrderedMap) == 0 {
+		v.P(prefix, literal.SourceRepresentation())
+	} else if len(literal.Array) > 0 { // both Array and OrderedMap should not be set simultaneously, need more followup with emicklei/proto
+		// TODO https://github.com/uber/prototool/issues/59
+	} else { // len(literal.OrderedMap) > 0
+		v.P(prefix, `{`)
+		v.In()
+		for _, namedLiteral := range literal.OrderedMap {
+			v.pInnerLiteral(namedLiteral.Name, *namedLiteral.Literal)
+		}
+		v.Out()
+		v.P(`}`)
+	}
 }
 
 func (v *baseVisitor) PField(prefix string, t string, field *proto.Field) {

--- a/internal/x/format/base_visitor.go
+++ b/internal/x/format/base_visitor.go
@@ -143,7 +143,7 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 			v.P(prefix, o.Name, ` = {`)
 			v.In()
 			for _, namedLiteral := range o.Constant.OrderedMap {
-				v.pInnerLiteral(namedLiteral.Name, namedLiteral)
+				v.pInnerLiteral(namedLiteral.Name, *namedLiteral.Literal)
 			}
 			v.Out()
 			v.PWithInlineComment(o.InlineComment, `}`, suffix)

--- a/internal/x/format/base_visitor.go
+++ b/internal/x/format/base_visitor.go
@@ -143,12 +143,21 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 			v.P(prefix, o.Name, ` = {`)
 			v.In()
 			for _, namedLiteral := range o.Constant.OrderedMap {
-				v.P(namedLiteral.Name, `: `, namedLiteral.SourceRepresentation())
+				v.pInnerLiteral(namedLiteral.Name, namedLiteral)
 			}
 			v.Out()
 			v.PWithInlineComment(o.InlineComment, `}`, suffix)
 		}
 	}
+}
+
+// should only be called by Poptions
+func (v *baseVisitor) pInnerLiteral(name string, literal proto.Literal) {
+	if name == "" {
+		v.P(literal.SourceRepresentation())
+		return
+	}
+	v.P(name, `: `, literal.SourceRepresentation())
 }
 
 func (v *baseVisitor) PField(prefix string, t string, field *proto.Field) {

--- a/internal/x/format/base_visitor.go
+++ b/internal/x/format/base_visitor.go
@@ -134,16 +134,16 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 			}
 		}
 		v.PComment(o.Comment)
-		switch len(o.AggregatedConstants) {
-		case 0:
+		// TODO: this is a good example of the reasoning for https://github.com/uber/prototool/issues/1
+		if len(o.Constant.Array) == 0 && len(o.Constant.OrderedMap) == 0 {
 			v.PWithInlineComment(o.InlineComment, prefix, o.Name, ` = `, o.Constant.SourceRepresentation(), suffix)
-		case 1:
-			v.PWithInlineComment(o.InlineComment, prefix, o.Name, ` = { `, o.AggregatedConstants[0].Name, ": ", o.AggregatedConstants[0].Literal.SourceRepresentation(), " }", suffix)
-		default:
+		} else if len(o.Constant.Array) > 0 { // both Array and OrderedMap should not be set simultaneously, need more followup with emicklei/proto
+			// TODO
+		} else { // len(o.Constant.OrderedMap) > 0
 			v.P(prefix, o.Name, ` = {`)
 			v.In()
-			for _, aggregatedConstant := range o.AggregatedConstants {
-				v.P(aggregatedConstant.Name, `: `, aggregatedConstant.Literal.SourceRepresentation())
+			for _, namedLiteral := range o.Constant.OrderedMap {
+				v.P(namedLiteral.Name, `: `, namedLiteral.SourceRepresentation())
 			}
 			v.Out()
 			v.PWithInlineComment(o.InlineComment, `}`, suffix)


### PR DESCRIPTION
After a fix done in emicklei/proto, we can now handle nested options. This fixes #27.

Message options with a single value are no longer special-cased, it's more difficult now that there is a recursive nature to the printing of option values.

As you can see in the code, there's some weirdness in emicklei/proto regarding options printing, this is a good example of why #1 should maybe be done.