### PR TITLE
Add list of valid protoc versions from GitHub Releases

### DIFF
--- a/internal/x/protoc/downloader.go
+++ b/internal/x/protoc/downloader.go
@@ -221,6 +221,11 @@ func (d *downloader) getProtocURL(goos string, goarch string) (string, error) {
 	if d.protocURL != "" {
 		return d.protocURL, nil
 	}
+	// if protocURL is not set, we need to make sure we have a version that will result
+	// in a GitHub Releases link with a protoc zip file
+	if _, ok := vars.ValidProtocVersions[d.config.Compile.ProtobufVersion]; !ok {
+		return "", fmt.Errorf("%s is not a known to have a protoc zip file in the proper format downloadable from https://github.com/google/protobuf/releases/v%s", d.config.Compile.ProtobufVersion, d.config.Compile.ProtobufVersion)
+	}
 	unameS, unameM, err := getUnameSUnameMPaths(goos, goarch)
 	if err != nil {
 		return "", err

--- a/internal/x/vars/vars.go
+++ b/internal/x/vars/vars.go
@@ -32,6 +32,28 @@ const (
 )
 
 var (
+	// ValidProtocVersions is the list of protoc versions that are known
+	// to have protoc zip files for darwin and osx. These need to contain
+	// protoc at bin/protoc, as well as the Well-Known Types in include.
+	// Google only packages zip files for certain versions, and without
+	// a known list, this can be confusing when errors happen.
+	// See https://github.com/uber/prototool/issues/63.
+	ValidProtocVersions = map[string]struct{}{
+		"3.5.1":          struct{}{},
+		"3.5.0":          struct{}{},
+		"3.4.0":          struct{}{},
+		"3.3.0":          struct{}{},
+		"3.2.0":          struct{}{},
+		"3.2.0rc2":       struct{}{},
+		"3.1.0":          struct{}{},
+		"3.0.2":          struct{}{},
+		"3.0.0":          struct{}{},
+		"3.0.0-beta-4":   struct{}{},
+		"3.0.0-beta-3.1": struct{}{},
+		"3.0.0-beta-3":   struct{}{},
+		"3.0.0-beta-2":   struct{}{},
+	}
+
 	// GitCommit is the git commit used to build the binary.
 	//
 	// This is populated at build time using ldflags.

--- a/internal/x/vars/vars_test.go
+++ b/internal/x/vars/vars_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package vars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultProtocVersionInValidProtocVersions(t *testing.T) {
+	assert.Contains(t, ValidProtocVersions, DefaultProtocVersion)
+}


### PR DESCRIPTION
See #63. This adds a `map[string]struct{}` of protoc versions that have a valid `protoc-VERSION-OS-ARCH.zip` uploaded to GitHub Releases (for example, https://github.com/google/protobuf/releases/v3.2.0), and returns an error if a protoc version is not known.