### PR TITLE
Add all lint group

### DIFF
--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -380,7 +380,12 @@ func (r *runner) ListLintGroup(group string) error {
 }
 
 func (r *runner) ListAllLintGroups() error {
+	groups := make([]string, 0, len(lint.GroupToCheckers))
 	for group := range lint.GroupToCheckers {
+		groups = append(groups, group)
+	}
+	sort.Strings(groups)
+	for _, group := range groups {
 		if err := r.println(group); err != nil {
 			return err
 		}

--- a/internal/x/lint/lint.go
+++ b/internal/x/lint/lint.go
@@ -96,9 +96,13 @@ var (
 	// DefaultGroup is the default group.
 	DefaultGroup = "default"
 
+	// AllGroup is the group of all known linters.
+	AllGroup = "all"
+
 	// GroupToCheckers is the map from checker group to the corresponding slice of checkers.
 	GroupToCheckers = map[string][]Checker{
 		DefaultGroup: DefaultCheckers,
+		AllGroup:     AllCheckers,
 	}
 )
 


### PR DESCRIPTION
This adds an `all` lint group, that contains all known linters. The default set of linters does not include all the linters, as some were removed, but users may want them in the future. The `all` group is primarily for testing, and testing will be added in #74.