### PR TITLE
Add a special error message if the protoc zip file cannot be downloaded

### DIFF
--- a/internal/x/protoc/downloader.go
+++ b/internal/x/protoc/downloader.go
@@ -159,7 +159,13 @@ func (d *downloader) downloadInternal(basePath string, goos string, goarch strin
 		return err
 	}
 	response, err := http.Get(url)
-	if err != nil {
+	if err != nil || response.StatusCode != http.StatusOK {
+		// if there is not given protocURL, we tried to
+		// download this from GitHub Releases, so add
+		// extra context to the error message
+		if d.protocURL == "" {
+			return fmt.Errorf("error downloading %s: %v\nmake sure GitHub Releases has a proper protoc zip file of the form protoc-VERSION-OS-ARCH.zip at https://github.com/google/protobuf/releases/v%s\nnote that many micro versions do not have this, and no version before 3.0.0-beta-2 has this", url, err, d.config.Compile.ProtobufVersion)
+		}
 		return err
 	}
 	d.logger.Debug("downloaded protobuf zip file", zap.String("url", url))

--- a/internal/x/protoc/downloader.go
+++ b/internal/x/protoc/downloader.go
@@ -164,7 +164,7 @@ func (d *downloader) downloadInternal(basePath string, goos string, goarch strin
 		// download this from GitHub Releases, so add
 		// extra context to the error message
 		if d.protocURL == "" {
-			return fmt.Errorf("error downloading %s: %v\nmake sure GitHub Releases has a proper protoc zip file of the form protoc-VERSION-OS-ARCH.zip at https://github.com/google/protobuf/releases/v%s\nnote that many micro versions do not have this, and no version before 3.0.0-beta-2 has this", url, err, d.config.Compile.ProtobufVersion)
+			return fmt.Errorf("error downloading %s: %v\nMake sure GitHub Releases has a proper protoc zip file of the form protoc-VERSION-OS-ARCH.zip at https://github.com/google/protobuf/releases/v%s\nNote that many micro versions do not have this, and no version before 3.0.0-beta-2 has this", url, err, d.config.Compile.ProtobufVersion)
 		}
 		return err
 	}


### PR DESCRIPTION
Re https://github.com/uber/prototool/pull/66. Fixes https://github.com/uber/prototool/issues/63. It also turns out that `http.Get` returns a nil error even if the response is not 200, so this is checked as well.

The error message that is printed out if `protoc_version` is set to `2.6.1` in the corresponding `prototool.yaml` file:

```
$ prototool download
error downloading https://github.com/google/protobuf/releases/download/v2.6.1/protoc-2.6.1-osx-x86_64.zip: <nil>
make sure GitHub Releases has a proper protoc zip file of the form protoc-VERSION-OS-ARCH.zip at https://github.com/google/protobuf/releases/v2.6.1
note that many micro versions do not have this, and no version before 3.0.0-beta-2 has this
```

Note Golang errors are not generally capitalized, so this is not capitalized in the code, and looks weird printed out, but I think this is OK.