### PR TITLE
Simplify internal/strs

### DIFF
--- a/internal/strs/strs.go
+++ b/internal/strs/strs.go
@@ -90,23 +90,9 @@ func ToUpperSnakeCase(s string) string {
 	return strings.ToUpper(toSnake(s))
 }
 
-// toSnake converts s to snake_case.
-// It is assumed s has no spaces.
-func toSnake(s string) string {
-	output := ""
-	for i, c := range s {
-		if i > 0 && unicode.IsUpper(c) && output[len(output)-1] != '_' && i < len(s)-1 && !unicode.IsUpper(rune(s[i+1])) {
-			output += "_" + string(c)
-		} else {
-			output += string(c)
-		}
-	}
-	return output
-}
-
-// Dedupe returns s with no duplicates and no empty strings, sorted.
+// DedupeSort returns s with no duplicates and no empty strings, sorted.
 // If modifier is not nil, modifier will be applied to each element in s.
-func Dedupe(s []string, modifier func(string) string) []string {
+func DedupeSort(s []string, modifier func(string) string) []string {
 	m := make(map[string]struct{}, len(s))
 	o := make([]string, 0, len(m))
 	for _, e := range s {
@@ -171,6 +157,20 @@ func IsUppercase(s string) bool {
 		return false
 	}
 	return strings.ToUpper(s) == s
+}
+
+// toSnake converts s to snake_case.
+// It is assumed s has no spaces.
+func toSnake(s string) string {
+	output := ""
+	for i, c := range s {
+		if i > 0 && unicode.IsUpper(c) && output[len(output)-1] != '_' && i < len(s)-1 && !unicode.IsUpper(rune(s[i+1])) {
+			output += "_" + string(c)
+		} else {
+			output += string(c)
+		}
+	}
+	return output
 }
 
 func isLetter(r rune) bool {

--- a/internal/strs/strs.go
+++ b/internal/strs/strs.go
@@ -28,7 +28,6 @@ package strs
 import (
 	"sort"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -164,7 +163,7 @@ func IsUppercase(s string) bool {
 func toSnake(s string) string {
 	output := ""
 	for i, c := range s {
-		if i > 0 && unicode.IsUpper(c) && output[len(output)-1] != '_' && i < len(s)-1 && !unicode.IsUpper(rune(s[i+1])) {
+		if i > 0 && isUpper(c) && output[len(output)-1] != '_' && i < len(s)-1 && !isUpper(rune(s[i+1])) {
 			output += "_" + string(c)
 		} else {
 			output += string(c)

--- a/internal/strs/strs_test.go
+++ b/internal/strs/strs_test.go
@@ -41,7 +41,6 @@ func TestIsCamelCase(t *testing.T) {
 	assert.True(t, IsCamelCase("helloWorld"))
 	assert.False(t, IsCamelCase("hello_world"))
 	assert.False(t, IsCamelCase("hello.World"))
-	assert.True(t, IsCamelCase("hello.World", '.'))
 	assert.True(t, IsCamelCase("ABBRCamel"))
 }
 
@@ -53,8 +52,6 @@ func TestIsLowerSnakeCase(t *testing.T) {
 	assert.False(t, IsLowerSnakeCase("Hello_world"))
 	assert.False(t, IsLowerSnakeCase("_hello_world"))
 	assert.False(t, IsLowerSnakeCase("hello_world_"))
-	assert.False(t, IsLowerSnakeCase("hello_world.foo"))
-	assert.True(t, IsLowerSnakeCase("hello_world.foo", '.'))
 }
 
 func TestIsUpperSnakeCase(t *testing.T) {
@@ -67,8 +64,6 @@ func TestIsUpperSnakeCase(t *testing.T) {
 	assert.False(t, IsUpperSnakeCase("Hello_world"))
 	assert.False(t, IsUpperSnakeCase("_HELLO_WORLD"))
 	assert.False(t, IsUpperSnakeCase("HELLO_WORLD_"))
-	assert.False(t, IsUpperSnakeCase("HELLO_WORLD.FOO"))
-	assert.True(t, IsUpperSnakeCase("HELLO_WORLD.FOO", '.'))
 }
 
 func TestIsLowercase(t *testing.T) {
@@ -85,16 +80,6 @@ func TestIsUppercase(t *testing.T) {
 	assert.True(t, IsUppercase("HELLO"))
 }
 
-func TestToSnakeCase(t *testing.T) {
-	assert.Equal(t, "", ToSnakeCase(""))
-	assert.Equal(t, "Camel_Case", ToSnakeCase("CamelCase"))
-	assert.Equal(t, "camel_Case", ToSnakeCase("camelCase"))
-	assert.Equal(t, "Camel_Case_", ToSnakeCase("CamelCase_"))
-	assert.Equal(t, "_Camel_Case", ToSnakeCase("_CamelCase"))
-	assert.Equal(t, "Camel_Case__Hello", ToSnakeCase("CamelCase__Hello"))
-	assert.Equal(t, "ABBR_Camel", ToSnakeCase("ABBRCamel"))
-}
-
 func TestToUpperSnakeCase(t *testing.T) {
 	assert.Equal(t, "", ToUpperSnakeCase(""))
 	assert.Equal(t, "CAMEL_CASE", ToUpperSnakeCase("CamelCase"))
@@ -105,38 +90,27 @@ func TestToUpperSnakeCase(t *testing.T) {
 	assert.Equal(t, "ABBR_CAMEL", ToUpperSnakeCase("ABBRCamel"))
 }
 
-func TestDedupeSlice(t *testing.T) {
-	assert.Equal(t, []string{"b", "a", "c"}, DedupeSlice([]string{"b", "A", "c"}, strings.ToLower))
-	assert.Equal(t, []string{"b", "a", "c"}, DedupeSlice([]string{"b", "A", "c", "a"}, strings.ToLower))
-	assert.Equal(t, []string{"b", "a", "c"}, DedupeSlice([]string{"b", "A", "c", "a", "B"}, strings.ToLower))
-	assert.Equal(t, []string{"b", "a", "c"}, DedupeSlice([]string{"b", "A", "c", "a", "B", "b"}, strings.ToLower))
-	assert.Equal(t, []string{"b", "A", "c"}, DedupeSlice([]string{"b", "A", "c"}, nil))
-	assert.Equal(t, []string{"b", "A", "c", "a"}, DedupeSlice([]string{"b", "A", "c", "a"}, nil))
-	assert.Equal(t, []string{"b", "A", "c", "B"}, DedupeSlice([]string{"b", "A", "c", "A", "B"}, nil))
-	assert.Equal(t, []string{"b", "A", "c", "B"}, DedupeSlice([]string{"b", "A", "c", "", "A", "B"}, nil))
+func TestDedupe(t *testing.T) {
+	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c"}, strings.ToLower))
+	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a"}, strings.ToLower))
+	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a", "B"}, strings.ToLower))
+	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a", "B", "b"}, strings.ToLower))
+	assert.Equal(t, []string{"A", "b", "c"}, Dedupe([]string{"b", "A", "c"}, nil))
+	assert.Equal(t, []string{"A", "a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a"}, nil))
+	assert.Equal(t, []string{"A", "B", "b", "c"}, Dedupe([]string{"b", "A", "c", "A", "B"}, nil))
+	assert.Equal(t, []string{"A", "B", "b", "c"}, Dedupe([]string{"b", "A", "c", "", "A", "B"}, nil))
 }
 
-func TestDedupeSortSlice(t *testing.T) {
-	assert.Equal(t, []string{"a", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c"}, strings.ToLower))
-	assert.Equal(t, []string{"a", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c", "a"}, strings.ToLower))
-	assert.Equal(t, []string{"a", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c", "a", "B"}, strings.ToLower))
-	assert.Equal(t, []string{"a", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c", "a", "B", "b"}, strings.ToLower))
-	assert.Equal(t, []string{"A", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c"}, nil))
-	assert.Equal(t, []string{"A", "a", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c", "a"}, nil))
-	assert.Equal(t, []string{"A", "B", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c", "A", "B"}, nil))
-	assert.Equal(t, []string{"A", "B", "b", "c"}, DedupeSortSlice([]string{"b", "A", "c", "", "A", "B"}, nil))
-}
-
-func TestIntersectionSlice(t *testing.T) {
-	assert.Equal(t, []string{}, IntersectionSlice([]string{"1", "2", "3"}, []string{"4", "5", "6"}))
-	assert.Equal(t, []string{"1"}, IntersectionSlice([]string{"1", "2", "3"}, []string{"1", "5", "6"}))
-	assert.Equal(t, []string{"1", "2"}, IntersectionSlice([]string{"1", "2", "3"}, []string{"1", "5", "2"}))
-	assert.Equal(t, []string{}, IntersectionSlice([]string{"1"}, []string{"4"}))
-	assert.Equal(t, []string{"1"}, IntersectionSlice([]string{"1"}, []string{"1"}))
-	assert.Equal(t, []string{}, IntersectionSlice([]string{}, []string{"1"}))
-	assert.Equal(t, []string{}, IntersectionSlice([]string{"1"}, []string{}))
-	assert.Equal(t, []string{}, IntersectionSlice([]string{}, []string{}))
-	assert.Equal(t, []string{"1", "2"}, IntersectionSlice([]string{"1", "2", "3"}, []string{"1", "5", "", "2"}))
-	assert.Equal(t, []string{"1", "2"}, IntersectionSlice([]string{"1", "2", "", "3"}, []string{"1", "5", "2"}))
-	assert.Equal(t, []string{"1", "2"}, IntersectionSlice([]string{"1", "2", "", "3"}, []string{"1", "5", "", "2"}))
+func TestIntersection(t *testing.T) {
+	assert.Equal(t, []string{}, Intersection([]string{"1", "2", "3"}, []string{"4", "5", "6"}))
+	assert.Equal(t, []string{"1"}, Intersection([]string{"1", "2", "3"}, []string{"1", "5", "6"}))
+	assert.Equal(t, []string{"1", "2"}, Intersection([]string{"1", "2", "3"}, []string{"1", "5", "2"}))
+	assert.Equal(t, []string{}, Intersection([]string{"1"}, []string{"4"}))
+	assert.Equal(t, []string{"1"}, Intersection([]string{"1"}, []string{"1"}))
+	assert.Equal(t, []string{}, Intersection([]string{}, []string{"1"}))
+	assert.Equal(t, []string{}, Intersection([]string{"1"}, []string{}))
+	assert.Equal(t, []string{}, Intersection([]string{}, []string{}))
+	assert.Equal(t, []string{"1", "2"}, Intersection([]string{"1", "2", "3"}, []string{"1", "5", "", "2"}))
+	assert.Equal(t, []string{"1", "2"}, Intersection([]string{"1", "2", "", "3"}, []string{"1", "5", "2"}))
+	assert.Equal(t, []string{"1", "2"}, Intersection([]string{"1", "2", "", "3"}, []string{"1", "5", "", "2"}))
 }

--- a/internal/strs/strs_test.go
+++ b/internal/strs/strs_test.go
@@ -52,6 +52,7 @@ func TestIsLowerSnakeCase(t *testing.T) {
 	assert.False(t, IsLowerSnakeCase("Hello_world"))
 	assert.False(t, IsLowerSnakeCase("_hello_world"))
 	assert.False(t, IsLowerSnakeCase("hello_world_"))
+	assert.False(t, IsLowerSnakeCase("hello_world.foo"))
 }
 
 func TestIsUpperSnakeCase(t *testing.T) {
@@ -64,6 +65,7 @@ func TestIsUpperSnakeCase(t *testing.T) {
 	assert.False(t, IsUpperSnakeCase("Hello_world"))
 	assert.False(t, IsUpperSnakeCase("_HELLO_WORLD"))
 	assert.False(t, IsUpperSnakeCase("HELLO_WORLD_"))
+	assert.False(t, IsUpperSnakeCase("HELLO_WORLD.FOO"))
 }
 
 func TestIsLowercase(t *testing.T) {
@@ -90,15 +92,15 @@ func TestToUpperSnakeCase(t *testing.T) {
 	assert.Equal(t, "ABBR_CAMEL", ToUpperSnakeCase("ABBRCamel"))
 }
 
-func TestDedupe(t *testing.T) {
-	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c"}, strings.ToLower))
-	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a"}, strings.ToLower))
-	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a", "B"}, strings.ToLower))
-	assert.Equal(t, []string{"a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a", "B", "b"}, strings.ToLower))
-	assert.Equal(t, []string{"A", "b", "c"}, Dedupe([]string{"b", "A", "c"}, nil))
-	assert.Equal(t, []string{"A", "a", "b", "c"}, Dedupe([]string{"b", "A", "c", "a"}, nil))
-	assert.Equal(t, []string{"A", "B", "b", "c"}, Dedupe([]string{"b", "A", "c", "A", "B"}, nil))
-	assert.Equal(t, []string{"A", "B", "b", "c"}, Dedupe([]string{"b", "A", "c", "", "A", "B"}, nil))
+func TestDedupeSort(t *testing.T) {
+	assert.Equal(t, []string{"a", "b", "c"}, DedupeSort([]string{"b", "A", "c"}, strings.ToLower))
+	assert.Equal(t, []string{"a", "b", "c"}, DedupeSort([]string{"b", "A", "c", "a"}, strings.ToLower))
+	assert.Equal(t, []string{"a", "b", "c"}, DedupeSort([]string{"b", "A", "c", "a", "B"}, strings.ToLower))
+	assert.Equal(t, []string{"a", "b", "c"}, DedupeSort([]string{"b", "A", "c", "a", "B", "b"}, strings.ToLower))
+	assert.Equal(t, []string{"A", "b", "c"}, DedupeSort([]string{"b", "A", "c"}, nil))
+	assert.Equal(t, []string{"A", "a", "b", "c"}, DedupeSort([]string{"b", "A", "c", "a"}, nil))
+	assert.Equal(t, []string{"A", "B", "b", "c"}, DedupeSort([]string{"b", "A", "c", "A", "B"}, nil))
+	assert.Equal(t, []string{"A", "B", "b", "c"}, DedupeSort([]string{"b", "A", "c", "", "A", "B"}, nil))
 }
 
 func TestIntersection(t *testing.T) {

--- a/internal/x/lint/check_package_lower_snake_case.go
+++ b/internal/x/lint/check_package_lower_snake_case.go
@@ -21,6 +21,8 @@
 package lint
 
 import (
+	"strings"
+
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
 	"github.com/uber/prototool/internal/x/text"
@@ -59,7 +61,7 @@ func (v *packageLowerSnakeCaseVisitor) VisitPackage(pkg *proto.Package) {
 
 func (v *packageLowerSnakeCaseVisitor) Finally() error {
 	if v.pkg != nil {
-		if !strs.IsLowerSnakeCase(v.pkg.Name, '.') {
+		if !strs.IsLowerSnakeCase(strings.Replace(v.pkg.Name, ".", "", -1)) {
 			v.AddFailuref(v.pkg.Position, "Package should be lower_snake.case but was %q.", v.pkg.Name)
 		}
 	}

--- a/internal/x/settings/config_provider.go
+++ b/internal/x/settings/config_provider.go
@@ -207,7 +207,7 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 		return Config{}, err
 	}
 	includePaths := make([]string, 0, len(e.ProtocIncludes))
-	for _, includePath := range strs.Dedupe(e.ProtocIncludes, nil) {
+	for _, includePath := range strs.DedupeSort(e.ProtocIncludes, nil) {
 		if !filepath.IsAbs(includePath) {
 			includePath = filepath.Join(dirPath, includePath)
 		}
@@ -279,10 +279,10 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 			AllowUnusedImports:    e.AllowUnusedImports,
 		},
 		Lint: LintConfig{
-			IDs:                 strs.Dedupe(e.Lint.IDs, strings.ToUpper),
+			IDs:                 strs.DedupeSort(e.Lint.IDs, strings.ToUpper),
 			Group:               strings.ToLower(e.Lint.Group),
-			IncludeIDs:          strs.Dedupe(e.Lint.IncludeIDs, strings.ToUpper),
-			ExcludeIDs:          strs.Dedupe(e.Lint.ExcludeIDs, strings.ToUpper),
+			IncludeIDs:          strs.DedupeSort(e.Lint.IncludeIDs, strings.ToUpper),
+			ExcludeIDs:          strs.DedupeSort(e.Lint.ExcludeIDs, strings.ToUpper),
 			IgnoreIDToFilePaths: ignoreIDToFilePaths,
 		},
 		Format: FormatConfig{
@@ -355,7 +355,7 @@ func getExcludePrefixes(excludes []string, noDefaultExcludes bool, dirPath strin
 		excludes = append(DefaultExcludePrefixes, excludes...)
 	}
 	excludePrefixes := make([]string, 0, len(excludes))
-	for _, excludePrefix := range strs.Dedupe(excludes, nil) {
+	for _, excludePrefix := range strs.DedupeSort(excludes, nil) {
 		if !filepath.IsAbs(excludePrefix) {
 			excludePrefix = filepath.Join(dirPath, excludePrefix)
 		}

--- a/internal/x/settings/config_provider.go
+++ b/internal/x/settings/config_provider.go
@@ -207,7 +207,7 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 		return Config{}, err
 	}
 	includePaths := make([]string, 0, len(e.ProtocIncludes))
-	for _, includePath := range strs.DedupeSortSlice(e.ProtocIncludes, nil) {
+	for _, includePath := range strs.Dedupe(e.ProtocIncludes, nil) {
 		if !filepath.IsAbs(includePath) {
 			includePath = filepath.Join(dirPath, includePath)
 		}
@@ -279,10 +279,10 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 			AllowUnusedImports:    e.AllowUnusedImports,
 		},
 		Lint: LintConfig{
-			IDs:                 strs.DedupeSortSlice(e.Lint.IDs, strings.ToUpper),
+			IDs:                 strs.Dedupe(e.Lint.IDs, strings.ToUpper),
 			Group:               strings.ToLower(e.Lint.Group),
-			IncludeIDs:          strs.DedupeSortSlice(e.Lint.IncludeIDs, strings.ToUpper),
-			ExcludeIDs:          strs.DedupeSortSlice(e.Lint.ExcludeIDs, strings.ToUpper),
+			IncludeIDs:          strs.Dedupe(e.Lint.IncludeIDs, strings.ToUpper),
+			ExcludeIDs:          strs.Dedupe(e.Lint.ExcludeIDs, strings.ToUpper),
 			IgnoreIDToFilePaths: ignoreIDToFilePaths,
 		},
 		Format: FormatConfig{
@@ -321,7 +321,7 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 	if len(config.Lint.IDs) > 0 && (len(config.Lint.Group) > 0 || len(config.Lint.IncludeIDs) > 0 || len(config.Lint.ExcludeIDs) > 0) {
 		return Config{}, fmt.Errorf("config was %v but can only specify either linters, or lint_group/lint_include/lint_exclude", e)
 	}
-	if intersection := strs.IntersectionSlice(config.Lint.IncludeIDs, config.Lint.ExcludeIDs); len(intersection) > 0 {
+	if intersection := strs.Intersection(config.Lint.IncludeIDs, config.Lint.ExcludeIDs); len(intersection) > 0 {
 		return Config{}, fmt.Errorf("config had intersection of %v between lint_include and lint_exclude", intersection)
 	}
 	return config, nil
@@ -355,7 +355,7 @@ func getExcludePrefixes(excludes []string, noDefaultExcludes bool, dirPath strin
 		excludes = append(DefaultExcludePrefixes, excludes...)
 	}
 	excludePrefixes := make([]string, 0, len(excludes))
-	for _, excludePrefix := range strs.DedupeSortSlice(excludes, nil) {
+	for _, excludePrefix := range strs.Dedupe(excludes, nil) {
 		if !filepath.IsAbs(excludePrefix) {
 			excludePrefix = filepath.Join(dirPath, excludePrefix)
 		}


### PR DESCRIPTION
As discussed in https://github.com/uber/prototool/pull/50, this makes several changes to the `internal/strs` package in an attempt at simplifying.

A couple functions using the `containsRune` helper (via the `extraRunes ...rune` parameter) were not actually being used, so it seems better to remove for now. The package name linter used this by allowing `.` characters, so we explicitly handle that there.

Given that the [Protobuf spec](https://developers.google.com/protocol-buffers/docs/reference/proto3-spec) strictly specifies valid identifiers as `A-Z`, `a-z` and `_`, this does not use the corresponding `unicode` functions, such as `unicode.IsLetter`. Instead, we explicitly check for the valid identifiers in a few helper functions, `isUpper`, `isLower`, and `isDigit` so that we restrict the valid input to what is expected by Proto. This is functionally the same as before.