### PR TITLE
Assign IDs to all Failures; refactor internal/text and move to internal/failure

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -54,39 +54,39 @@ func TestCompile(t *testing.T) {
 	assertDoCompileFiles(
 		t,
 		false,
-		`testdata/compile/dep_errors.proto:6:1:Expected ";".`,
+		`testdata/compile/dep_errors.proto:6:1:PROTO Expected ";".`,
 		"testdata/compile/dep_errors.proto",
 	)
 	assertDoCompileFiles(
 		t,
 		false,
-		`dep_errors.proto:6:1:Expected ";".
-		testdata/compile/errors_on_import.proto:10:3:"foo.DepError" is not defined.`,
+		`dep_errors.proto:6:1:PROTO Expected ";".
+		testdata/compile/errors_on_import.proto:10:3:PROTO "foo.DepError" is not defined.`,
 		"testdata/compile/errors_on_import.proto",
 	)
 	assertDoCompileFiles(
 		t,
 		false,
-		`testdata/compile/extra_import.proto:1:1:Import "dep.proto" was not used.`,
+		`testdata/compile/extra_import.proto:1:1:PROTO Import "dep.proto" was not used.`,
 		"testdata/compile/extra_import.proto",
 	)
 	assertDoCompileFiles(
 		t,
 		false,
-		`testdata/compile/json_camel_case_conflict.proto:1:1:The JSON camel-case name of field "helloworld" conflicts with field "helloWorld". This is not allowed in proto3.`,
+		`testdata/compile/json_camel_case_conflict.proto:1:1:PROTO The JSON camel-case name of field "helloworld" conflicts with field "helloWorld". This is not allowed in proto3.`,
 		"testdata/compile/json_camel_case_conflict.proto",
 	)
 	assertDoCompileFiles(
 		t,
 		false,
-		`testdata/compile/missing_package_semicolon.proto:5:1:Expected ";".`,
+		`testdata/compile/missing_package_semicolon.proto:5:1:PROTO Expected ";".`,
 		"testdata/compile/missing_package_semicolon.proto",
 	)
 	assertDoCompileFiles(
 		t,
 		false,
-		`testdata/compile/missing_syntax.proto:1:1:No syntax specified. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version.
-		testdata/compile/missing_syntax.proto:4:3:Expected "required", "optional", or "repeated".`,
+		`testdata/compile/missing_syntax.proto:1:1:PROTO No syntax specified. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version.
+		testdata/compile/missing_syntax.proto:4:3:PROTO Expected "required", "optional", or "repeated".`,
 		"testdata/compile/missing_syntax.proto",
 	)
 	assertDoCompileFiles(
@@ -98,7 +98,7 @@ func TestCompile(t *testing.T) {
 	assertDoCompileFiles(
 		t,
 		false,
-		`testdata/compile/not_imported.proto:11:3:"foo.Dep" seems to be defined in "dep.proto", which is not imported by "not_imported.proto".  To use it here, please add the necessary import.`,
+		`testdata/compile/not_imported.proto:11:3:PROTO "foo.Dep" seems to be defined in "dep.proto", which is not imported by "not_imported.proto".  To use it here, please add the necessary import.`,
 		"testdata/compile/dep.proto",
 		"testdata/compile/not_imported.proto",
 	)

--- a/internal/failure/failure.go
+++ b/internal/failure/failure.go
@@ -161,6 +161,9 @@ func (f *Failure) Fprintln(writer Writer, fields ...Field) error {
 			}
 			printColon = false
 		case Message:
+			if _, err := writer.WriteRune(' '); err != nil {
+				return err
+			}
 			if _, err := writer.WriteString(f.Message); err != nil {
 				return err
 			}

--- a/internal/failure/failure.go
+++ b/internal/failure/failure.go
@@ -48,13 +48,6 @@ var (
 		Column,
 		Message,
 	}
-	_failureFieldToString = map[Field]string{
-		Filename: "filename",
-		Line:     "line",
-		Column:   "column",
-		ID:       "id",
-		Message:  "message",
-	}
 	_stringToField = map[string]Field{
 		"filename": Filename,
 		"line":     Line,
@@ -66,14 +59,6 @@ var (
 
 // Field references a field of a Failure.
 type Field int
-
-// String implements fmt.Stringer.
-func (f Field) String() string {
-	if s, ok := _failureFieldToString[f]; ok {
-		return s
-	}
-	return strconv.Itoa(int(f))
-}
 
 // ParseFields parses Fields from the given string.
 // Fields are expected to be colon-separated in the given string.
@@ -182,15 +167,15 @@ func Newf(position scanner.Position, id string, format string, args ...interface
 // Sort sorts the Failures by the following precedence:
 //
 //  filename > line > column > id > message
-func Sort(failures []*Failure) {
-	sort.Stable(sortFailures(failures))
+func Sort(fs []*Failure) {
+	sort.Stable(failures(fs))
 }
 
-type sortFailures []*Failure
+type failures []*Failure
 
-func (f sortFailures) Len() int          { return len(f) }
-func (f sortFailures) Swap(i int, j int) { f[i], f[j] = f[j], f[i] }
-func (f sortFailures) Less(i int, j int) bool {
+func (f failures) Len() int          { return len(f) }
+func (f failures) Swap(i int, j int) { f[i], f[j] = f[j], f[i] }
+func (f failures) Less(i int, j int) bool {
 	if f[i] == nil && f[j] == nil {
 		return false
 	}

--- a/internal/failure/failure.go
+++ b/internal/failure/failure.go
@@ -48,8 +48,10 @@ const (
 	// Message references the Message field of a Failure.
 	Message
 
+	// Error identifies a generic Failure.
+	Error ID = iota
 	// Format identifies a diff format Failure.
-	Format ID = iota
+	Format
 	// Lint identifies a lint Failure.
 	Lint
 	// Proto identitifes an invalid proto Failure.
@@ -78,6 +80,7 @@ var (
 		"message":  Message,
 	}
 	_IDToString = map[ID]string{
+		Error:  "ERROR",
 		Format: "FORMAT",
 		Lint:   "LINT",
 		Proto:  "PROTO",
@@ -163,7 +166,11 @@ func (f *Failure) Fprintln(writer Writer, fields ...Field) error {
 				return err
 			}
 		case Identifier:
-			if _, err := writer.WriteString(f.ID); err != nil {
+			id := f.ID
+			if id == "" {
+				id = Error.String()
+			}
+			if _, err := writer.WriteString(id); err != nil {
 				return err
 			}
 			printColon = false

--- a/internal/failure/failure.go
+++ b/internal/failure/failure.go
@@ -54,6 +54,13 @@ const (
 	Lint
 	// Proto identitifes an invalid proto Failure.
 	Proto
+
+	// DefaultFilename is the default Failure filename.
+	DefaultFilename = "<input>"
+	// DefaultLine is the default Failure line.
+	DefaultLine = 1
+	// DefaultColumn is the default Failure column number.
+	DefaultColumn = 1
 )
 
 var (
@@ -134,7 +141,7 @@ func (f *Failure) Fprintln(writer Writer, fields ...Field) error {
 		case Filename:
 			filename := f.Filename
 			if filename == "" {
-				filename = "<input>"
+				filename = DefaultFilename
 			}
 			if _, err := writer.WriteString(filename); err != nil {
 				return err
@@ -142,7 +149,7 @@ func (f *Failure) Fprintln(writer Writer, fields ...Field) error {
 		case Line:
 			line := strconv.Itoa(f.Line)
 			if line == "0" {
-				line = "1"
+				line = strconv.Itoa(DefaultLine)
 			}
 			if _, err := writer.WriteString(line); err != nil {
 				return err
@@ -150,7 +157,7 @@ func (f *Failure) Fprintln(writer Writer, fields ...Field) error {
 		case Column:
 			column := strconv.Itoa(f.Column)
 			if column == "0" {
-				column = "1"
+				column = strconv.Itoa(DefaultColumn)
 			}
 			if _, err := writer.WriteString(column); err != nil {
 				return err

--- a/internal/failure/failure_test.go
+++ b/internal/failure/failure_test.go
@@ -33,15 +33,15 @@ import (
 //assert.Equal(t, "<input>:1:2:ID hello", newTestFailure("", 0, 2, "ID", "hello").String())
 //assert.Equal(t, "<input>:2:2:ID hello", newTestFailure("", 2, 2, "ID", "hello").String())
 //assert.Equal(t, "foo:2:2:ID hello", newTestFailure("foo", 2, 2, "ID", "hello").String())
-//assert.Equal(t, "foo:2:2:BAR hello", newTestFailure("foo", 2, 2, "BAR", "hello").String())
+//assert.Equal(t, "foo:2:2:BAR hello", newTestFailure("foo", 2, 2, Lint, "hello").String())
 //}
 
 func TestFailureFprintln(t *testing.T) {
-	testFailureFprintln(t, "2:1:<input>:BAR", newTestFailure("", 0, 2, "BAR", "hello"),
+	testFailureFprintln(t, "2:1:<input>:LINT", newTestFailure("", 0, 2, Lint, "hello"),
 		Column,
 		Line,
 		Filename,
-		ID,
+		Identifier,
 	)
 }
 
@@ -54,7 +54,7 @@ func testFailureFprintln(t *testing.T, expected string, failure *Failure, failur
 func TestParseFields(t *testing.T) {
 	testParseFields(t, "", false, _defaultFields...)
 	testParseFields(t, "filename", false, Filename)
-	testParseFields(t, "filename:id", false, Filename, ID)
+	testParseFields(t, "filename:id", false, Filename, Identifier)
 	testParseFields(t, ":", true)
 	testParseFields(t, ":filename:id", true)
 	testParseFields(t, "filename:id:", true)
@@ -74,29 +74,29 @@ func testParseFields(t *testing.T, input string, expectError bool, expectedField
 func TestSort(t *testing.T) {
 	failures := []*Failure{
 		nil,
-		newTestFailure("foo", 3, 3, "BAT", "mello"),
-		newTestFailure("bar", 3, 3, "BAT", "mello"),
-		newTestFailure("foo", 3, 3, "BAT", "hello"),
-		newTestFailure("foo", 3, 3, "", "hello"),
-		newTestFailure("foo", 2, 3, "", "hello"),
-		newTestFailure("foo", 2, 2, "", "hello"),
-		newTestFailure("foo", 2, 0, "", "hello"),
-		newTestFailure("foo", 3, 3, "BAT", "mello"),
-		newTestFailure("foo", 3, 3, "", "hello"),
-		newTestFailure("foo", 0, 0, "", "hello"),
-		newTestFailure("", 0, 0, "", "hello"),
+		newTestFailure("foo", 3, 3, Proto, "mello"),
+		newTestFailure("bar", 3, 3, Proto, "mello"),
+		newTestFailure("foo", 3, 3, Proto, "hello"),
+		newTestFailure("foo", 3, 3, Format, "hello"),
+		newTestFailure("foo", 2, 3, Format, "hello"),
+		newTestFailure("foo", 2, 2, Format, "hello"),
+		newTestFailure("foo", 2, 0, Format, "hello"),
+		newTestFailure("foo", 3, 3, Proto, "mello"),
+		newTestFailure("foo", 3, 3, Format, "hello"),
+		newTestFailure("foo", 0, 0, Format, "hello"),
+		newTestFailure("", 0, 0, Format, "hello"),
 		nil,
 		nil,
-		newTestFailure("foo", 3, 3, "BAT", "mello"),
-		newTestFailure("foo", 3, 3, "BAT", "hello"),
-		newTestFailure("foo", 3, 3, "BAR", "hello"),
-		newTestFailure("foo", 2, 3, "", "hello"),
-		newTestFailure("foo", 2, 4, "", "hello"),
-		newTestFailure("foo", 2, 2, "", "hello"),
-		newTestFailure("foo", 3, 3, "BAR", "hello"),
-		newTestFailure("foo", 2, 0, "", "hello"),
-		newTestFailure("foo", 0, 0, "", "hello"),
-		newTestFailure("", 0, 0, "", "hello"),
+		newTestFailure("foo", 3, 3, Proto, "mello"),
+		newTestFailure("foo", 3, 3, Proto, "hello"),
+		newTestFailure("foo", 3, 3, Lint, "hello"),
+		newTestFailure("foo", 2, 3, Format, "hello"),
+		newTestFailure("foo", 2, 4, Format, "hello"),
+		newTestFailure("foo", 2, 2, Format, "hello"),
+		newTestFailure("foo", 3, 3, Lint, "hello"),
+		newTestFailure("foo", 2, 0, Format, "hello"),
+		newTestFailure("foo", 0, 0, Format, "hello"),
+		newTestFailure("", 0, 0, Format, "hello"),
 		nil,
 	}
 	Sort(failures)
@@ -107,32 +107,32 @@ func TestSort(t *testing.T) {
 			nil,
 			nil,
 			nil,
-			newTestFailure("", 0, 0, "", "hello"),
-			newTestFailure("", 0, 0, "", "hello"),
-			newTestFailure("bar", 3, 3, "BAT", "mello"),
-			newTestFailure("foo", 0, 0, "", "hello"),
-			newTestFailure("foo", 0, 0, "", "hello"),
-			newTestFailure("foo", 2, 0, "", "hello"),
-			newTestFailure("foo", 2, 0, "", "hello"),
-			newTestFailure("foo", 2, 2, "", "hello"),
-			newTestFailure("foo", 2, 2, "", "hello"),
-			newTestFailure("foo", 2, 3, "", "hello"),
-			newTestFailure("foo", 2, 3, "", "hello"),
-			newTestFailure("foo", 2, 4, "", "hello"),
-			newTestFailure("foo", 3, 3, "", "hello"),
-			newTestFailure("foo", 3, 3, "", "hello"),
-			newTestFailure("foo", 3, 3, "BAR", "hello"),
-			newTestFailure("foo", 3, 3, "BAR", "hello"),
-			newTestFailure("foo", 3, 3, "BAT", "hello"),
-			newTestFailure("foo", 3, 3, "BAT", "hello"),
-			newTestFailure("foo", 3, 3, "BAT", "mello"),
-			newTestFailure("foo", 3, 3, "BAT", "mello"),
-			newTestFailure("foo", 3, 3, "BAT", "mello"),
+			newTestFailure("", 0, 0, Format, "hello"),
+			newTestFailure("", 0, 0, Format, "hello"),
+			newTestFailure("bar", 3, 3, Proto, "mello"),
+			newTestFailure("foo", 0, 0, Format, "hello"),
+			newTestFailure("foo", 0, 0, Format, "hello"),
+			newTestFailure("foo", 2, 0, Format, "hello"),
+			newTestFailure("foo", 2, 0, Format, "hello"),
+			newTestFailure("foo", 2, 2, Format, "hello"),
+			newTestFailure("foo", 2, 2, Format, "hello"),
+			newTestFailure("foo", 2, 3, Format, "hello"),
+			newTestFailure("foo", 2, 3, Format, "hello"),
+			newTestFailure("foo", 2, 4, Format, "hello"),
+			newTestFailure("foo", 3, 3, Format, "hello"),
+			newTestFailure("foo", 3, 3, Format, "hello"),
+			newTestFailure("foo", 3, 3, Lint, "hello"),
+			newTestFailure("foo", 3, 3, Lint, "hello"),
+			newTestFailure("foo", 3, 3, Proto, "hello"),
+			newTestFailure("foo", 3, 3, Proto, "hello"),
+			newTestFailure("foo", 3, 3, Proto, "mello"),
+			newTestFailure("foo", 3, 3, Proto, "mello"),
+			newTestFailure("foo", 3, 3, Proto, "mello"),
 		},
 		failures,
 	)
 }
 
-func newTestFailure(filename string, line int, column int, id string, message string) *Failure {
+func newTestFailure(filename string, line int, column int, id ID, message string) *Failure {
 	return Newf(scanner.Position{Filename: filename, Line: line, Column: column}, id, message)
 }

--- a/internal/failure/failure_test.go
+++ b/internal/failure/failure_test.go
@@ -28,13 +28,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//func TestFailureString(t *testing.T) {
-//assert.Equal(t, "<input>:1:1: hello", newTestFailure("", 0, 0, "", "hello").String())
-//assert.Equal(t, "<input>:1:2:ID hello", newTestFailure("", 0, 2, "ID", "hello").String())
-//assert.Equal(t, "<input>:2:2:ID hello", newTestFailure("", 2, 2, "ID", "hello").String())
-//assert.Equal(t, "foo:2:2:ID hello", newTestFailure("foo", 2, 2, "ID", "hello").String())
-//assert.Equal(t, "foo:2:2:BAR hello", newTestFailure("foo", 2, 2, Lint, "hello").String())
-//}
+func TestIDString(t *testing.T) {
+	assert.Equal(t, "FORMAT", Format.String())
+	assert.Equal(t, "LINT", Lint.String())
+	assert.Equal(t, "PROTO", Proto.String())
+}
 
 func TestFailureFprintln(t *testing.T) {
 	testFailureFprintln(t, "2:1:<input>:LINT", newTestFailure("", 0, 2, Lint, "hello"),

--- a/internal/failure/failure_test.go
+++ b/internal/failure/failure_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestIDString(t *testing.T) {
+	assert.Equal(t, "ERROR", Error.String())
 	assert.Equal(t, "FORMAT", Format.String())
 	assert.Equal(t, "LINT", Lint.String())
 	assert.Equal(t, "PROTO", Proto.String())

--- a/internal/failure/failure_test.go
+++ b/internal/failure/failure_test.go
@@ -28,13 +28,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFailureString(t *testing.T) {
-	assert.Equal(t, "<input>:1:1: hello", newTestFailure("", 0, 0, "", "hello").String())
-	assert.Equal(t, "<input>:1:2:ID hello", newTestFailure("", 0, 2, "ID", "hello").String())
-	assert.Equal(t, "<input>:2:2:ID hello", newTestFailure("", 2, 2, "ID", "hello").String())
-	assert.Equal(t, "foo:2:2:ID hello", newTestFailure("foo", 2, 2, "ID", "hello").String())
-	assert.Equal(t, "foo:2:2:BAR hello", newTestFailure("foo", 2, 2, "BAR", "hello").String())
-}
+//func TestFailureString(t *testing.T) {
+//assert.Equal(t, "<input>:1:1: hello", newTestFailure("", 0, 0, "", "hello").String())
+//assert.Equal(t, "<input>:1:2:ID hello", newTestFailure("", 0, 2, "ID", "hello").String())
+//assert.Equal(t, "<input>:2:2:ID hello", newTestFailure("", 2, 2, "ID", "hello").String())
+//assert.Equal(t, "foo:2:2:ID hello", newTestFailure("foo", 2, 2, "ID", "hello").String())
+//assert.Equal(t, "foo:2:2:BAR hello", newTestFailure("foo", 2, 2, "BAR", "hello").String())
+//}
 
 func TestFailureFprintln(t *testing.T) {
 	testFailureFprintln(t, "2:1:<input>:BAR", newTestFailure("", 0, 2, "BAR", "hello"),

--- a/internal/failure/text_test.go
+++ b/internal/failure/text_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package text
+package failure
 
 import (
 	"bytes"
@@ -45,33 +45,33 @@ func TestFailureFprintln(t *testing.T) {
 	)
 }
 
-func testFailureFprintln(t *testing.T, expected string, failure *Failure, failureFields ...FailureField) {
+func testFailureFprintln(t *testing.T, expected string, failure *Failure, failureFields ...Field) {
 	buffer := bytes.NewBuffer(nil)
 	assert.NoError(t, failure.Fprintln(buffer, failureFields...))
 	assert.Equal(t, expected+"\n", buffer.String())
 }
 
-func TestParseFailureFields(t *testing.T) {
-	testParseFailureFields(t, "", false, _defaultFailureFields...)
-	testParseFailureFields(t, "filename", false, Filename)
-	testParseFailureFields(t, "filename:id", false, Filename, ID)
-	testParseFailureFields(t, ":", true)
-	testParseFailureFields(t, ":filename:id", true)
-	testParseFailureFields(t, "filename:id:", true)
-	testParseFailureFields(t, "filename:id2", true)
+func TestParseFields(t *testing.T) {
+	testParseFields(t, "", false, _defaultFields...)
+	testParseFields(t, "filename", false, Filename)
+	testParseFields(t, "filename:id", false, Filename, ID)
+	testParseFields(t, ":", true)
+	testParseFields(t, ":filename:id", true)
+	testParseFields(t, "filename:id:", true)
+	testParseFields(t, "filename:id2", true)
 }
 
-func testParseFailureFields(t *testing.T, input string, expectError bool, expectedFailureFields ...FailureField) {
-	failureFields, err := ParseFailureFields(input)
+func testParseFields(t *testing.T, input string, expectError bool, expectedFields ...Field) {
+	failureFields, err := ParseFields(input)
 	if expectError {
 		assert.Error(t, err)
 	} else {
 		assert.NoError(t, err)
-		assert.Equal(t, expectedFailureFields, failureFields)
+		assert.Equal(t, expectedFields, failureFields)
 	}
 }
 
-func TestSortFailures(t *testing.T) {
+func TestSort(t *testing.T) {
 	failures := []*Failure{
 		nil,
 		newTestFailure("foo", 3, 3, "BAT", "mello"),
@@ -99,7 +99,7 @@ func TestSortFailures(t *testing.T) {
 		newTestFailure("", 0, 0, "", "hello"),
 		nil,
 	}
-	SortFailures(failures)
+	Sort(failures)
 	assert.Equal(
 		t,
 		[]*Failure{
@@ -134,5 +134,5 @@ func TestSortFailures(t *testing.T) {
 }
 
 func newTestFailure(filename string, line int, column int, id string, message string) *Failure {
-	return NewFailuref(scanner.Position{Filename: filename, Line: line, Column: column}, id, message)
+	return Newf(scanner.Position{Filename: filename, Line: line, Column: column}, id, message)
 }

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -29,19 +29,19 @@ import (
 )
 
 func TestFailureString(t *testing.T) {
-	assert.Equal(t, "<input>:1:1:hello", newTestFailure("", 0, 0, "", "hello").String())
-	assert.Equal(t, "<input>:1:2:hello", newTestFailure("", 0, 2, "", "hello").String())
-	assert.Equal(t, "<input>:2:2:hello", newTestFailure("", 2, 2, "", "hello").String())
-	assert.Equal(t, "foo:2:2:hello", newTestFailure("foo", 2, 2, "", "hello").String())
+	assert.Equal(t, "<input>:1:1: hello", newTestFailure("", 0, 0, "", "hello").String())
+	assert.Equal(t, "<input>:1:2:ID hello", newTestFailure("", 0, 2, "ID", "hello").String())
+	assert.Equal(t, "<input>:2:2:ID hello", newTestFailure("", 2, 2, "ID", "hello").String())
+	assert.Equal(t, "foo:2:2:ID hello", newTestFailure("foo", 2, 2, "ID", "hello").String())
 	assert.Equal(t, "foo:2:2:BAR hello", newTestFailure("foo", 2, 2, "BAR", "hello").String())
 }
 
 func TestFailureFprintln(t *testing.T) {
 	testFailureFprintln(t, "2:1:<input>:BAR", newTestFailure("", 0, 2, "BAR", "hello"),
-		FailureFieldColumn,
-		FailureFieldLine,
-		FailureFieldFilename,
-		FailureFieldID,
+		Column,
+		Line,
+		Filename,
+		ID,
 	)
 }
 
@@ -51,18 +51,18 @@ func testFailureFprintln(t *testing.T, expected string, failure *Failure, failur
 	assert.Equal(t, expected+"\n", buffer.String())
 }
 
-func TestParseColonSeparatedFailureFields(t *testing.T) {
-	testParseColonSeparatedFailureFields(t, "", false, DefaultFailureFields...)
-	testParseColonSeparatedFailureFields(t, "filename", false, FailureFieldFilename)
-	testParseColonSeparatedFailureFields(t, "filename:id", false, FailureFieldFilename, FailureFieldID)
-	testParseColonSeparatedFailureFields(t, ":", true)
-	testParseColonSeparatedFailureFields(t, ":filename:id", true)
-	testParseColonSeparatedFailureFields(t, "filename:id:", true)
-	testParseColonSeparatedFailureFields(t, "filename:id2", true)
+func TestParseFailureFields(t *testing.T) {
+	testParseFailureFields(t, "", false, _defaultFailureFields...)
+	testParseFailureFields(t, "filename", false, Filename)
+	testParseFailureFields(t, "filename:id", false, Filename, ID)
+	testParseFailureFields(t, ":", true)
+	testParseFailureFields(t, ":filename:id", true)
+	testParseFailureFields(t, "filename:id:", true)
+	testParseFailureFields(t, "filename:id2", true)
 }
 
-func testParseColonSeparatedFailureFields(t *testing.T, input string, expectError bool, expectedFailureFields ...FailureField) {
-	failureFields, err := ParseColonSeparatedFailureFields(input)
+func testParseFailureFields(t *testing.T, input string, expectError bool, expectedFailureFields ...FailureField) {
+	failureFields, err := ParseFailureFields(input)
 	if expectError {
 		assert.Error(t, err)
 	} else {

--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -40,7 +40,7 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/uber/prototool/internal/diff"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/vars"
 	"github.com/uber/prototool/internal/x/cfginit"
 	"github.com/uber/prototool/internal/x/extract"
@@ -442,7 +442,7 @@ func (r *runner) formatFile(overwrite bool, diffMode bool, lintMode bool, meta *
 			return ioutil.WriteFile(protoFile.Path, data, os.ModePerm)
 		}
 		if lintMode {
-			if err := r.printFailures("", meta, text.NewFailuref(scanner.Position{
+			if err := r.printFailures("", meta, failure.Newf(scanner.Position{
 				Filename: protoFile.DisplayPath,
 			}, "FORMAT_DIFF", "Format returned a diff.")); err != nil {
 				return err
@@ -790,17 +790,17 @@ func (r *runner) getMeta(args []string) (*meta, error) {
 // filename is optional
 // if set, it will update the Failures to have this filename
 // will be sorted
-func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Failure) error {
+func (r *runner) printFailures(filename string, meta *meta, failures ...*failure.Failure) error {
 	for _, failure := range failures {
 		if filename != "" {
 			failure.Filename = filename
 		}
 	}
-	failureFields, err := text.ParseFailureFields(r.printFields)
+	failureFields, err := failure.ParseFields(r.printFields)
 	if err != nil {
 		return err
 	}
-	text.SortFailures(failures)
+	failure.Sort(failures)
 	bufWriter := bufio.NewWriter(r.output)
 	for _, failure := range failures {
 		shouldPrint := false

--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -796,7 +796,7 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 			failure.Filename = filename
 		}
 	}
-	failureFields, err := text.ParseColonSeparatedFailureFields(r.printFields)
+	failureFields, err := text.ParseFailureFields(r.printFields)
 	if err != nil {
 		return err
 	}

--- a/internal/x/exec/runner.go
+++ b/internal/x/exec/runner.go
@@ -444,7 +444,7 @@ func (r *runner) formatFile(overwrite bool, diffMode bool, lintMode bool, meta *
 		if lintMode {
 			if err := r.printFailures("", meta, failure.Newf(scanner.Position{
 				Filename: protoFile.DisplayPath,
-			}, "FORMAT_DIFF", "Format returned a diff.")); err != nil {
+			}, failure.Format, "Format returned a diff.")); err != nil {
 				return err
 			}
 		}

--- a/internal/x/format/base_visitor.go
+++ b/internal/x/format/base_visitor.go
@@ -144,7 +144,7 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 		} else if len(o.Constant.Array) > 0 { // both Array and OrderedMap should not be set simultaneously, need more followup with emicklei/proto
 			v.Failures = append(
 				v.Failures,
-				failure.Newf(o.Position, "INVALID_PROTOBUF", "top-level options should never be arrays, this should not compile with protoc"),
+				failure.Newf(o.Position, failure.Proto, "top-level options should never be arrays, this should not compile with protoc"),
 			)
 		} else { // len(o.Constant.OrderedMap) > 0
 			v.P(prefix, o.Name, ` = {`)

--- a/internal/x/format/base_visitor.go
+++ b/internal/x/format/base_visitor.go
@@ -27,13 +27,13 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 type baseVisitor struct {
 	*printer
 
-	Failures []*text.Failure
+	Failures []*failure.Failure
 }
 
 func newBaseVisitor(indent string) *baseVisitor {
@@ -59,7 +59,7 @@ func newBaseVisitor(indent string) *baseVisitor {
 //func (v *baseVisitor) VisitExtensions(element *proto.Extensions)   {}
 
 func (v *baseVisitor) AddFailure(position scanner.Position, format string, args ...interface{}) {
-	v.Failures = append(v.Failures, &text.Failure{
+	v.Failures = append(v.Failures, &failure.Failure{
 		Line:    position.Line,
 		Column:  position.Column,
 		Message: fmt.Sprintf(format, args...),
@@ -144,7 +144,7 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 		} else if len(o.Constant.Array) > 0 { // both Array and OrderedMap should not be set simultaneously, need more followup with emicklei/proto
 			v.Failures = append(
 				v.Failures,
-				text.NewFailuref(o.Position, "INVALID_PROTOBUF", "top-level options should never be arrays, this should not compile with protoc"),
+				failure.Newf(o.Position, "INVALID_PROTOBUF", "top-level options should never be arrays, this should not compile with protoc"),
 			)
 		} else { // len(o.Constant.OrderedMap) > 0
 			v.P(prefix, o.Name, ` = {`)

--- a/internal/x/format/base_visitor.go
+++ b/internal/x/format/base_visitor.go
@@ -21,7 +21,6 @@
 package format
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"text/scanner"
@@ -59,11 +58,7 @@ func newBaseVisitor(indent string) *baseVisitor {
 //func (v *baseVisitor) VisitExtensions(element *proto.Extensions)   {}
 
 func (v *baseVisitor) AddFailure(position scanner.Position, format string, args ...interface{}) {
-	v.Failures = append(v.Failures, &failure.Failure{
-		Line:    position.Line,
-		Column:  position.Column,
-		Message: fmt.Sprintf(format, args...),
-	})
+	v.Failures = append(v.Failures, failure.Newf(position, failure.Format, format, args...))
 }
 
 func (v *baseVisitor) PWithInlineComment(inlineComment *proto.Comment, args ...interface{}) {

--- a/internal/x/format/first_pass_visitor.go
+++ b/internal/x/format/first_pass_visitor.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/wkt"
 	"github.com/uber/prototool/internal/x/settings"
 )
@@ -47,7 +47,7 @@ func newFirstPassVisitor(config settings.Config) *firstPassVisitor {
 	return &firstPassVisitor{baseVisitor: newBaseVisitor(config.Format.Indent)}
 }
 
-func (v *firstPassVisitor) Do() []*text.Failure {
+func (v *firstPassVisitor) Do() []*failure.Failure {
 	if v.Syntax != nil {
 		v.PComment(v.Syntax.Comment)
 		if v.Syntax.Comment != nil {

--- a/internal/x/format/format.go
+++ b/internal/x/format/format.go
@@ -21,7 +21,7 @@
 package format
 
 import (
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/x/settings"
 	"go.uber.org/zap"
 )
@@ -35,7 +35,7 @@ type Transformer interface {
 	// Failures should never happen in the CLI tool as we run the files
 	// through protoc first, but this is done because we want to verify
 	// code correctness here and protect against the bad case.
-	Transform(config settings.Config, data []byte) ([]byte, []*text.Failure, error)
+	Transform(config settings.Config, data []byte) ([]byte, []*failure.Failure, error)
 }
 
 // TransformerOption is an option for a new Transformer.

--- a/internal/x/format/middle_visitor.go
+++ b/internal/x/format/middle_visitor.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/x/settings"
 )
 
@@ -42,7 +42,7 @@ func newMiddleVisitor(config settings.Config, isProto2 bool) *middleVisitor {
 	return &middleVisitor{isProto2: isProto2, rpcUseSemicolons: config.Format.RPCUseSemicolons, baseVisitor: newBaseVisitor(config.Format.Indent)}
 }
 
-func (v *middleVisitor) Do() []*text.Failure {
+func (v *middleVisitor) Do() []*failure.Failure {
 	return v.Failures
 }
 

--- a/internal/x/format/transformer.go
+++ b/internal/x/format/transformer.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/x/settings"
 	"go.uber.org/zap"
 )
@@ -45,7 +45,7 @@ func newTransformer(options ...TransformerOption) *transformer {
 	return transformer
 }
 
-func (t *transformer) Transform(config settings.Config, data []byte) ([]byte, []*text.Failure, error) {
+func (t *transformer) Transform(config settings.Config, data []byte) ([]byte, []*failure.Failure, error) {
 	descriptor, err := proto.NewParser(bytes.NewReader(data)).Parse()
 	if err != nil {
 		return nil, nil, err
@@ -86,7 +86,7 @@ func (t *transformer) Transform(config settings.Config, data []byte) ([]byte, []
 	failures = append(failures, middleVisitor.Do()...)
 	buffer.Write(middleVisitor.Bytes())
 
-	text.SortFailures(failures)
+	failure.Sort(failures)
 
 	// TODO: expensive
 	s := strings.TrimSpace(buffer.String())

--- a/internal/x/lint/base_checker.go
+++ b/internal/x/lint/base_checker.go
@@ -25,28 +25,28 @@ import (
 	"sync"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 type baseChecker struct {
 	id      string
 	purpose string
-	check   func(string, []*proto.Proto) ([]*text.Failure, error)
+	check   func(string, []*proto.Proto) ([]*failure.Failure, error)
 }
 
 func newBaseAddChecker(
 	id string,
 	purpose string,
-	addCheck func(func(*text.Failure), string, []*proto.Proto) error,
+	addCheck func(func(*failure.Failure), string, []*proto.Proto) error,
 ) *baseChecker {
 	return newBaseChecker(
 		id,
 		purpose,
-		func(dirPath string, descriptors []*proto.Proto) ([]*text.Failure, error) {
-			var failures []*text.Failure
+		func(dirPath string, descriptors []*proto.Proto) ([]*failure.Failure, error) {
+			var failures []*failure.Failure
 			var lock sync.Mutex
 			if err := addCheck(
-				func(failure *text.Failure) {
+				func(failure *failure.Failure) {
 					lock.Lock()
 					failures = append(failures, failure)
 					lock.Unlock()
@@ -64,7 +64,7 @@ func newBaseAddChecker(
 func newBaseChecker(
 	id string,
 	purpose string,
-	check func(string, []*proto.Proto) ([]*text.Failure, error),
+	check func(string, []*proto.Proto) ([]*failure.Failure, error),
 ) *baseChecker {
 	return &baseChecker{
 		id:      strings.ToUpper(id),
@@ -81,7 +81,7 @@ func (c *baseChecker) Purpose() string {
 	return c.purpose
 }
 
-func (c *baseChecker) Check(dirPath string, descriptors []*proto.Proto) ([]*text.Failure, error) {
+func (c *baseChecker) Check(dirPath string, descriptors []*proto.Proto) ([]*failure.Failure, error) {
 	failures, err := c.check(dirPath, descriptors)
 	for _, failure := range failures {
 		failure.ID = c.id

--- a/internal/x/lint/base_visitor.go
+++ b/internal/x/lint/base_visitor.go
@@ -60,7 +60,7 @@ func newBaseAddVisitor(add func(*failure.Failure)) baseAddVisitor {
 }
 
 func (v baseAddVisitor) AddFailuref(position scanner.Position, format string, args ...interface{}) {
-	v.add(failure.Newf(position, "LINT", format, args...))
+	v.add(failure.Newf(position, failure.Lint, format, args...))
 }
 
 // extendedVisitor extends the proto.Visitor interface.

--- a/internal/x/lint/base_visitor.go
+++ b/internal/x/lint/base_visitor.go
@@ -60,7 +60,7 @@ func newBaseAddVisitor(add func(*text.Failure)) baseAddVisitor {
 }
 
 func (v baseAddVisitor) AddFailuref(position scanner.Position, format string, args ...interface{}) {
-	v.add(text.NewFailuref(position, "", format, args...))
+	v.add(text.NewFailuref(position, "LINT", format, args...))
 }
 
 // extendedVisitor extends the proto.Visitor interface.

--- a/internal/x/lint/base_visitor.go
+++ b/internal/x/lint/base_visitor.go
@@ -24,7 +24,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 type baseVisitor struct{}
@@ -52,15 +52,15 @@ func (baseVisitor) VisitExtensions(e *proto.Extensions)   {}
 
 type baseAddVisitor struct {
 	baseVisitor
-	add func(*text.Failure)
+	add func(*failure.Failure)
 }
 
-func newBaseAddVisitor(add func(*text.Failure)) baseAddVisitor {
+func newBaseAddVisitor(add func(*failure.Failure)) baseAddVisitor {
 	return baseAddVisitor{add: add}
 }
 
 func (v baseAddVisitor) AddFailuref(position scanner.Position, format string, args ...interface{}) {
-	v.add(text.NewFailuref(position, "LINT", format, args...))
+	v.add(failure.Newf(position, "LINT", format, args...))
 }
 
 // extendedVisitor extends the proto.Visitor interface.

--- a/internal/x/lint/check_comments_no_c_style.go
+++ b/internal/x/lint/check_comments_no_c_style.go
@@ -24,7 +24,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var commentsNoCStyleChecker = NewAddChecker(
@@ -33,7 +33,7 @@ var commentsNoCStyleChecker = NewAddChecker(
 	checkCommentsNoCStyle,
 )
 
-func checkCommentsNoCStyle(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkCommentsNoCStyle(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&commentsNoCStyleVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_enum_field_names_upper_snake_case.go
+++ b/internal/x/lint/check_enum_field_names_upper_snake_case.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var enumFieldNamesUpperSnakeCaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var enumFieldNamesUpperSnakeCaseChecker = NewAddChecker(
 	checkEnumFieldNamesUpperSnakeCase,
 )
 
-func checkEnumFieldNamesUpperSnakeCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkEnumFieldNamesUpperSnakeCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(enumFieldNamesUpperSnakeCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_enum_field_names_uppercase.go
+++ b/internal/x/lint/check_enum_field_names_uppercase.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var enumFieldNamesUppercaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var enumFieldNamesUppercaseChecker = NewAddChecker(
 	checkEnumFieldNamesUppercase,
 )
 
-func checkEnumFieldNamesUppercase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkEnumFieldNamesUppercase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(enumFieldNamesUppercaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_enum_field_prefixes.go
+++ b/internal/x/lint/check_enum_field_prefixes.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var enumFieldPrefixesChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var enumFieldPrefixesChecker = NewAddChecker(
 	checkEnumFieldPrefixes,
 )
 
-func checkEnumFieldPrefixes(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkEnumFieldPrefixes(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&enumFieldPrefixesVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_enum_names_camel_case.go
+++ b/internal/x/lint/check_enum_names_camel_case.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var enumNamesCamelCaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var enumNamesCamelCaseChecker = NewAddChecker(
 	checkEnumNamesCamelCase,
 )
 
-func checkEnumNamesCamelCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkEnumNamesCamelCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(enumNamesCamelCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_enum_names_capitalized.go
+++ b/internal/x/lint/check_enum_names_capitalized.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var enumNamesCapitalizedChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var enumNamesCapitalizedChecker = NewAddChecker(
 	checkEnumNamesCapitalized,
 )
 
-func checkEnumNamesCapitalized(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkEnumNamesCapitalized(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(enumNamesCapitalizedVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_enum_zero_values_invalid.go
+++ b/internal/x/lint/check_enum_zero_values_invalid.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var enumZeroValuesInvalidChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var enumZeroValuesInvalidChecker = NewAddChecker(
 	checkEnumZeroValuesInvalid,
 )
 
-func checkEnumZeroValuesInvalid(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkEnumZeroValuesInvalid(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&enumZeroValuesInvalidVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_enums_have_comments.go
+++ b/internal/x/lint/check_enums_have_comments.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var enumsHaveCommentsChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var enumsHaveCommentsChecker = NewAddChecker(
 	checkEnumsHaveComments,
 )
 
-func checkEnumsHaveComments(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkEnumsHaveComments(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(enumsHaveCommentsVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_file_options_equal.go
+++ b/internal/x/lint/check_file_options_equal.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var fileOptionsEqualGoPackagePbSuffixChecker = NewAddChecker(
@@ -60,8 +60,8 @@ var fileOptionsEqualJavaPackageComPbChecker = NewAddChecker(
 	}),
 )
 
-func newCheckFileOptionsEqual(fileOption string, expectedValueFunc func(*proto.Package) string) func(func(*text.Failure), string, []*proto.Proto) error {
-	return func(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func newCheckFileOptionsEqual(fileOption string, expectedValueFunc func(*proto.Package) string) func(func(*failure.Failure), string, []*proto.Proto) error {
+	return func(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 		return runVisitor(&fileOptionsEqualVisitor{
 			baseAddVisitor:    newBaseAddVisitor(add),
 			fileOption:        fileOption,

--- a/internal/x/lint/check_file_options_required.go
+++ b/internal/x/lint/check_file_options_required.go
@@ -24,7 +24,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var fileOptionsRequireGoPackageChecker = NewAddChecker(
@@ -51,8 +51,8 @@ var fileOptionsRequireJavaPackageChecker = NewAddChecker(
 	newCheckFileOptionsRequire("java_package"),
 )
 
-func newCheckFileOptionsRequire(fileOption string) func(func(*text.Failure), string, []*proto.Proto) error {
-	return func(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func newCheckFileOptionsRequire(fileOption string) func(func(*failure.Failure), string, []*proto.Proto) error {
+	return func(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 		return runVisitor(&fileOptionsRequireVisitor{
 			baseAddVisitor: newBaseAddVisitor(add),
 			fileOption:     fileOption,

--- a/internal/x/lint/check_file_options_same_in_dir.go
+++ b/internal/x/lint/check_file_options_same_in_dir.go
@@ -26,7 +26,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var fileOptionsGoPackageSameInDirChecker = NewAddChecker(
@@ -41,8 +41,8 @@ var fileOptionsJavaPackageSameInDirChecker = NewAddChecker(
 	newCheckFileOptionsSameInDir("java_package"),
 )
 
-func newCheckFileOptionsSameInDir(fileOption string) func(func(*text.Failure), string, []*proto.Proto) error {
-	return func(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func newCheckFileOptionsSameInDir(fileOption string) func(func(*failure.Failure), string, []*proto.Proto) error {
+	return func(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 		visitor := &fileOptionsSameInDirVisitor{
 			baseAddVisitor:   newBaseAddVisitor(add),
 			fileOption:       fileOption,

--- a/internal/x/lint/check_message_field_names_lower_snake_case.go
+++ b/internal/x/lint/check_message_field_names_lower_snake_case.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var messageFieldNamesLowerSnakeCaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var messageFieldNamesLowerSnakeCaseChecker = NewAddChecker(
 	checkMessageFieldNamesLowerSnakeCase,
 )
 
-func checkMessageFieldNamesLowerSnakeCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkMessageFieldNamesLowerSnakeCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(messageFieldNamesLowerSnakeCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_message_field_names_lowercase.go
+++ b/internal/x/lint/check_message_field_names_lowercase.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var messageFieldNamesLowercaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var messageFieldNamesLowercaseChecker = NewAddChecker(
 	checkMessageFieldNamesLowercase,
 )
 
-func checkMessageFieldNamesLowercase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkMessageFieldNamesLowercase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(messageFieldNamesLowercaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_message_fields_not_floats.go
+++ b/internal/x/lint/check_message_fields_not_floats.go
@@ -22,7 +22,7 @@ package lint
 
 import (
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var messageFieldsNotFloatsChecker = NewAddChecker(
@@ -31,7 +31,7 @@ var messageFieldsNotFloatsChecker = NewAddChecker(
 	checkMessageFieldsNotFloats,
 )
 
-func checkMessageFieldsNotFloats(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkMessageFieldsNotFloats(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(messageFieldsNotFloatsVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_message_names_camel_case.go
+++ b/internal/x/lint/check_message_names_camel_case.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var messageNamesCamelCaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var messageNamesCamelCaseChecker = NewAddChecker(
 	checkMessageNamesCamelCase,
 )
 
-func checkMessageNamesCamelCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkMessageNamesCamelCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(messageNamesCamelCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_message_names_capitalized.go
+++ b/internal/x/lint/check_message_names_capitalized.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var messageNamesCapitalizedChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var messageNamesCapitalizedChecker = NewAddChecker(
 	checkMessageNamesCapitalized,
 )
 
-func checkMessageNamesCapitalized(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkMessageNamesCapitalized(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(messageNamesCapitalizedVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_messages_have_comments.go
+++ b/internal/x/lint/check_messages_have_comments.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var messagesHaveCommentsChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var messagesHaveCommentsChecker = NewAddChecker(
 	checkMessagesHaveComments,
 )
 
-func checkMessagesHaveComments(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkMessagesHaveComments(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(messagesHaveCommentsVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_messages_have_comments_except_request_response_types.go
+++ b/internal/x/lint/check_messages_have_comments_except_request_response_types.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var messagesHaveCommentsExceptRequestResponseTypesChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var messagesHaveCommentsExceptRequestResponseTypesChecker = NewAddChecker(
 	checkMessagesHaveCommentsExceptRequestResponseTypes,
 )
 
-func checkMessagesHaveCommentsExceptRequestResponseTypes(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkMessagesHaveCommentsExceptRequestResponseTypes(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&messagesHaveCommentsExceptRequestResponseTypesVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_oneof_names_lower_snake_case.go
+++ b/internal/x/lint/check_oneof_names_lower_snake_case.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var oneofNamesLowerSnakeCaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var oneofNamesLowerSnakeCaseChecker = NewAddChecker(
 	checkOneofNamesLowerSnakeCase,
 )
 
-func checkOneofNamesLowerSnakeCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkOneofNamesLowerSnakeCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(oneofNamesLowerSnakeCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_package_is_declared.go
+++ b/internal/x/lint/check_package_is_declared.go
@@ -24,7 +24,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var packageIsDeclaredChecker = NewAddChecker(
@@ -33,7 +33,7 @@ var packageIsDeclaredChecker = NewAddChecker(
 	checkPackageIsDeclared,
 )
 
-func checkPackageIsDeclared(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkPackageIsDeclared(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&packageIsDeclaredVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_package_lower_snake_case.go
+++ b/internal/x/lint/check_package_lower_snake_case.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var packageLowerSnakeCaseChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var packageLowerSnakeCaseChecker = NewAddChecker(
 	checkPackageLowerSnakeCase,
 )
 
-func checkPackageLowerSnakeCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkPackageLowerSnakeCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&packageLowerSnakeCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_packages_same_in_dir.go
+++ b/internal/x/lint/check_packages_same_in_dir.go
@@ -26,7 +26,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var packagesSameInDirChecker = NewAddChecker(
@@ -35,7 +35,7 @@ var packagesSameInDirChecker = NewAddChecker(
 	checkPackagesSameInDir,
 )
 
-func checkPackagesSameInDir(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkPackagesSameInDir(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	visitor := &packagesSameInDirVisitor{baseAddVisitor: newBaseAddVisitor(add), pkgs: make(map[string]struct{})}
 	if err := runVisitor(visitor, descriptors); err != nil {
 		return err

--- a/internal/x/lint/check_request_response_names_match_rpc.go
+++ b/internal/x/lint/check_request_response_names_match_rpc.go
@@ -22,7 +22,7 @@ package lint
 
 import (
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var requestResponseNamesMatchRPCChecker = NewAddChecker(
@@ -31,7 +31,7 @@ var requestResponseNamesMatchRPCChecker = NewAddChecker(
 	checkRequestResponseNamesMatchRPC,
 )
 
-func checkRequestResponseNamesMatchRPC(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkRequestResponseNamesMatchRPC(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(requestResponseNamesMatchRPCVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_request_response_types_in_same_file.go
+++ b/internal/x/lint/check_request_response_types_in_same_file.go
@@ -25,7 +25,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var requestResponseTypesInSameFileChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var requestResponseTypesInSameFileChecker = NewAddChecker(
 	checkRequestResponseTypesInSameFile,
 )
 
-func checkRequestResponseTypesInSameFile(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkRequestResponseTypesInSameFile(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&requestResponseTypesInSameFileVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_request_response_types_unique.go
+++ b/internal/x/lint/check_request_response_types_unique.go
@@ -22,7 +22,7 @@ package lint
 
 import (
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var requestResponseTypesUniqueChecker = NewAddChecker(
@@ -31,7 +31,7 @@ var requestResponseTypesUniqueChecker = NewAddChecker(
 	checkRequestResponseTypesUnique,
 )
 
-func checkRequestResponseTypesUnique(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkRequestResponseTypesUnique(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&requestResponseTypesUniqueVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_rpc_names_camel_case.go
+++ b/internal/x/lint/check_rpc_names_camel_case.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var rpcNamesCamelCaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var rpcNamesCamelCaseChecker = NewAddChecker(
 	checkRPCNamesCamelCase,
 )
 
-func checkRPCNamesCamelCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkRPCNamesCamelCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(rpcNamesCamelCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_rpc_names_capitalized.go
+++ b/internal/x/lint/check_rpc_names_capitalized.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var rpcNamesCapitalizedChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var rpcNamesCapitalizedChecker = NewAddChecker(
 	checkRPCNamesCapitalized,
 )
 
-func checkRPCNamesCapitalized(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkRPCNamesCapitalized(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(rpcNamesCapitalizedVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_rpcs_have_comments.go
+++ b/internal/x/lint/check_rpcs_have_comments.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var rpcsHaveCommentsChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var rpcsHaveCommentsChecker = NewAddChecker(
 	checkRPCsHaveComments,
 )
 
-func checkRPCsHaveComments(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkRPCsHaveComments(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(rpcsHaveCommentsVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_service_names_camel_case.go
+++ b/internal/x/lint/check_service_names_camel_case.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var serviceNamesCamelCaseChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var serviceNamesCamelCaseChecker = NewAddChecker(
 	checkServiceNamesCamelCase,
 )
 
-func checkServiceNamesCamelCase(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkServiceNamesCamelCase(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(serviceNamesCamelCaseVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_service_names_capitalized.go
+++ b/internal/x/lint/check_service_names_capitalized.go
@@ -23,7 +23,7 @@ package lint
 import (
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/strs"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var serviceNamesCapitalizedChecker = NewAddChecker(
@@ -32,7 +32,7 @@ var serviceNamesCapitalizedChecker = NewAddChecker(
 	checkServiceNamesCapitalized,
 )
 
-func checkServiceNamesCapitalized(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkServiceNamesCapitalized(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(serviceNamesCapitalizedVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_services_have_comments.go
+++ b/internal/x/lint/check_services_have_comments.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var servicesHaveCommentsChecker = NewAddChecker(
@@ -34,7 +34,7 @@ var servicesHaveCommentsChecker = NewAddChecker(
 	checkServicesHaveComments,
 )
 
-func checkServicesHaveComments(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkServicesHaveComments(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(servicesHaveCommentsVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_syntax_proto3.go
+++ b/internal/x/lint/check_syntax_proto3.go
@@ -24,7 +24,7 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 var syntaxProto3Checker = NewAddChecker(
@@ -33,7 +33,7 @@ var syntaxProto3Checker = NewAddChecker(
 	checkSyntaxProto3,
 )
 
-func checkSyntaxProto3(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkSyntaxProto3(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&syntaxProto3Visitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/check_wkt_directly_imported.go
+++ b/internal/x/lint/check_wkt_directly_imported.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/wkt"
 )
 
@@ -39,7 +39,7 @@ var (
 	)
 )
 
-func checkWKTDirectlyImported(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+func checkWKTDirectlyImported(add func(*failure.Failure), dirPath string, descriptors []*proto.Proto) error {
 	return runVisitor(&wktDirectlyImportedVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
 }
 

--- a/internal/x/lint/runner.go
+++ b/internal/x/lint/runner.go
@@ -21,7 +21,7 @@
 package lint
 
 import (
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/x/file"
 	"go.uber.org/zap"
 )
@@ -40,8 +40,8 @@ func newRunner(options ...RunnerOption) *runner {
 	return runner
 }
 
-func (r *runner) Run(protoSets ...*file.ProtoSet) ([]*text.Failure, error) {
-	var failures []*text.Failure
+func (r *runner) Run(protoSets ...*file.ProtoSet) ([]*failure.Failure, error) {
+	var failures []*failure.Failure
 	for _, protoSet := range protoSets {
 		checkers, err := GetCheckers(protoSet.Config.Lint)
 		if err != nil {

--- a/internal/x/phab/phab.go
+++ b/internal/x/phab/phab.go
@@ -29,7 +29,7 @@ package phab
 import (
 	"fmt"
 
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 const (
@@ -45,7 +45,7 @@ const (
 	DefaultHarbormasterLintResultSeverity = "error"
 )
 
-// HarbormasterLintResult represents a text.Failure in a structure
+// HarbormasterLintResult represents a failure.Failure in a structure
 // compatible with a Harbormaster Lint Result. It is meant to be
 // encoded to JSON.
 //
@@ -60,8 +60,8 @@ type HarbormasterLintResult struct {
 	Description string `json:"description,omitempty"`
 }
 
-// TextFailureToHarbormasterLintResult converts a text.Failure to a HarbormasterLintResult.
-func TextFailureToHarbormasterLintResult(textFailure *text.Failure) (*HarbormasterLintResult, error) {
+// TextFailureToHarbormasterLintResult converts a failure.Failure to a HarbormasterLintResult.
+func TextFailureToHarbormasterLintResult(textFailure *failure.Failure) (*HarbormasterLintResult, error) {
 	if textFailure == nil {
 		return nil, nil
 	}

--- a/internal/x/phab/phab_test.go
+++ b/internal/x/phab/phab_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 )
 
 func TestTextFailureToHarbormasterLintResult(t *testing.T) {
 	harbormasterLintResult, err := TextFailureToHarbormasterLintResult(
-		&text.Failure{
+		&failure.Failure{
 			Filename: "path/to/foo.proto",
 			Line:     2,
 			Message:  "Foo is a foo.",
@@ -49,7 +49,7 @@ func TestTextFailureToHarbormasterLintResult(t *testing.T) {
 		harbormasterLintResult,
 	)
 	harbormasterLintResult, err = TextFailureToHarbormasterLintResult(
-		&text.Failure{
+		&failure.Failure{
 			Filename: "path/to/foo.proto",
 			Line:     2,
 			ID:       "FOO",

--- a/internal/x/protoc/compiler.go
+++ b/internal/x/protoc/compiler.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/wkt"
 	"github.com/uber/prototool/internal/x/file"
 	"github.com/uber/prototool/internal/x/settings"
@@ -105,7 +105,7 @@ func (c *compiler) Compile(protoSets ...*file.ProtoSet) (*CompileResult, error) 
 			return nil, err
 		}
 	}
-	var failures []*text.Failure
+	var failures []*failure.Failure
 	var errs []error
 	var lock sync.Mutex
 	var wg sync.WaitGroup
@@ -124,7 +124,7 @@ func (c *compiler) Compile(protoSets ...*file.ProtoSet) (*CompileResult, error) 
 		}()
 	}
 	wg.Wait()
-	// errors are not text.Failures, these are actual unhandled
+	// errors are not failure.Failures, these are actual unhandled
 	// system errors from calling protoc, so we short circuit
 	if len(errs) > 0 {
 		// I want newlines instead of spaces so not using multierr
@@ -142,7 +142,7 @@ func (c *compiler) Compile(protoSets ...*file.ProtoSet) (*CompileResult, error) 
 	// as we should error out, so we do not do any parsing of file descriptor sets
 	// this decision could be revisited
 	if len(failures) > 0 {
-		text.SortFailures(failures)
+		failure.Sort(failures)
 		return &CompileResult{
 			Failures: failures,
 		}, nil
@@ -204,7 +204,7 @@ func (c *compiler) makeGenDirs(protoSets ...*file.ProtoSet) error {
 	return nil
 }
 
-func (c *compiler) runCmdMeta(cmdMeta *cmdMeta) ([]*text.Failure, error) {
+func (c *compiler) runCmdMeta(cmdMeta *cmdMeta) ([]*failure.Failure, error) {
 	c.logger.Debug("running protoc", zap.String("command", cmdMeta.String()))
 	buffer := bytes.NewBuffer(nil)
 	cmdMeta.execCmd.Stderr = buffer
@@ -214,7 +214,7 @@ func (c *compiler) runCmdMeta(cmdMeta *cmdMeta) ([]*text.Failure, error) {
 	cmdMeta.execCmd.Stdout = ioutil.Discard
 	runErr := cmdMeta.execCmd.Run()
 	if runErr != nil {
-		// exit errors are ok, we can probably parse them into text.Failures
+		// exit errors are ok, we can probably parse them into failure.Failures
 		// if not an exec.ExitError, short circuit
 		if _, ok := runErr.(*exec.ExitError); !ok {
 			return nil, runErr
@@ -496,10 +496,10 @@ func getIncludes(
 	return includes, nil
 }
 
-// we try to handle all protoc errors to convert them into text.Failures
+// we try to handle all protoc errors to convert them into failure.Failures
 // so we can output failures in the standard filename:line:column:message format
-func parseProtocOutput(cmdMeta *cmdMeta, output string) ([]*text.Failure, error) {
-	var failures []*text.Failure
+func parseProtocOutput(cmdMeta *cmdMeta, output string) ([]*failure.Failure, error) {
+	var failures []*failure.Failure
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
@@ -515,21 +515,21 @@ func parseProtocOutput(cmdMeta *cmdMeta, output string) ([]*text.Failure, error)
 	return failures, nil
 }
 
-func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*text.Failure, error) {
+func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, error) {
 	if matches := pluginFailedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-		return &text.Failure{
+		return &failure.Failure{
 			Message: fmt.Sprintf("protoc-gen-%s failed with status code %s.", matches[1], matches[2]),
 		}, nil
 	}
 	if matches := otherPluginFailureRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-		return &text.Failure{
+		return &failure.Failure{
 			Message: fmt.Sprintf("protoc-gen-%s: %s", matches[1], matches[2]),
 		}, nil
 	}
 	split := strings.Split(protocLine, ":")
 	if len(split) != 4 {
 		if matches := noSyntaxSpecifiedRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  `No syntax specified. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version.`,
 			}, nil
@@ -538,20 +538,20 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*text.Failure, error)
 			if cmdMeta.protoSet.Config.Compile.AllowUnusedImports {
 				return nil, nil
 			}
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  fmt.Sprintf(`Import "%s" was not used.`, matches[2]),
 			}, nil
 		}
 		if matches := fileNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &text.Failure{
+			return &failure.Failure{
 				// TODO: can we figure out the file name?
 				Filename: "",
 				Message:  fmt.Sprintf(`Import "%s" was not found.`, matches[1]),
 			}, nil
 		}
 		if matches := explicitDefaultValuesProto3Regexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  `Explicit default values are not allowed in proto3.`,
 			}, nil
@@ -562,36 +562,36 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*text.Failure, error)
 			return nil, nil
 		}
 		if matches := jsonCamelCaseRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  matches[2],
 			}, nil
 		}
 		if matches := isNotDefinedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  fmt.Sprintf(`%s is not defined.`, matches[2]),
 			}, nil
 		}
 		if matches := seemsToBeDefinedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  matches[2],
 			}, nil
 		}
 		if matches := optionValueRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  fmt.Sprintf(`Error while parsing option value for %s`, matches[2]),
 			}, nil
 		}
 		if matches := programNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &text.Failure{
+			return &failure.Failure{
 				Message: fmt.Sprintf("protoc-gen-%s not found or is not executable.", matches[1]),
 			}, nil
 		}
 		if matches := firstEnumValueZeroRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &text.Failure{
+			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
 				Message:  `The first enum value must be zero in proto3.`,
 			}, nil
@@ -601,7 +601,7 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*text.Failure, error)
 		// I would prefer to error so that we signal that we don't know what the line is
 		// but if this becomes problematic with some plugin in the future, we should
 		// return nil, nil here
-		// TODO: this should probably be changed to return a generic *text.Failure with
+		// TODO: this should probably be changed to return a generic *failure.Failure with
 		// no file, line, or column, and just the message being protocLine
 		// https://github.com/uber/prototool/issues/14
 		return nil, fmt.Errorf("could not interpret protoc line: %s", protocLine)
@@ -618,7 +618,7 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*text.Failure, error)
 	if message == "" {
 		return nil, fmt.Errorf("could not interpret protoc line: %s", protocLine)
 	}
-	return &text.Failure{
+	return &failure.Failure{
 		Filename: bestFilePath(cmdMeta, split[0]),
 		Line:     line,
 		Column:   column,

--- a/internal/x/protoc/compiler.go
+++ b/internal/x/protoc/compiler.go
@@ -33,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/scanner"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -408,7 +409,7 @@ func getPluginFlagSetProtoFlags(protoSet *file.ProtoSet, dirPath string, genPlug
 		return genPlugin.Flags, nil
 	}
 	if genPlugin.Type.IsGo() && genPlugin.Type.IsGogo() {
-		return "", fmt.Errorf("internal error: plugin %s is both a go and gogo plugin", genPlugin.Name)
+		return "", fmt.Errorf("internal error: plugin %q is both a go and gogo plugin", genPlugin.Name)
 	}
 	var goFlags []string
 	if genPlugin.Flags != "" {
@@ -517,49 +518,28 @@ func parseProtocOutput(cmdMeta *cmdMeta, output string) ([]*failure.Failure, err
 
 func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, error) {
 	if matches := pluginFailedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-		return &failure.Failure{
-			ID:      failure.Proto.String(),
-			Message: fmt.Sprintf("protoc-gen-%s failed with status code %s.", matches[1], matches[2]),
-		}, nil
+		return newFailure("", "protoc-gen-%s failed with status code %s.", matches[1], matches[2]), nil
 	}
 	if matches := otherPluginFailureRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-		return &failure.Failure{
-			ID:      failure.Proto.String(),
-			Message: fmt.Sprintf("protoc-gen-%s: %s", matches[1], matches[2]),
-		}, nil
+		return newFailure("", "protoc-gen-%s: %s", matches[1], matches[2]), nil
 	}
 	split := strings.Split(protocLine, ":")
 	if len(split) != 4 {
 		if matches := noSyntaxSpecifiedRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  `No syntax specified. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version.`,
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), `No syntax specified. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version.`), nil
 		}
 		if matches := extraImportRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 			if cmdMeta.protoSet.Config.Compile.AllowUnusedImports {
 				return nil, nil
 			}
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  fmt.Sprintf(`Import "%s" was not used.`, matches[2]),
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), "Import %q was not used.", matches[2]), nil
 		}
 		if matches := fileNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &failure.Failure{
-				// TODO: can we figure out the file name?
-				ID:      failure.Proto.String(),
-				Message: fmt.Sprintf(`Import "%s" was not found.`, matches[1]),
-			}, nil
+			// TODO: can we figure out the file name?
+			return newFailure("", "Import %q was not found.", matches[1]), nil
 		}
 		if matches := explicitDefaultValuesProto3Regexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  `Explicit default values are not allowed in proto3.`,
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), "Explicit default values are not allowed in proto3."), nil
 		}
 		if matches := importNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 			// handled by fileNotFoundRegexp
@@ -567,45 +547,22 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, err
 			return nil, nil
 		}
 		if matches := jsonCamelCaseRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  matches[2],
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), matches[2]), nil
 		}
 		if matches := isNotDefinedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  fmt.Sprintf(`%s is not defined.`, matches[2]),
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), "%q is not defined.", matches[2]), nil
 		}
 		if matches := seemsToBeDefinedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  matches[2],
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), matches[2]), nil
 		}
 		if matches := optionValueRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  fmt.Sprintf(`Error while parsing option value for %s`, matches[2]),
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), "Error while parsing option value for %q", matches[2]), nil
 		}
 		if matches := programNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &failure.Failure{
-				Message: fmt.Sprintf("protoc-gen-%s not found or is not executable.", matches[1]),
-				ID:      failure.Proto.String(),
-			}, nil
+			return newFailure("", "protoc-gen-%s not found or is not executable.", matches[1]), nil
 		}
 		if matches := firstEnumValueZeroRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return &failure.Failure{
-				Filename: bestFilePath(cmdMeta, matches[1]),
-				ID:       failure.Proto.String(),
-				Message:  `The first enum value must be zero in proto3.`,
-			}, nil
+			return newFailure(bestFilePath(cmdMeta, matches[1]), "The first enum value must be zero in proto3."), nil
 		}
 		// TODO: plugins can output to stderr as well and we have no way to redirect the output
 		// this will error if there are any logging line from a plugin
@@ -745,4 +702,13 @@ func tryRemoveTempFile(tempFilePath string) {
 	if tempFilePath != "" {
 		_ = os.Remove(tempFilePath)
 	}
+}
+
+func newFailure(filename string, format string, args ...interface{}) *failure.Failure {
+	return failure.Newf(
+		scanner.Position{Filename: filename, Line: 1, Column: 1}, // default position
+		failure.Proto,
+		format,
+		args...,
+	)
 }

--- a/internal/x/protoc/compiler.go
+++ b/internal/x/protoc/compiler.go
@@ -518,10 +518,10 @@ func parseProtocOutput(cmdMeta *cmdMeta, output string) ([]*failure.Failure, err
 
 func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, error) {
 	if matches := pluginFailedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-		return newFailure("", "protoc-gen-%s failed with status code %s.", matches[1], matches[2]), nil
+		return newFailure(failure.DefaultFilename, "protoc-gen-%s failed with status code %s.", matches[1], matches[2]), nil
 	}
 	if matches := otherPluginFailureRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
-		return newFailure("", "protoc-gen-%s: %s", matches[1], matches[2]), nil
+		return newFailure(failure.DefaultFilename, "protoc-gen-%s: %s", matches[1], matches[2]), nil
 	}
 	split := strings.Split(protocLine, ":")
 	if len(split) != 4 {
@@ -536,7 +536,7 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, err
 		}
 		if matches := fileNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			// TODO: can we figure out the file name?
-			return newFailure("", "Import %q was not found.", matches[1]), nil
+			return newFailure(failure.DefaultFilename, "Import %q was not found.", matches[1]), nil
 		}
 		if matches := explicitDefaultValuesProto3Regexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			return newFailure(bestFilePath(cmdMeta, matches[1]), "Explicit default values are not allowed in proto3."), nil
@@ -559,7 +559,7 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, err
 			return newFailure(bestFilePath(cmdMeta, matches[1]), "Error while parsing option value for %q", matches[2]), nil
 		}
 		if matches := programNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
-			return newFailure("", "protoc-gen-%s not found or is not executable.", matches[1]), nil
+			return newFailure(failure.DefaultFilename, "protoc-gen-%s not found or is not executable.", matches[1]), nil
 		}
 		if matches := firstEnumValueZeroRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			return newFailure(bestFilePath(cmdMeta, matches[1]), "The first enum value must be zero in proto3."), nil
@@ -706,7 +706,7 @@ func tryRemoveTempFile(tempFilePath string) {
 
 func newFailure(filename string, format string, args ...interface{}) *failure.Failure {
 	return failure.Newf(
-		scanner.Position{Filename: filename, Line: 1, Column: 1}, // default position
+		scanner.Position{Filename: filename, Line: failure.DefaultLine, Column: failure.DefaultColumn},
 		failure.Proto,
 		format,
 		args...,

--- a/internal/x/protoc/compiler.go
+++ b/internal/x/protoc/compiler.go
@@ -518,11 +518,13 @@ func parseProtocOutput(cmdMeta *cmdMeta, output string) ([]*failure.Failure, err
 func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, error) {
 	if matches := pluginFailedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 		return &failure.Failure{
+			ID:      failure.Proto.String(),
 			Message: fmt.Sprintf("protoc-gen-%s failed with status code %s.", matches[1], matches[2]),
 		}, nil
 	}
 	if matches := otherPluginFailureRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 		return &failure.Failure{
+			ID:      failure.Proto.String(),
 			Message: fmt.Sprintf("protoc-gen-%s: %s", matches[1], matches[2]),
 		}, nil
 	}
@@ -531,6 +533,7 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, err
 		if matches := noSyntaxSpecifiedRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  `No syntax specified. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version.`,
 			}, nil
 		}
@@ -540,19 +543,21 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, err
 			}
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  fmt.Sprintf(`Import "%s" was not used.`, matches[2]),
 			}, nil
 		}
 		if matches := fileNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			return &failure.Failure{
 				// TODO: can we figure out the file name?
-				Filename: "",
-				Message:  fmt.Sprintf(`Import "%s" was not found.`, matches[1]),
+				ID:      failure.Proto.String(),
+				Message: fmt.Sprintf(`Import "%s" was not found.`, matches[1]),
 			}, nil
 		}
 		if matches := explicitDefaultValuesProto3Regexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  `Explicit default values are not allowed in proto3.`,
 			}, nil
 		}
@@ -564,35 +569,41 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, err
 		if matches := jsonCamelCaseRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  matches[2],
 			}, nil
 		}
 		if matches := isNotDefinedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  fmt.Sprintf(`%s is not defined.`, matches[2]),
 			}, nil
 		}
 		if matches := seemsToBeDefinedRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  matches[2],
 			}, nil
 		}
 		if matches := optionValueRegexp.FindStringSubmatch(protocLine); len(matches) > 2 {
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  fmt.Sprintf(`Error while parsing option value for %s`, matches[2]),
 			}, nil
 		}
 		if matches := programNotFoundRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			return &failure.Failure{
 				Message: fmt.Sprintf("protoc-gen-%s not found or is not executable.", matches[1]),
+				ID:      failure.Proto.String(),
 			}, nil
 		}
 		if matches := firstEnumValueZeroRegexp.FindStringSubmatch(protocLine); len(matches) > 1 {
 			return &failure.Failure{
 				Filename: bestFilePath(cmdMeta, matches[1]),
+				ID:       failure.Proto.String(),
 				Message:  `The first enum value must be zero in proto3.`,
 			}, nil
 		}
@@ -620,6 +631,7 @@ func parseProtocLine(cmdMeta *cmdMeta, protocLine string) (*failure.Failure, err
 	}
 	return &failure.Failure{
 		Filename: bestFilePath(cmdMeta, split[0]),
+		ID:       failure.Proto.String(),
 		Line:     line,
 		Column:   column,
 		Message:  message,

--- a/internal/x/protoc/protoc.go
+++ b/internal/x/protoc/protoc.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/uber/prototool/internal/text"
+	"github.com/uber/prototool/internal/failure"
 	"github.com/uber/prototool/internal/x/file"
 	"github.com/uber/prototool/internal/x/settings"
 	"go.uber.org/zap"
@@ -105,7 +105,7 @@ func NewDownloader(config settings.Config, options ...DownloaderOption) Download
 // CompileResult is the result of a compile
 type CompileResult struct {
 	// The failures from all calls.
-	Failures []*text.Failure
+	Failures []*failure.Failure
 	// Will not be set if there are any failures.
 	FileDescriptorSets []*descriptor.FileDescriptorSet
 }

--- a/internal/x/settings/settings.go
+++ b/internal/x/settings/settings.go
@@ -122,7 +122,7 @@ func ParseGenPluginType(s string) (GenPluginType, error) {
 //
 // All paths returned should be absolute paths. Outside of this package,
 // all other internal packages should verify that all given paths are
-// absolute, except for the internal/text package.
+// absolute, except for the internal/failure package.
 type Config struct {
 	// The working directory path.
 	// Expected to be absolute path.


### PR DESCRIPTION
Note that this moves the `internal/text` package to `internal/failure`. Seeing as this package is primarily concerned with failures, it makes more sense to remove some of the verbose naming (e.g. `FailureField`, `FailureWriter`, etc.).

The primary change introduced here is the `failure.ID` type, which is used to categorize prototool failures. The available IDs are `{Error, Format, Lint, Proto}`. Previously, we supported `DIFF_FORMAT` and `INVALID_PROTOBUF` for special cases. These are now `FORMAT` and `PROTO`, respectively. All of the failures created in `internal/x/lint` are now identified by `LINT` and those created in `internal/x/protoc` are `PROTO`.

The mapping is now as follows:

```
Error -> "ERROR"
Format -> "FORMAT"
Lint -> "LINT"
Proto -> "PROTO"
```

This now enforces that all failures creates with `failure.Newf` will contain a valid `failure.ID`. And in the cases where `failure.Newf` cannot be easily used (in the absence of a `scanner.Position`), such as in `internal/x/protoc`, we use a `newFailure` wrapper/helper.

We continue to use the fallback behavior previously found in `failure.Fprintln` so that we make sure all of our failures will contain valid fields. This is especially important if any `failure.Failure` types are created without a filename, line, or column (i.e. without using `failure.Newf`). 

With that said, we should avoid creating `failure.Failure` types in-place whenever possible. Rather, we should rely on the `failure.Newf` function so that we always categorize our failures with a `failure.ID`. Ideally, the fallback `failure.Error` ID would not be used.

-------------

Note that I've attempted to break this up in more-easily reviewable commits so that the changes here are better understood.