### PR TITLE
protoc.Compile: clean up cmdMetas

### DIFF
--- a/internal/x/protoc/compiler.go
+++ b/internal/x/protoc/compiler.go
@@ -83,17 +83,20 @@ func newCompiler(options ...CompilerOption) *compiler {
 
 func (c *compiler) Compile(protoSets ...*file.ProtoSet) (*CompileResult, error) {
 	var allCmdMetas []*cmdMeta
-	// we potentially create temporary files if doFileDescriptorSet is true
-	// if so, we try to remove them when we return no matter what
-	// by putting this defer here, we get this catch early
-	defer cleanCmdMetas(allCmdMetas)
 	for _, protoSet := range protoSets {
 		cmdMetas, err := c.getCmdMetas(protoSet)
 		if err != nil {
+			cleanCmdMetas(allCmdMetas)
 			return nil, err
 		}
 		allCmdMetas = append(allCmdMetas, cmdMetas...)
 	}
+
+	// we potentially create temporary files if doFileDescriptorSet is true
+	// if so, we try to remove them when we return no matter what
+	// by putting this defer here, we get this catch early
+	defer cleanCmdMetas(allCmdMetas)
+
 	if c.doGen {
 		// the directories for the output files have to exist
 		// so if we are generating, we create them before running


### PR DESCRIPTION
Deferring the call to `cleanCmdMetas` so early means we'll be calling
with a nil value for `allCmdMetas` rather than the final pointer value
that `append` could have returned.