### PR TITLE
Exclude vendor from git clean in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ releaseclean:
 .PHONY: clean
 clean:
 	go clean -i $(PKGS)
-	git clean -xdf
+	git clean -xdf --exclude vendor
 
 .PHONY: cleanall
 cleanall: clean releaseclean


### PR DESCRIPTION
It's not fun when `make clean` deletes your `vendor` directory as well, this makes it a little nicer.