### PR TITLE
 Switch --update-file-options to --no-update-file-options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,13 @@ golden: install
 		rm -f $${file}; \
 	done
 	for file in $(shell find internal/cmd/testdata/format -name '*.proto'); do \
-		prototool format $${file} > $${file}.golden || true; \
+		prototool format --no-update-file-options $${file} > $${file}.golden || true; \
 	done
 	for file in $(shell find internal/cmd/testdata/format-update-file-options -name '*.proto.golden'); do \
 		rm -f $${file}; \
 	done
 	for file in $(shell find internal/cmd/testdata/format-update-file-options -name '*.proto'); do \
-		prototool format --update-file-options $${file} > $${file}.golden || true; \
+		prototool format $${file} > $${file}.golden || true; \
 	done
 
 .PHONY: example

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -100,14 +100,14 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Short: "Compile, then format and overwrite, then re-compile and generate, then lint, stopping if any step fails.",
 		Run: func(cmd *cobra.Command, args []string) {
 			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error {
-				return runner.All(args, flags.disableFormat, flags.disableLint, flags.updateFileOptions)
+				return runner.All(args, flags.disableFormat, flags.disableLint, !flags.noUpdateFileOptions)
 			})
 		},
 	}
 	flags.bindDirMode(allCmd.PersistentFlags())
 	flags.bindDisableFormat(allCmd.PersistentFlags())
 	flags.bindDisableLint(allCmd.PersistentFlags())
-	flags.bindUpdateFileOptions(allCmd.PersistentFlags())
+	flags.bindNoUpdateFileOptions(allCmd.PersistentFlags())
 
 	binaryToJSONCmd := &cobra.Command{
 		Use:   "binary-to-json dirOrProtoFiles... messagePath data",
@@ -191,14 +191,14 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Short: "Format a proto file and compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
 			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error {
-				return runner.Format(args, flags.overwrite, flags.diffMode, flags.lintMode, flags.updateFileOptions)
+				return runner.Format(args, flags.overwrite, flags.diffMode, flags.lintMode, !flags.noUpdateFileOptions)
 			})
 		},
 	}
 	flags.bindDiffMode(formatCmd.PersistentFlags())
 	flags.bindLintMode(formatCmd.PersistentFlags())
 	flags.bindOverwrite(formatCmd.PersistentFlags())
-	flags.bindUpdateFileOptions(formatCmd.PersistentFlags())
+	flags.bindNoUpdateFileOptions(formatCmd.PersistentFlags())
 
 	genCmd := &cobra.Command{
 		Use:   "gen dirOrProtoFiles...",

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -682,8 +682,8 @@ func assertDoLintFiles(t *testing.T, expectSuccess bool, expectedLinePrefixes st
 
 func assertGoldenFormat(t *testing.T, expectSuccess bool, updateFileOptions bool, filePath string) {
 	args := []string{"format"}
-	if updateFileOptions {
-		args = append(args, "--update-file-options")
+	if !updateFileOptions {
+		args = append(args, "--no-update-file-options")
 	}
 	args = append(args, filePath)
 	output, exitCode := testDo(t, args...)

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -25,25 +25,25 @@ import (
 )
 
 type flags struct {
-	cachePath         string
-	callTimeout       string
-	connectTimeout    string
-	debug             bool
-	diffMode          bool
-	dirMode           bool
-	disableFormat     bool
-	disableLint       bool
-	gen               bool
-	harbormaster      bool
-	headers           []string
-	keepaliveTime     string
-	lintMode          bool
-	overwrite         bool
-	pkg               string
-	printFields       string
-	protocURL         string
-	uncomment         bool
-	updateFileOptions bool
+	cachePath           string
+	callTimeout         string
+	connectTimeout      string
+	debug               bool
+	diffMode            bool
+	dirMode             bool
+	disableFormat       bool
+	disableLint         bool
+	gen                 bool
+	harbormaster        bool
+	headers             []string
+	keepaliveTime       string
+	lintMode            bool
+	overwrite           bool
+	pkg                 string
+	printFields         string
+	protocURL           string
+	uncomment           bool
+	noUpdateFileOptions bool
 }
 
 func (f *flags) bindCachePath(flagSet *pflag.FlagSet) {
@@ -118,6 +118,6 @@ func (f *flags) bindUncomment(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.uncomment, "uncomment", false, "Uncomment the example config settings.")
 }
 
-func (f *flags) bindUpdateFileOptions(flagSet *pflag.FlagSet) {
-	flagSet.BoolVar(&f.updateFileOptions, "update-file-options", false, "Update the file options go_package and java_package to match the package per the guidelines of the style guide.")
+func (f *flags) bindNoUpdateFileOptions(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.noUpdateFileOptions, "no-update-file-options", false, "Do not update the file options go_package and java_package to match the package per the guidelines of the style guide.")
 }


### PR DESCRIPTION
As opposed to opting in to `--update-file-options`, I think we might want it as the default, changing the flag to the negating `--no-update-file-options` for the current behavior. I only updated this in the `internal/cmd` package, doing `!flags.noUpdateFileOptions` when this is passed to the `internal/x/exec` package. If we don't get complaints and end up wanting this, we can go back and change everything from `updateFileOptions` to `noUpdateFileOptions` down the stack later, but I'd prefer not to have thrashing here, and also we might just want to keep it this way (it makes more sense logically in my head at the moment).