### PR TITLE
Centralize Protobuf package/filename string manipulation functionality

### DIFF
--- a/internal/create/handler.go
+++ b/internal/create/handler.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/uber/prototool/internal/protostrs"
 	"github.com/uber/prototool/internal/settings"
-	"github.com/uber/prototool/internal/strs"
 	"go.uber.org/zap"
 )
 
@@ -111,9 +111,9 @@ func (h *handler) create(filePath string) error {
 	data, err := getData(
 		&tmplData{
 			Pkg:                pkg,
-			GoPkg:              getGoPkg(pkg),
-			JavaOuterClassname: getJavaOuterclassname(filePath),
-			JavaPkg:            getJavaPkg(pkg),
+			GoPkg:              protostrs.GoPackage(pkg),
+			JavaOuterClassname: protostrs.JavaOuterClassname(filePath),
+			JavaPkg:            protostrs.JavaPackage(pkg),
 		},
 	)
 	if err != nil {
@@ -190,21 +190,6 @@ func getPkgFromRel(rel string, basePkg string) string {
 		return relPkg
 	}
 	return basePkg + "." + relPkg
-}
-
-func getGoPkg(pkg string) string {
-	split := strings.Split(pkg, ".")
-	return split[len(split)-1] + "pb"
-}
-
-func getJavaOuterclassname(filename string) string {
-	filename = filepath.Base(filename)
-	filename = strings.TrimSuffix(filename, filepath.Ext(filename))
-	return strs.ToUpperCamelCase(filename) + "Proto"
-}
-
-func getJavaPkg(pkg string) string {
-	return "com." + pkg
 }
 
 func getData(tmplData *tmplData) ([]byte, error) {

--- a/internal/format/first_pass_visitor.go
+++ b/internal/format/first_pass_visitor.go
@@ -21,13 +21,11 @@
 package format
 
 import (
-	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/emicklei/proto"
+	"github.com/uber/prototool/internal/protostrs"
 	"github.com/uber/prototool/internal/settings"
-	"github.com/uber/prototool/internal/strs"
 	"github.com/uber/prototool/internal/text"
 )
 
@@ -85,18 +83,18 @@ func (v *firstPassVisitor) Do() []*text.Failure {
 			v.javaPackageOption = &proto.Option{Name: "java_package"}
 		}
 		v.goPackageOption.Constant = proto.Literal{
-			Source:   packageBasename(v.Package.Name) + "pb",
+			Source:   protostrs.GoPackage(v.Package.Name),
 			IsString: true,
 		}
 		v.javaMultipleFilesOption.Constant = proto.Literal{
 			Source: "true",
 		}
 		v.javaOuterClassnameOption.Constant = proto.Literal{
-			Source:   fileBasenameUpperCamelCase(v.filename) + "Proto",
+			Source:   protostrs.JavaOuterClassname(v.filename),
 			IsString: true,
 		}
 		v.javaPackageOption.Constant = proto.Literal{
-			Source:   "com." + v.Package.Name,
+			Source:   protostrs.JavaPackage(v.Package.Name),
 			IsString: true,
 		}
 		v.Options = append(
@@ -238,15 +236,4 @@ func (v *firstPassVisitor) PImports(imports []*proto.Import) {
 		}
 		v.PWithInlineComment(i.InlineComment, `import `, kind, `"`, i.Filename, `";`)
 	}
-}
-
-func packageBasename(pkg string) string {
-	split := strings.Split(pkg, ".")
-	return split[len(split)-1]
-}
-
-func fileBasenameUpperCamelCase(filename string) string {
-	filename = filepath.Base(filename)
-	filename = strings.TrimSuffix(filename, filepath.Ext(filename))
-	return strs.ToUpperCamelCase(filename)
 }

--- a/internal/lint/check_file_options_equal.go
+++ b/internal/lint/check_file_options_equal.go
@@ -22,11 +22,9 @@ package lint
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/emicklei/proto"
-	"github.com/uber/prototool/internal/strs"
+	"github.com/uber/prototool/internal/protostrs"
 	"github.com/uber/prototool/internal/text"
 )
 
@@ -34,7 +32,7 @@ var fileOptionsEqualGoPackagePbSuffixLinter = NewLinter(
 	"FILE_OPTIONS_EQUAL_GO_PACKAGE_PB_SUFFIX",
 	`Verifies that the file option "go_package" is equal to $(basename PACKAGE)pb.`,
 	newCheckFileOptionsEqual("go_package", func(_ *proto.Proto, pkg *proto.Package) string {
-		return packageBasename(pkg.Name) + "pb"
+		return protostrs.GoPackage(pkg.Name)
 	}),
 )
 
@@ -50,7 +48,7 @@ var fileOptionsEqualJavaOuterClassnameProtoSuffixLinter = NewLinter(
 	"FILE_OPTIONS_EQUAL_JAVA_OUTER_CLASSNAME_PROTO_SUFFIX",
 	`Verifies that the file option "java_outer_classname" is equal to $(upperCamelCase $(basename FILE))Proto.`,
 	newCheckFileOptionsEqual("java_outer_classname", func(descriptor *proto.Proto, _ *proto.Package) string {
-		return fileBasenameUpperCamelCase(descriptor.Filename) + "Proto"
+		return protostrs.JavaOuterClassname(descriptor.Filename)
 	}),
 )
 
@@ -58,7 +56,7 @@ var fileOptionsEqualJavaPackageComPrefixLinter = NewLinter(
 	"FILE_OPTIONS_EQUAL_JAVA_PACKAGE_COM_PREFIX",
 	`Verifies that the file option "java_package" is equal to com.PACKAGE.`,
 	newCheckFileOptionsEqual("java_package", func(_ *proto.Proto, pkg *proto.Package) string {
-		return "com." + pkg.Name
+		return protostrs.JavaPackage(pkg.Name)
 	}),
 )
 
@@ -119,15 +117,4 @@ func (v *fileOptionsEqualVisitor) Finally() error {
 		v.AddFailuref(v.option.Position, "Expected %q for option %q but was %q.", expectedValue, v.option.Name, value)
 	}
 	return nil
-}
-
-func packageBasename(pkg string) string {
-	split := strings.Split(pkg, ".")
-	return split[len(split)-1]
-}
-
-func fileBasenameUpperCamelCase(filename string) string {
-	filename = filepath.Base(filename)
-	filename = strings.TrimSuffix(filename, filepath.Ext(filename))
-	return strs.ToUpperCamelCase(filename)
 }

--- a/internal/protostrs/protostrs.go
+++ b/internal/protostrs/protostrs.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package protostrs contains common string manipulation functionality for
+// Protobuf packages and files.
+//
+// This is used in the format, lint, and create packages. The Java rules in this
+// package roughly follow https://cloud.google.com/apis/design/file_structure.
+package protostrs
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/uber/prototool/internal/strs"
+)
+
+// GoPackage returns the value for the file option "go_package" given
+// a package name. This will be equal to the last value of the package
+// separated by "."s, followed by "pb". If packageName is empty,
+// this will return an empty string.
+func GoPackage(packageName string) string {
+	if packageName == "" {
+		return ""
+	}
+	split := strings.Split(packageName, ".")
+	return split[len(split)-1] + "pb"
+}
+
+// JavaOuterClassname returns the value for the file option
+// "java_outer_classname" given a file name. This will be equal to the
+// basename of the file with it's extension stripped, UpperCamelCased,
+// followed by "Proto". If filename is empty, this will return an empty
+// string.
+func JavaOuterClassname(filename string) string {
+	if filename == "" {
+		return ""
+	}
+	filename = filepath.Base(filename)
+	filename = strings.TrimSuffix(filename, filepath.Ext(filename))
+	return strs.ToUpperCamelCase(filename) + "Proto"
+}
+
+// JavaPackage returns the value for the file option "java_package" given
+// a package name. This will be equal to "com." followed by the package.
+// If packageName is empty, this will return an empty string.
+func JavaPackage(packageName string) string {
+	if packageName == "" {
+		return ""
+	}
+	return "com." + packageName
+}

--- a/internal/protostrs/protostrs_test.go
+++ b/internal/protostrs/protostrs_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protostrs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoPackage(t *testing.T) {
+	assert.Equal(t, "", GoPackage(""))
+}
+
+func TestJavaOuterClassname(t *testing.T) {
+	assert.Equal(t, "", JavaOuterClassname(""))
+}
+
+func TestJavaPackage(t *testing.T) {
+	assert.Equal(t, "", JavaPackage(""))
+}

--- a/internal/protostrs/protostrs_test.go
+++ b/internal/protostrs/protostrs_test.go
@@ -28,8 +28,8 @@ import (
 
 func TestGoPackage(t *testing.T) {
 	assert.Equal(t, "", GoPackage(""))
-	assert.Equal(t, "foo", GoPackage("foopb"))
-	assert.Equal(t, "foo.bar", GoPackage("barpb"))
+	assert.Equal(t, "foopb", GoPackage("foo"))
+	assert.Equal(t, "barpb", GoPackage("foo.bar"))
 }
 
 func TestJavaOuterClassname(t *testing.T) {
@@ -41,9 +41,12 @@ func TestJavaOuterClassname(t *testing.T) {
 	assert.Equal(t, "FileOneProto", JavaOuterClassname("a/b/file_one.proto"))
 	assert.Equal(t, "FileOneProto", JavaOuterClassname("a/b/file-one.proto"))
 	assert.Equal(t, "FileOneProto", JavaOuterClassname("a/b/file one.proto"))
-	assert.Equal(t, "FileOneTwoProto", JavaOuterClassname("a/b/fiLe_One_two.proto"))
+	assert.Equal(t, "FiLeOneTwoProto", JavaOuterClassname("a/b/fiLe_One_two.proto"))
+	assert.Equal(t, "FileOneProto", JavaOuterClassname("a/b/file one.txt"))
 }
 
 func TestJavaPackage(t *testing.T) {
 	assert.Equal(t, "", JavaPackage(""))
+	assert.Equal(t, "com.foo", JavaPackage("foo"))
+	assert.Equal(t, "com.foo.bar", JavaPackage("foo.bar"))
 }

--- a/internal/protostrs/protostrs_test.go
+++ b/internal/protostrs/protostrs_test.go
@@ -28,10 +28,20 @@ import (
 
 func TestGoPackage(t *testing.T) {
 	assert.Equal(t, "", GoPackage(""))
+	assert.Equal(t, "foo", GoPackage("foopb"))
+	assert.Equal(t, "foo.bar", GoPackage("barpb"))
 }
 
 func TestJavaOuterClassname(t *testing.T) {
 	assert.Equal(t, "", JavaOuterClassname(""))
+	assert.Equal(t, "FileProto", JavaOuterClassname("file.proto"))
+	assert.Equal(t, "FileProto", JavaOuterClassname("file.txt"))
+	assert.Equal(t, "FileProto", JavaOuterClassname("a/file.proto"))
+	assert.Equal(t, "FileProto", JavaOuterClassname("a/b/file.proto"))
+	assert.Equal(t, "FileOneProto", JavaOuterClassname("a/b/file_one.proto"))
+	assert.Equal(t, "FileOneProto", JavaOuterClassname("a/b/file-one.proto"))
+	assert.Equal(t, "FileOneProto", JavaOuterClassname("a/b/file one.proto"))
+	assert.Equal(t, "FileOneTwoProto", JavaOuterClassname("a/b/fiLe_One_two.proto"))
 }
 
 func TestJavaPackage(t *testing.T) {


### PR DESCRIPTION
This combines the string manipulation functionality to go from package and filename to `go_package`, `java_package`, and `java_outer_classname`.