### PR TITLE
Add dry-run flag to replace protoc-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - A linter to verify that no enum uses the option `allow_alias.`
-
+### Changed
+- The protoc-commands command is now accessible via the `dry-run`
+  flag for compile, format, gen, and lint.
 
 ## [0.4.0] - 2018-06-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Prototool accomplishes this by downloading and calling protoc on the fly for you
     * [prototool format](#prototool-format)
     * [prototool create](#prototool-create)
     * [prototool files](#prototool-files)
-    * [prototool protoc-commands](#prototool-protoc-commands)
     * [prototool grpc](#prototool-grpc)
   * [gRPC Example](#grpc-example)
   * [Tips and Tricks](#tips-and-tricks)
@@ -65,8 +64,6 @@ prototool files idl/uber # list the files that will be used after applying exclu
 prototool list-linters # list all current lint rules being used
 prototool compile idl/uber # make sure all .proto files in idl/uber compile, but do not generate stubs
 prototool gen idl/uber # generate stubs, see the generation directives in the config file example
-prototool protoc-commands idl/uber # print out the protoc commands that would be invoked with prototool compile idl/uber
-prototool protoc-commands --gen idl/uber # print out the protoc commands that would be invoked with prototool gen idl/uber
 prototool grpc idl/uber 0.0.0.0:8080 foo.ExcitedService/Exclamation '{"value":"hello"}' # call the foo.ExcitedService method Exclamation with the given data on 0.0.0.0:8080
 cd $(prototool download) # download prints out the cached protoc dir, so this changes to the cache directory
 ```
@@ -243,10 +240,6 @@ If [Vim integration](#vim-integration) is set up, files will be generated when y
 ##### `prototool files`
 
 Print the list of all files that will be used given the input `dirOrProtoFiles...`. Useful for debugging.
-
-##### `prototool protoc-commands`
-
-Print all `protoc` commands that would be run on `prototool compile`. Add the `--gen` flag to print all commands that would be run on `prototool gen`.
 
 ##### `prototool grpc`
 

--- a/example/gen/proto/go/foo/foo.pb.gw.go
+++ b/example/gen/proto/go/foo/foo.pb.gw.go
@@ -65,14 +65,14 @@ func RegisterHelloServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.S
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()
@@ -86,8 +86,8 @@ func RegisterHelloServiceHandler(ctx context.Context, mux *runtime.ServeMux, con
 	return RegisterHelloServiceHandlerClient(ctx, mux, NewHelloServiceClient(conn))
 }
 
-// RegisterHelloServiceHandlerClient registers the http handlers for service HelloService
-// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "HelloServiceClient".
+// RegisterHelloServiceHandler registers the http handlers for service HelloService to "mux".
+// The handlers forward requests to the grpc endpoint over the given implementation of "HelloServiceClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "HelloServiceClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "HelloServiceClient" to call the correct interceptors.

--- a/example/gen/proto/go/foo/foo.pb.gw.go
+++ b/example/gen/proto/go/foo/foo.pb.gw.go
@@ -65,14 +65,14 @@ func RegisterHelloServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.S
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()
@@ -86,8 +86,8 @@ func RegisterHelloServiceHandler(ctx context.Context, mux *runtime.ServeMux, con
 	return RegisterHelloServiceHandlerClient(ctx, mux, NewHelloServiceClient(conn))
 }
 
-// RegisterHelloServiceHandler registers the http handlers for service HelloService to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "HelloServiceClient".
+// RegisterHelloServiceHandlerClient registers the http handlers for service HelloService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "HelloServiceClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "HelloServiceClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "HelloServiceClient" to call the correct interceptors.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -100,7 +100,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Short: "Compile, then format and overwrite, then re-compile and generate, then lint, stopping if any step fails.",
 		Run: func(cmd *cobra.Command, args []string) {
 			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error {
-				return runner.All(args, flags.disableFormat, flags.disableLint, !flags.noRewrite, flags.dryRun)
+				return runner.All(args, flags.disableFormat, flags.disableLint, !flags.noRewrite)
 			})
 		},
 	}
@@ -191,7 +191,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Short: "Format a proto file and compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
 			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error {
-				return runner.Format(args, flags.overwrite, flags.diffMode, flags.lintMode, !flags.noRewrite, flags.dryRun)
+				return runner.Format(args, flags.overwrite, flags.diffMode, flags.lintMode, !flags.noRewrite)
 			})
 		},
 	}
@@ -248,7 +248,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Use:   "lint dirOrProtoFiles...",
 		Short: "Lint proto files and compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Lint(args, flags.dryRun) })
+			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Lint(args) })
 		},
 	}
 	flags.bindDirMode(lintCmd.PersistentFlags())

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -100,7 +100,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Short: "Compile, then format and overwrite, then re-compile and generate, then lint, stopping if any step fails.",
 		Run: func(cmd *cobra.Command, args []string) {
 			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error {
-				return runner.All(args, flags.disableFormat, flags.disableLint, !flags.noRewrite)
+				return runner.All(args, flags.disableFormat, flags.disableLint, !flags.noRewrite, flags.dryRun)
 			})
 		},
 	}
@@ -132,7 +132,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Use:   "compile dirOrProtoFiles...",
 		Short: "Compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Compile(args) })
+			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Compile(args, flags.dryRun) })
 		},
 	}
 	flags.bindDirMode(compileCmd.PersistentFlags())
@@ -191,7 +191,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Short: "Format a proto file and compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
 			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error {
-				return runner.Format(args, flags.overwrite, flags.diffMode, flags.lintMode, !flags.noRewrite)
+				return runner.Format(args, flags.overwrite, flags.diffMode, flags.lintMode, !flags.noRewrite, flags.dryRun)
 			})
 		},
 	}
@@ -204,7 +204,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Use:   "gen dirOrProtoFiles...",
 		Short: "Generate with protoc.",
 		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Gen(args) })
+			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Gen(args, flags.dryRun) })
 		},
 	}
 	flags.bindDirMode(genCmd.PersistentFlags())
@@ -248,7 +248,7 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Use:   "lint dirOrProtoFiles...",
 		Short: "Lint proto files and compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Lint(args) })
+			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Lint(args, flags.dryRun) })
 		},
 	}
 	flags.bindDirMode(lintCmd.PersistentFlags())
@@ -289,16 +289,6 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		},
 	}
 
-	protocCommandsCmd := &cobra.Command{
-		Use:   "protoc-commands dirOrProtoFiles...",
-		Short: "Print the commands that would be run on compile or gen.",
-		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.ProtocCommands(args, flags.gen) })
-		},
-	}
-	flags.bindDirMode(protocCommandsCmd.PersistentFlags())
-	flags.bindGen(protocCommandsCmd.PersistentFlags())
-
 	serviceDescriptorProtoCmd := &cobra.Command{
 		Use:   "service-descriptor-proto dirOrProtoFiles... servicePath",
 		Short: "Get the service descriptor proto for the service path.",
@@ -338,13 +328,13 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 	rootCmd.AddCommand(listAllLintGroupsCmd)
 	rootCmd.AddCommand(listLintersCmd)
 	rootCmd.AddCommand(listLintGroupCmd)
-	rootCmd.AddCommand(protocCommandsCmd)
 	rootCmd.AddCommand(serviceDescriptorProtoCmd)
 	rootCmd.AddCommand(versionCmd)
 
 	// flags bound to rootCmd are global flags
 	flags.bindCachePath(rootCmd.PersistentFlags())
 	flags.bindDebug(rootCmd.PersistentFlags())
+	flags.bindDryRun(rootCmd.PersistentFlags())
 	flags.bindHarbormaster(rootCmd.PersistentFlags())
 	flags.bindPrintFields(rootCmd.PersistentFlags())
 	flags.bindProtocURL(rootCmd.PersistentFlags())

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -33,7 +33,7 @@ type flags struct {
 	dirMode        bool
 	disableFormat  bool
 	disableLint    bool
-	gen            bool
+	dryRun         bool
 	harbormaster   bool
 	headers        []string
 	keepaliveTime  string
@@ -78,8 +78,8 @@ func (f *flags) bindDisableLint(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.disableLint, "disable-lint", false, "Do not run linting.")
 }
 
-func (f *flags) bindGen(flagSet *pflag.FlagSet) {
-	flagSet.BoolVar(&f.gen, "gen", false, "Print the commands that would be run on gen instead of compile.")
+func (f *flags) bindDryRun(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.dryRun, "dry-run", false, "Print the protoc commands that would have been run without actually running them.")
 }
 
 func (f *flags) bindHarbormaster(flagSet *pflag.FlagSet) {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -56,15 +56,15 @@ type Runner interface {
 	DescriptorProto(args []string) error
 	FieldDescriptorProto(args []string) error
 	ServiceDescriptorProto(args []string) error
-	Lint(args []string, dryRun bool) error
+	Lint(args []string) error
 	ListLinters() error
 	ListAllLinters() error
 	ListLintGroup(group string) error
 	ListAllLintGroups() error
-	Format(args []string, overwrite, diffMode, lintMode, rewrite, dryRun bool) error
+	Format(args []string, overwrite, diffMode, lintMode, rewrite bool) error
 	BinaryToJSON(args []string) error
 	JSONToBinary(args []string) error
-	All(args []string, disableFormat, disableLint, rewrite, dryRun bool) error
+	All(args []string, disableFormat, disableLint, rewrite bool) error
 	GRPC(args, headers []string, callTimeout, connectTimeout, keepaliveTime string) error
 }
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -51,22 +51,21 @@ type Runner interface {
 	Download() error
 	Clean() error
 	Files(args []string) error
-	Compile(args []string) error
-	Gen(args []string) error
+	Compile(args []string, dryRun bool) error
+	Gen(args []string, dryRun bool) error
 	DescriptorProto(args []string) error
 	FieldDescriptorProto(args []string) error
 	ServiceDescriptorProto(args []string) error
-	ProtocCommands(args []string, genCommands bool) error
-	Lint(args []string) error
+	Lint(args []string, dryRun bool) error
 	ListLinters() error
 	ListAllLinters() error
 	ListLintGroup(group string) error
 	ListAllLintGroups() error
-	Format(args []string, overwrite bool, diffMode bool, lintMode bool, rewrite bool) error
+	Format(args []string, overwrite, diffMode, lintMode, rewrite, dryRun bool) error
 	BinaryToJSON(args []string) error
 	JSONToBinary(args []string) error
-	All(args []string, disableFormat bool, disableLint bool, rewrite bool) error
-	GRPC(args []string, headers []string, callTimeout string, connectTimeout string, keepaliveTime string) error
+	All(args []string, disableFormat, disableLint, rewrite, dryRun bool) error
+	GRPC(args, headers []string, callTimeout, connectTimeout, keepaliveTime string) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -324,13 +324,13 @@ func (r *runner) printCommands(doGen bool, protoSets ...*file.ProtoSet) error {
 	return nil
 }
 
-func (r *runner) Lint(args []string, dryRun bool) error {
+func (r *runner) Lint(args []string) error {
 	meta, err := r.getMeta(args)
 	if err != nil {
 		return err
 	}
 	r.printAffectedFiles(meta)
-	if _, err := r.compile(false, false, dryRun, meta); err != nil {
+	if _, err := r.compile(false, false, false, meta); err != nil {
 		return err
 	}
 	return r.lint(meta)
@@ -389,7 +389,7 @@ func (r *runner) ListAllLintGroups() error {
 	return nil
 }
 
-func (r *runner) Format(args []string, overwrite, diffMode, lintMode, rewrite, dryRun bool) error {
+func (r *runner) Format(args []string, overwrite, diffMode, lintMode, rewrite bool) error {
 	if (overwrite && diffMode) || (overwrite && lintMode) || (diffMode && lintMode) {
 		return newExitErrorf(255, "can only set one of overwrite, diff, lint")
 	}
@@ -398,16 +398,13 @@ func (r *runner) Format(args []string, overwrite, diffMode, lintMode, rewrite, d
 		return err
 	}
 	r.printAffectedFiles(meta)
-	if _, err := r.compile(false, false, dryRun, meta); err != nil {
+	if _, err := r.compile(false, false, false, meta); err != nil {
 		return err
 	}
-	return r.format(overwrite, diffMode, lintMode, rewrite, dryRun, meta)
+	return r.format(overwrite, diffMode, lintMode, rewrite, meta)
 }
 
-func (r *runner) format(overwrite, diffMode, lintMode, rewrite, dryRun bool, meta *meta) error {
-	if dryRun {
-		return nil
-	}
+func (r *runner) format(overwrite, diffMode, lintMode, rewrite bool, meta *meta) error {
 	success := true
 	for _, protoSet := range meta.ProtoSets {
 		for _, protoFiles := range protoSet.DirPathToFiles {
@@ -541,24 +538,24 @@ func (r *runner) JSONToBinary(args []string) error {
 	return err
 }
 
-func (r *runner) All(args []string, disableFormat, disableLint, rewrite, dryRun bool) error {
+func (r *runner) All(args []string, disableFormat, disableLint, rewrite bool) error {
 	meta, err := r.getMeta(args)
 	if err != nil {
 		return err
 	}
 	r.printAffectedFiles(meta)
-	if _, err := r.compile(false, false, dryRun, meta); err != nil {
+	if _, err := r.compile(false, false, false, meta); err != nil {
 		return err
 	}
-	if !disableFormat && !dryRun {
-		if err := r.format(true, false, false, rewrite, dryRun, meta); err != nil {
+	if !disableFormat {
+		if err := r.format(true, false, false, rewrite, meta); err != nil {
 			return err
 		}
 	}
-	if _, err := r.compile(true, false, dryRun, meta); err != nil {
+	if _, err := r.compile(true, false, false, meta); err != nil {
 		return err
 	}
-	if !disableLint && !dryRun {
+	if !disableLint {
 		return r.lint(meta)
 	}
 	return nil


### PR DESCRIPTION
This replaces the `protoc-commands` command with a `--dry-run` flag in the relevant commands: compile, format, gen, and lint. Using a `dry-run` flag is featured in a variety of other CLI tools, such as git, and it removes the need for an additional command.

Previously, we only supported `protoc-commands` for `compile` and `gen`. It was simple enough to introduce these to `format` and `lint`. I'm not opposed to removing this functionality, as it might not be as necessary for `format` and `lint`, but thought it was worth including here.