### PR TITLE
Collape list commands into lint flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The protoc-commands command is now accessible via the `dry-run`
   flag for compile, format, gen, and lint.
+- The list-* commands are now accessible via lint command flags:
+  list-all, list-configured, list-groups, and list-group.
 
 ## [0.4.0] - 2018-06-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ prototool lint idl/uber # directory mode, search for all .proto files recursivel
 prototool lint # same as "prototool lint .", by default the current directory is used in directory mode
 prototool create foo.proto # create the file foo.proto from a template that passes lint
 prototool files idl/uber # list the files that will be used after applying exclude_paths from corresponding prototool.yaml files
-prototool list-linters # list all current lint rules being used
 prototool compile idl/uber # make sure all .proto files in idl/uber compile, but do not generate stubs
 prototool gen idl/uber # generate stubs, see the generation directives in the config file example
 prototool grpc idl/uber 0.0.0.0:8080 foo.ExcitedService/Exclamation '{"value":"hello"}' # call the foo.ExcitedService method Exclamation with the given data on 0.0.0.0:8080

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -248,46 +248,16 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 		Use:   "lint dirOrProtoFiles...",
 		Short: "Lint proto files and compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Lint(args) })
+			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error {
+				return runner.Lint(args, flags.listGroup, flags.listAll, flags.listConfigured, flags.listGroups)
+			})
 		},
 	}
 	flags.bindDirMode(lintCmd.PersistentFlags())
-
-	listAllLintersCmd := &cobra.Command{
-		Use:   "list-all-linters",
-		Short: "List all available linters.",
-		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, exec.Runner.ListAllLinters)
-		},
-	}
-
-	listAllLintGroupsCmd := &cobra.Command{
-		Use:   "list-all-lint-groups",
-		Short: "List all the available lint groups.",
-		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, exec.Runner.ListAllLintGroups)
-		},
-	}
-
-	listLintersCmd := &cobra.Command{
-		Use:   "list-linters",
-		Short: "List the configurerd linters.",
-		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, exec.Runner.ListLinters)
-		},
-	}
-
-	listLintGroupCmd := &cobra.Command{
-		Use:   "list-lint-group group",
-		Short: "List the linters in the given lint group.",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.ListLintGroup(args[0]) })
-		},
-	}
+	flags.bindListAll(lintCmd.PersistentFlags())
+	flags.bindListConfigured(lintCmd.PersistentFlags())
+	flags.bindListGroups(lintCmd.PersistentFlags())
+	flags.bindListGroup(lintCmd.PersistentFlags())
 
 	serviceDescriptorProtoCmd := &cobra.Command{
 		Use:   "service-descriptor-proto dirOrProtoFiles... servicePath",
@@ -324,10 +294,6 @@ func getRootCommand(exitCodeAddr *int, args []string, stdin io.Reader, stdout io
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(jsonToBinaryCmd)
 	rootCmd.AddCommand(lintCmd)
-	rootCmd.AddCommand(listAllLintersCmd)
-	rootCmd.AddCommand(listAllLintGroupsCmd)
-	rootCmd.AddCommand(listLintersCmd)
-	rootCmd.AddCommand(listLintGroupCmd)
 	rootCmd.AddCommand(serviceDescriptorProtoCmd)
 	rootCmd.AddCommand(versionCmd)
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -532,7 +532,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestListAllLintGroups(t *testing.T) {
-	assertExact(t, 0, "all\ndefault", "list-all-lint-groups")
+	assertExact(t, 0, "all\ndefault", "lint", "--list-groups")
 }
 
 func TestDescriptorProto(t *testing.T) {
@@ -637,11 +637,11 @@ func TestServiceDescriptorProto(t *testing.T) {
 }
 
 func TestListLinters(t *testing.T) {
-	assertLinters(t, lint.DefaultLinters, "list-linters")
+	assertLinters(t, lint.DefaultLinters, "lint", "--list-configured")
 }
 
 func TestListAllLinters(t *testing.T) {
-	assertLinters(t, lint.AllLinters, "list-all-linters")
+	assertLinters(t, lint.AllLinters, "lint", "--list-all")
 }
 
 func assertLinters(t *testing.T, linters []lint.Linter, args ...string) {

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -38,6 +38,10 @@ type flags struct {
 	headers        []string
 	keepaliveTime  string
 	lintMode       bool
+	listAll        bool
+	listConfigured bool
+	listGroups     bool
+	listGroup      string
 	overwrite      bool
 	pkg            string
 	printFields    string
@@ -96,6 +100,22 @@ func (f *flags) bindKeepaliveTime(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindLintMode(flagSet *pflag.FlagSet) {
 	flagSet.BoolVarP(&f.lintMode, "lint", "l", false, "Write a lint error saying that the file is not formatted instead of writing the formatted file to stdout.")
+}
+
+func (f *flags) bindListAll(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.listAll, "list-all", false, "List all of the available linters.")
+}
+
+func (f *flags) bindListConfigured(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.listConfigured, "list-configured", false, "List all of the configured linters.")
+}
+
+func (f *flags) bindListGroups(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.listGroups, "list-groups", false, "List all of the available linter groups.")
+}
+
+func (f *flags) bindListGroup(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.listGroup, "list-group", "", "List all of the linters configured in the given group.")
 }
 
 func (f *flags) bindOverwrite(flagSet *pflag.FlagSet) {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -56,11 +56,7 @@ type Runner interface {
 	DescriptorProto(args []string) error
 	FieldDescriptorProto(args []string) error
 	ServiceDescriptorProto(args []string) error
-	Lint(args []string) error
-	ListLinters() error
-	ListAllLinters() error
-	ListLintGroup(group string) error
-	ListAllLintGroups() error
+	Lint(args []string, listGroup string, listAll, listConfigured, listGroups bool) error
 	Format(args []string, overwrite, diffMode, lintMode, rewrite bool) error
 	BinaryToJSON(args []string) error
 	JSONToBinary(args []string) error


### PR DESCRIPTION
Similar to https://github.com/uber/prototool/pull/135, this collapses the `lint-*` commands into CLI flags for `prototool lint`. 