### PR TITLE
Fixed invalid yaml syntax for dir_to_base_package

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -35,9 +35,9 @@ create:
   dir_to_base_package:
     # This means that a file created "foo.proto" in the current directory will have package "bar".
     # A file created "a/b/foo.proto" will have package "bar.a.b".
-    .:bar
+    .: bar
     # This means that a file created "idl/code.uber/a/b/c.proto" will have package "uber.a.b".
-    idl/code.uber:uber
+    idl/code.uber: uber
 
 # Lint directives.
 lint:

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -65,9 +65,9 @@ protoc_version: {{.ProtocVersion}}
   {{.V}}dir_to_base_package:
     # This means that a file created "foo.proto" in the current directory will have package "bar".
     # A file created "a/b/foo.proto" will have package "bar.a.b".
-    {{.V}}.:bar
+    {{.V}}.: bar
     # This means that a file created "idl/code.uber/a/b/c.proto" will have package "uber.a.b".
-    {{.V}}idl/code.uber:uber
+    {{.V}}idl/code.uber: uber
 
 # Lint directives.
 {{.V}}lint:


### PR DESCRIPTION
Hi,

`prototool init` generates invalid yaml file

I don't understand why ci fails. Locally everything is fine.

```
mbp88msk:prototool erakhimberdin$ make init
go get github.com/Masterminds/glide
rm -rf vendor
glide install
[INFO]  Downloading dependencies. Please wait...
[INFO]  --> Found desired version locally github.com/beorn7/perks 3a771d992973f24aa725d07868b467d1ddfceafb!
[INFO]  --> Found desired version locally github.com/cpuguy83/go-md2man 48d8747a2ca13185e7cc8efe6e9fc196a83f71a5!
[INFO]  --> Found desired version locally github.com/emicklei/proto 92ccf4bb8fea88ece4fda55edd4d9cb9c329e18c!
[INFO]  --> Found desired version locally github.com/fullstorydev/grpcurl 819d39047c4d05485bc92ddfd5d9a07f7c8f4f66!
[INFO]  --> Found desired version locally github.com/gogo/protobuf 342cbe0a04158f6dcb03ca0079991a51a4248c02!
[INFO]  --> Found desired version locally github.com/golang/protobuf 5831880292e721c76b58a16ecc60adc27d8e6355!
[INFO]  --> Found desired version locally github.com/grpc-ecosystem/grpc-gateway 78a473d0e7485950359c782b3c663ee6981eed0c!
[INFO]  --> Found desired version locally github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75!
[INFO]  --> Found desired version locally github.com/jhump/protoreflect ebe8e6a9a8fafdc380875177e03a6e95574bf3f1!
[INFO]  --> Found desired version locally github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c!
[INFO]  --> Found desired version locally github.com/opentracing/opentracing-go 1949ddbfd147afd4d964a9f00b24eb291e0e7c38!
[INFO]  --> Found desired version locally github.com/prometheus/client_golang c5b7fccd204277076155f10851dad72b76a49317!
[INFO]  --> Found desired version locally github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c!
[INFO]  --> Found desired version locally github.com/prometheus/common 7600349dcfe1abd18d72d3a1770870d9800a7801!
[INFO]  --> Found desired version locally github.com/prometheus/procfs 7d6f385de8bea29190f15ba9931442a0eaef9af7!
[INFO]  --> Found desired version locally github.com/russross/blackfriday 11635eb403ff09dbc3a6b5a007ab5ab09151c229!
[INFO]  --> Found desired version locally github.com/spf13/cobra 1e58aa3361fd650121dceeedc399e7189c05674a!
[INFO]  --> Found desired version locally github.com/spf13/pflag 3ebe029320b2676d667ae88da602a5f854788a8a!
[INFO]  --> Found desired version locally github.com/uber-go/atomic 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289!
[INFO]  --> Found desired version locally github.com/uber-go/tally 79f2a33b0e55b1255ffbbaf824dcafb09ff34dda!
[INFO]  --> Found desired version locally github.com/uber/tchannel-go cc0c40929b0dbdb755b727a8c253de2b5d4af46b!
[INFO]  --> Found desired version locally go.uber.org/atomic 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289!
[INFO]  --> Found desired version locally go.uber.org/dig 45540ff1846c207f109bbb7de2f2748f7198ca21!
[INFO]  --> Found desired version locally go.uber.org/fx 4556160e761570faf2b4e89547c04cdcd96e0c7a!
[INFO]  --> Found desired version locally go.uber.org/multierr 3c4937480c32f4c13a875a1829af76c98ca3d40a!
[INFO]  --> Found desired version locally go.uber.org/net/metrics 1e19de5b971489a45d178e12a0f72a78c70e300e!
[INFO]  --> Found desired version locally go.uber.org/thriftrw 43dfafd7bb1c99f0460d645a1959b73f6dfa536f!
[INFO]  --> Found desired version locally go.uber.org/yarpc 889176c1e87f871683102ca81e9701feaa6d0aa2!
[INFO]  --> Found desired version locally go.uber.org/zap eeedf312bc6c57391d84767a4cd413f02a917974!
[INFO]  --> Found desired version locally golang.org/x/net db08ff08e8622530d9ed3a0e8ac279f6d4c02196!
[INFO]  --> Found desired version locally golang.org/x/text 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877!
[INFO]  --> Found desired version locally google.golang.org/genproto 32ee49c4dd805befd833990acba36cb75042378c!
[INFO]  --> Found desired version locally google.golang.org/grpc 24f3cca1ffddeab04708c325f8088c76c2d74972!
[INFO]  --> Found desired version locally gopkg.in/yaml.v2 5420a8b6744d3b0345ab293f6fcba19c978f1183!
[INFO]  --> Found desired version locally github.com/davecgh/go-spew 8991bc29aa16c548c550c7ff78260e27b9ab7c73!
[INFO]  --> Found desired version locally github.com/ghodss/yaml e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6!
[INFO]  --> Found desired version locally github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998!
[INFO]  --> Found desired version locally github.com/golang/lint 470b6b0bb3005eda157f0275e2e4895055396a81!
[INFO]  --> Found desired version locally github.com/kisielk/errcheck 55d8f507faff4d6eddd0c41a3e713e2567fca4e5!
[INFO]  --> Found desired version locally github.com/kisielk/gotool 80517062f582ea3340cd4baf70e86d539ae7d84d!
[INFO]  --> Found desired version locally github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2!
[INFO]  --> Found desired version locally github.com/stretchr/testify f35b8ab0b5a2cef36673838d662e249dd9c94686!
[INFO]  --> Found desired version locally github.com/wadey/gocovmerge b5bfa59ec0adc420475f97f89b58045c721d761c!
[INFO]  --> Found desired version locally go.uber.org/tools ce2550dad7144b81ae2f67dc5e55597643f6902b!
[INFO]  --> Found desired version locally golang.org/x/lint 470b6b0bb3005eda157f0275e2e4895055396a81!
[INFO]  --> Found desired version locally golang.org/x/tools c995a088887b4ae00a4c85a984117cbc8d86ca3d!
[INFO]  --> Found desired version locally honnef.co/go/tools 57ee65dc7ff868f8fe21064b05f9e744a73bc9ab!
[INFO]  Setting references.
[INFO]  --> Setting version for github.com/gogo/protobuf to 342cbe0a04158f6dcb03ca0079991a51a4248c02.
[INFO]  --> Setting version for github.com/golang/protobuf to 5831880292e721c76b58a16ecc60adc27d8e6355.
[INFO]  --> Setting version for github.com/prometheus/common to 7600349dcfe1abd18d72d3a1770870d9800a7801.
[INFO]  --> Setting version for github.com/jhump/protoreflect to ebe8e6a9a8fafdc380875177e03a6e95574bf3f1.
[INFO]  --> Setting version for github.com/opentracing/opentracing-go to 1949ddbfd147afd4d964a9f00b24eb291e0e7c38.
[INFO]  --> Setting version for github.com/fullstorydev/grpcurl to 819d39047c4d05485bc92ddfd5d9a07f7c8f4f66.
[INFO]  --> Setting version for github.com/spf13/pflag to 3ebe029320b2676d667ae88da602a5f854788a8a.
[INFO]  --> Setting version for github.com/matttproud/golang_protobuf_extensions to c12348ce28de40eed0136aa2b644d0ee0650e56c.
[INFO]  --> Setting version for github.com/emicklei/proto to 92ccf4bb8fea88ece4fda55edd4d9cb9c329e18c.
[INFO]  --> Setting version for github.com/beorn7/perks to 3a771d992973f24aa725d07868b467d1ddfceafb.
[INFO]  --> Setting version for github.com/uber-go/atomic to 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289.
[INFO]  --> Setting version for github.com/grpc-ecosystem/grpc-gateway to 78a473d0e7485950359c782b3c663ee6981eed0c.
[INFO]  --> Setting version for github.com/russross/blackfriday to 11635eb403ff09dbc3a6b5a007ab5ab09151c229.
[INFO]  --> Setting version for github.com/prometheus/procfs to 7d6f385de8bea29190f15ba9931442a0eaef9af7.
[INFO]  --> Setting version for github.com/prometheus/client_golang to c5b7fccd204277076155f10851dad72b76a49317.
[INFO]  --> Setting version for github.com/spf13/cobra to 1e58aa3361fd650121dceeedc399e7189c05674a.
[INFO]  --> Setting version for github.com/uber-go/tally to 79f2a33b0e55b1255ffbbaf824dcafb09ff34dda.
[INFO]  --> Setting version for github.com/cpuguy83/go-md2man to 48d8747a2ca13185e7cc8efe6e9fc196a83f71a5.
[INFO]  --> Setting version for github.com/prometheus/client_model to 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c.
[INFO]  --> Setting version for github.com/inconshreveable/mousetrap to 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75.
[INFO]  --> Setting version for github.com/uber/tchannel-go to cc0c40929b0dbdb755b727a8c253de2b5d4af46b.
[INFO]  --> Setting version for go.uber.org/fx to 4556160e761570faf2b4e89547c04cdcd96e0c7a.
[INFO]  --> Setting version for go.uber.org/multierr to 3c4937480c32f4c13a875a1829af76c98ca3d40a.
[INFO]  --> Setting version for go.uber.org/thriftrw to 43dfafd7bb1c99f0460d645a1959b73f6dfa536f.
[INFO]  --> Setting version for go.uber.org/dig to 45540ff1846c207f109bbb7de2f2748f7198ca21.
[INFO]  --> Setting version for go.uber.org/atomic to 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289.
[INFO]  --> Setting version for go.uber.org/net/metrics to 1e19de5b971489a45d178e12a0f72a78c70e300e.
[INFO]  --> Setting version for go.uber.org/yarpc to 889176c1e87f871683102ca81e9701feaa6d0aa2.
[INFO]  --> Setting version for google.golang.org/grpc to 24f3cca1ffddeab04708c325f8088c76c2d74972.
[INFO]  --> Setting version for github.com/davecgh/go-spew to 8991bc29aa16c548c550c7ff78260e27b9ab7c73.
[INFO]  --> Setting version for github.com/ghodss/yaml to e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6.
[INFO]  --> Setting version for github.com/golang/lint to 470b6b0bb3005eda157f0275e2e4895055396a81.
[INFO]  --> Setting version for github.com/golang/glog to 23def4e6c14b4da8ac2ed8007337bc5eb5007998.
[INFO]  --> Setting version for github.com/kisielk/errcheck to 55d8f507faff4d6eddd0c41a3e713e2567fca4e5.
[INFO]  --> Setting version for google.golang.org/genproto to 32ee49c4dd805befd833990acba36cb75042378c.
[INFO]  --> Setting version for github.com/kisielk/gotool to 80517062f582ea3340cd4baf70e86d539ae7d84d.
[INFO]  --> Setting version for gopkg.in/yaml.v2 to 5420a8b6744d3b0345ab293f6fcba19c978f1183.
[INFO]  --> Setting version for golang.org/x/text to 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877.
[INFO]  --> Setting version for golang.org/x/net to db08ff08e8622530d9ed3a0e8ac279f6d4c02196.
[INFO]  --> Setting version for go.uber.org/zap to eeedf312bc6c57391d84767a4cd413f02a917974.
[INFO]  --> Setting version for github.com/stretchr/testify to f35b8ab0b5a2cef36673838d662e249dd9c94686.
[INFO]  --> Setting version for github.com/wadey/gocovmerge to b5bfa59ec0adc420475f97f89b58045c721d761c.
[INFO]  --> Setting version for golang.org/x/lint to 470b6b0bb3005eda157f0275e2e4895055396a81.
[INFO]  --> Setting version for github.com/pmezard/go-difflib to 792786c7400a136282c1664665ae0a8db921c6c2.
[INFO]  --> Setting version for honnef.co/go/tools to 57ee65dc7ff868f8fe21064b05f9e744a73bc9ab.
[INFO]  --> Setting version for go.uber.org/tools to ce2550dad7144b81ae2f67dc5e55597643f6902b.
[INFO]  --> Setting version for golang.org/x/tools to c995a088887b4ae00a4c85a984117cbc8d86ca3d.
[INFO]  Exporting resolved dependencies...
[INFO]  --> Exporting github.com/beorn7/perks
[INFO]  --> Exporting github.com/emicklei/proto
[INFO]  --> Exporting github.com/cpuguy83/go-md2man
[INFO]  --> Exporting github.com/gogo/protobuf
[INFO]  --> Exporting github.com/prometheus/client_golang
[INFO]  --> Exporting github.com/spf13/pflag
[INFO]  --> Exporting github.com/prometheus/client_model
[INFO]  --> Exporting github.com/grpc-ecosystem/grpc-gateway
[INFO]  --> Exporting github.com/fullstorydev/grpcurl
[INFO]  --> Exporting github.com/golang/protobuf
[INFO]  --> Exporting github.com/inconshreveable/mousetrap
[INFO]  --> Exporting github.com/prometheus/common
[INFO]  --> Exporting github.com/russross/blackfriday
[INFO]  --> Exporting github.com/opentracing/opentracing-go
[INFO]  --> Exporting github.com/jhump/protoreflect
[INFO]  --> Exporting github.com/uber-go/tally
[INFO]  --> Exporting github.com/uber-go/atomic
[INFO]  --> Exporting github.com/spf13/cobra
[INFO]  --> Exporting github.com/prometheus/procfs
[INFO]  --> Exporting github.com/matttproud/golang_protobuf_extensions
[INFO]  --> Exporting github.com/uber/tchannel-go
[INFO]  --> Exporting go.uber.org/dig
[INFO]  --> Exporting google.golang.org/grpc
[INFO]  --> Exporting go.uber.org/fx
[INFO]  --> Exporting go.uber.org/atomic
[INFO]  --> Exporting github.com/ghodss/yaml
[INFO]  --> Exporting github.com/davecgh/go-spew
[INFO]  --> Exporting go.uber.org/multierr
[INFO]  --> Exporting go.uber.org/net/metrics
[INFO]  --> Exporting github.com/golang/glog
[INFO]  --> Exporting go.uber.org/thriftrw
[INFO]  --> Exporting go.uber.org/yarpc
[INFO]  --> Exporting golang.org/x/net
[INFO]  --> Exporting go.uber.org/zap
[INFO]  --> Exporting google.golang.org/genproto
[INFO]  --> Exporting golang.org/x/text
[INFO]  --> Exporting github.com/golang/lint
[INFO]  --> Exporting github.com/kisielk/errcheck
[INFO]  --> Exporting github.com/kisielk/gotool
[INFO]  --> Exporting github.com/stretchr/testify
[INFO]  --> Exporting github.com/pmezard/go-difflib
[INFO]  --> Exporting github.com/wadey/gocovmerge
[INFO]  --> Exporting golang.org/x/lint
[INFO]  --> Exporting go.uber.org/tools
[INFO]  --> Exporting honnef.co/go/tools
[INFO]  --> Exporting golang.org/x/tools
[INFO]  --> Exporting gopkg.in/yaml.v2
[INFO]  Replacing existing vendor dependencies
mbp88msk:prototool erakhimberdin$ make generate
update-license ./cmd/prototool/main.go ./internal/cmd/cmd.go ./internal/cmd/cmd_test.go ./internal/cmd/gen-prototool-manpages/main.go ./internal/cmd/flags.go ./internal/cmd/gen-prototool-zsh-completion/main.go ./internal/cmd/gen-prototool-bash-completion/main.go ./internal/settings/config_provider.go ./internal/settings/settings.go ./internal/vars/vars.go ./internal/lint/check_services_have_comments.go ./internal/lint/check_comments_no_c_style.go ./internal/lint/check_wkt_directly_imported.go ./internal/lint/check_enum_zero_values_invalid.go ./internal/lint/runner.go ./internal/lint/check_rpc_names_camel_case.go ./internal/lint/check_syntax_proto3.go ./internal/lint/base_visitor.go ./internal/lint/check_enum_names_capitalized.go ./internal/lint/check_request_response_names_match_rpc.go ./internal/lint/check_package_is_declared.go ./internal/lint/check_enums_have_comments.go ./internal/lint/check_message_field_names_lower_snake_case.go ./internal/lint/check_file_options_required.go ./internal/lint/check_message_names_camel_case.go ./internal/lint/check_enum_names_camel_case.go ./internal/lint/check_message_fields_not_floats.go ./internal/lint/check_messages_have_comments.go ./internal/lint/check_service_names_capitalized.go ./internal/lint/check_message_names_capitalized.go ./internal/lint/check_enum_field_prefixes.go ./internal/lint/check_file_options_same_in_dir.go ./internal/lint/check_rpcs_have_comments.go ./internal/lint/check_enum_field_names_uppercase.go ./internal/lint/check_enum_field_names_upper_snake_case.go ./internal/lint/check_package_lower_snake_case.go ./internal/lint/check_request_response_types_in_same_file.go ./internal/lint/check_rpc_names_capitalized.go ./internal/lint/check_service_names_camel_case.go ./internal/lint/check_messages_have_comments_except_request_response_types.go ./internal/lint/check_packages_same_in_dir.go ./internal/lint/check_message_field_names_lowercase.go ./internal/lint/check_file_options_unset.go ./internal/lint/lint.go ./internal/lint/check_enums_no_allow_alias.go ./internal/lint/base_linter.go ./internal/lint/check_request_response_types_unique.go ./internal/lint/check_oneof_names_lower_snake_case.go ./internal/lint/check_file_options_equal.go ./internal/file/proto_set_provider.go ./internal/file/proto_set_provider_test.go ./internal/file/file.go ./internal/desc/desc.go ./internal/grpc/handler.go ./internal/grpc/grpc.go ./internal/grpc/invocation_event_handler.go ./internal/strs/strs_test.go ./internal/strs/strs.go ./internal/reflect/handler.go ./internal/reflect/reflect.go ./internal/diff/diff_test.go ./internal/diff/diff.go ./internal/cfginit/cfginit.go ./internal/exec/runner.go ./internal/exec/exec.go ./internal/wkt/wkt.go ./internal/protoc/downloader.go ./internal/protoc/compiler.go ./internal/protoc/protoc.go ./internal/protoc/downloader_test.go ./internal/format/base_visitor.go ./internal/format/first_pass_visitor.go ./internal/format/format.go ./internal/format/main_visitor.go ./internal/format/transformer.go ./internal/format/printer.go ./internal/protostrs/protostrs_test.go ./internal/protostrs/protostrs.go ./internal/extract/extract.go ./internal/extract/getter.go ./internal/phab/phab.go ./internal/phab/phab_test.go ./internal/text/text_test.go ./internal/text/text.go ./internal/create/create.go ./internal/create/handler.go
go install \
                -ldflags "-X 'github.com/uber/prototool/internal/x/vars.GitCommit=124c9ba306c94ea0b0d025f50d3b50c01d83c29d' -X 'github.com/uber/prototool/internal/x/vars.BuiltTimestamp=Mon Jul  9 10:14:08 UTC 2018'" \
                github.com/uber/prototool/cmd/prototool
for file in internal/cmd/testdata/format/foo/foo.proto.golden internal/cmd/testdata/format/foo/foo_proto2.proto.golden internal/cmd/testdata/format/bar/bar_proto2.proto.golden internal/cmd/testdata/format/bar/bar.proto.golden; do \
                rm -f ${file}; \
        done
for file in internal/cmd/testdata/format/foo/foo.proto internal/cmd/testdata/format/foo/foo_proto2.proto internal/cmd/testdata/format/bar/bar_proto2.proto internal/cmd/testdata/format/bar/bar.proto; do \
                prototool format --no-rewrite ${file} > ${file}.golden || true; \
        done
for file in internal/cmd/testdata/format-rewrite/foo.proto.golden; do \
                rm -f ${file}; \
        done
for file in internal/cmd/testdata/format-rewrite/foo.proto; do \
                prototool format ${file} > ${file}.golden || true; \
        done
rm -rf example/gen
prototool all example/idl/uber
touch ./example/gen/proto/go/foo/.nocover
touch ./example/gen/proto/go/sub/.nocover
go build ./example/gen/proto/go/foo
go build ./example/gen/proto/go/sub
go build ./example/cmd/excited/main.go
prototool lint etc/style
prototool gen internal/cmd/testdata/grpc
rm -f etc/config/example/prototool.yaml
prototool init etc/config/example --uncomment
mbp88msk:prototool erakhimberdin$ make init
go get github.com/Masterminds/glide
rm -rf vendor
glide install
[INFO]  Downloading dependencies. Please wait...
[INFO]  --> Found desired version locally github.com/beorn7/perks 3a771d992973f24aa725d07868b467d1ddfceafb!
[INFO]  --> Found desired version locally github.com/cpuguy83/go-md2man 48d8747a2ca13185e7cc8efe6e9fc196a83f71a5!
[INFO]  --> Found desired version locally github.com/emicklei/proto 92ccf4bb8fea88ece4fda55edd4d9cb9c329e18c!
[INFO]  --> Found desired version locally github.com/fullstorydev/grpcurl 819d39047c4d05485bc92ddfd5d9a07f7c8f4f66!
[INFO]  --> Found desired version locally github.com/gogo/protobuf 342cbe0a04158f6dcb03ca0079991a51a4248c02!
[INFO]  --> Found desired version locally github.com/golang/protobuf 5831880292e721c76b58a16ecc60adc27d8e6355!
[INFO]  --> Found desired version locally github.com/grpc-ecosystem/grpc-gateway 78a473d0e7485950359c782b3c663ee6981eed0c!
[INFO]  --> Found desired version locally github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75!
[INFO]  --> Found desired version locally github.com/jhump/protoreflect ebe8e6a9a8fafdc380875177e03a6e95574bf3f1!
[INFO]  --> Found desired version locally github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c!
[INFO]  --> Found desired version locally github.com/opentracing/opentracing-go 1949ddbfd147afd4d964a9f00b24eb291e0e7c38!
[INFO]  --> Found desired version locally github.com/prometheus/client_golang c5b7fccd204277076155f10851dad72b76a49317!
[INFO]  --> Found desired version locally github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c!
[INFO]  --> Found desired version locally github.com/prometheus/common 7600349dcfe1abd18d72d3a1770870d9800a7801!
[INFO]  --> Found desired version locally github.com/prometheus/procfs 7d6f385de8bea29190f15ba9931442a0eaef9af7!
[INFO]  --> Found desired version locally github.com/russross/blackfriday 11635eb403ff09dbc3a6b5a007ab5ab09151c229!
[INFO]  --> Found desired version locally github.com/spf13/cobra 1e58aa3361fd650121dceeedc399e7189c05674a!
[INFO]  --> Found desired version locally github.com/spf13/pflag 3ebe029320b2676d667ae88da602a5f854788a8a!
[INFO]  --> Found desired version locally github.com/uber-go/atomic 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289!
[INFO]  --> Found desired version locally github.com/uber-go/tally 79f2a33b0e55b1255ffbbaf824dcafb09ff34dda!
[INFO]  --> Found desired version locally github.com/uber/tchannel-go cc0c40929b0dbdb755b727a8c253de2b5d4af46b!
[INFO]  --> Found desired version locally go.uber.org/atomic 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289!
[INFO]  --> Found desired version locally go.uber.org/dig 45540ff1846c207f109bbb7de2f2748f7198ca21!
[INFO]  --> Found desired version locally go.uber.org/fx 4556160e761570faf2b4e89547c04cdcd96e0c7a!
[INFO]  --> Found desired version locally go.uber.org/multierr 3c4937480c32f4c13a875a1829af76c98ca3d40a!
[INFO]  --> Found desired version locally go.uber.org/net/metrics 1e19de5b971489a45d178e12a0f72a78c70e300e!
[INFO]  --> Found desired version locally go.uber.org/thriftrw 43dfafd7bb1c99f0460d645a1959b73f6dfa536f!
[INFO]  --> Found desired version locally go.uber.org/yarpc 889176c1e87f871683102ca81e9701feaa6d0aa2!
[INFO]  --> Found desired version locally go.uber.org/zap eeedf312bc6c57391d84767a4cd413f02a917974!
[INFO]  --> Found desired version locally golang.org/x/net db08ff08e8622530d9ed3a0e8ac279f6d4c02196!
[INFO]  --> Found desired version locally golang.org/x/text 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877!
[INFO]  --> Found desired version locally google.golang.org/genproto 32ee49c4dd805befd833990acba36cb75042378c!
[INFO]  --> Found desired version locally google.golang.org/grpc 24f3cca1ffddeab04708c325f8088c76c2d74972!
[INFO]  --> Found desired version locally gopkg.in/yaml.v2 5420a8b6744d3b0345ab293f6fcba19c978f1183!
[INFO]  --> Found desired version locally github.com/davecgh/go-spew 8991bc29aa16c548c550c7ff78260e27b9ab7c73!
[INFO]  --> Found desired version locally github.com/ghodss/yaml e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6!
[INFO]  --> Found desired version locally github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998!
[INFO]  --> Found desired version locally github.com/golang/lint 470b6b0bb3005eda157f0275e2e4895055396a81!
[INFO]  --> Found desired version locally github.com/kisielk/errcheck 55d8f507faff4d6eddd0c41a3e713e2567fca4e5!
[INFO]  --> Found desired version locally github.com/kisielk/gotool 80517062f582ea3340cd4baf70e86d539ae7d84d!
[INFO]  --> Found desired version locally github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2!
[INFO]  --> Found desired version locally github.com/stretchr/testify f35b8ab0b5a2cef36673838d662e249dd9c94686!
[INFO]  --> Found desired version locally github.com/wadey/gocovmerge b5bfa59ec0adc420475f97f89b58045c721d761c!
[INFO]  --> Found desired version locally go.uber.org/tools ce2550dad7144b81ae2f67dc5e55597643f6902b!
[INFO]  --> Found desired version locally golang.org/x/lint 470b6b0bb3005eda157f0275e2e4895055396a81!
[INFO]  --> Found desired version locally golang.org/x/tools c995a088887b4ae00a4c85a984117cbc8d86ca3d!
[INFO]  --> Found desired version locally honnef.co/go/tools 57ee65dc7ff868f8fe21064b05f9e744a73bc9ab!
[INFO]  Setting references.
[INFO]  --> Setting version for github.com/opentracing/opentracing-go to 1949ddbfd147afd4d964a9f00b24eb291e0e7c38.
[INFO]  --> Setting version for github.com/spf13/cobra to 1e58aa3361fd650121dceeedc399e7189c05674a.
[INFO]  --> Setting version for github.com/uber-go/atomic to 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289.
[INFO]  --> Setting version for github.com/prometheus/client_golang to c5b7fccd204277076155f10851dad72b76a49317.
[INFO]  --> Setting version for github.com/uber-go/tally to 79f2a33b0e55b1255ffbbaf824dcafb09ff34dda.
[INFO]  --> Setting version for github.com/matttproud/golang_protobuf_extensions to c12348ce28de40eed0136aa2b644d0ee0650e56c.
[INFO]  --> Setting version for github.com/prometheus/common to 7600349dcfe1abd18d72d3a1770870d9800a7801.
[INFO]  --> Setting version for github.com/fullstorydev/grpcurl to 819d39047c4d05485bc92ddfd5d9a07f7c8f4f66.
[INFO]  --> Setting version for github.com/emicklei/proto to 92ccf4bb8fea88ece4fda55edd4d9cb9c329e18c.
[INFO]  --> Setting version for github.com/cpuguy83/go-md2man to 48d8747a2ca13185e7cc8efe6e9fc196a83f71a5.
[INFO]  --> Setting version for github.com/prometheus/client_model to 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c.
[INFO]  --> Setting version for github.com/jhump/protoreflect to ebe8e6a9a8fafdc380875177e03a6e95574bf3f1.
[INFO]  --> Setting version for github.com/inconshreveable/mousetrap to 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75.
[INFO]  --> Setting version for github.com/russross/blackfriday to 11635eb403ff09dbc3a6b5a007ab5ab09151c229.
[INFO]  --> Setting version for github.com/spf13/pflag to 3ebe029320b2676d667ae88da602a5f854788a8a.
[INFO]  --> Setting version for github.com/gogo/protobuf to 342cbe0a04158f6dcb03ca0079991a51a4248c02.
[INFO]  --> Setting version for github.com/beorn7/perks to 3a771d992973f24aa725d07868b467d1ddfceafb.
[INFO]  --> Setting version for github.com/golang/protobuf to 5831880292e721c76b58a16ecc60adc27d8e6355.
[INFO]  --> Setting version for github.com/prometheus/procfs to 7d6f385de8bea29190f15ba9931442a0eaef9af7.
[INFO]  --> Setting version for github.com/grpc-ecosystem/grpc-gateway to 78a473d0e7485950359c782b3c663ee6981eed0c.
[INFO]  --> Setting version for github.com/uber/tchannel-go to cc0c40929b0dbdb755b727a8c253de2b5d4af46b.
[INFO]  --> Setting version for go.uber.org/dig to 45540ff1846c207f109bbb7de2f2748f7198ca21.
[INFO]  --> Setting version for go.uber.org/atomic to 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289.
[INFO]  --> Setting version for go.uber.org/multierr to 3c4937480c32f4c13a875a1829af76c98ca3d40a.
[INFO]  --> Setting version for go.uber.org/net/metrics to 1e19de5b971489a45d178e12a0f72a78c70e300e.
[INFO]  --> Setting version for go.uber.org/yarpc to 889176c1e87f871683102ca81e9701feaa6d0aa2.
[INFO]  --> Setting version for go.uber.org/thriftrw to 43dfafd7bb1c99f0460d645a1959b73f6dfa536f.
[INFO]  --> Setting version for github.com/ghodss/yaml to e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6.
[INFO]  --> Setting version for google.golang.org/grpc to 24f3cca1ffddeab04708c325f8088c76c2d74972.
[INFO]  --> Setting version for github.com/golang/glog to 23def4e6c14b4da8ac2ed8007337bc5eb5007998.
[INFO]  --> Setting version for github.com/golang/lint to 470b6b0bb3005eda157f0275e2e4895055396a81.
[INFO]  --> Setting version for github.com/davecgh/go-spew to 8991bc29aa16c548c550c7ff78260e27b9ab7c73.
[INFO]  --> Setting version for github.com/kisielk/errcheck to 55d8f507faff4d6eddd0c41a3e713e2567fca4e5.
[INFO]  --> Setting version for github.com/kisielk/gotool to 80517062f582ea3340cd4baf70e86d539ae7d84d.
[INFO]  --> Setting version for golang.org/x/net to db08ff08e8622530d9ed3a0e8ac279f6d4c02196.
[INFO]  --> Setting version for golang.org/x/text to 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877.
[INFO]  --> Setting version for google.golang.org/genproto to 32ee49c4dd805befd833990acba36cb75042378c.
[INFO]  --> Setting version for go.uber.org/zap to eeedf312bc6c57391d84767a4cd413f02a917974.
[INFO]  --> Setting version for go.uber.org/fx to 4556160e761570faf2b4e89547c04cdcd96e0c7a.
[INFO]  --> Setting version for gopkg.in/yaml.v2 to 5420a8b6744d3b0345ab293f6fcba19c978f1183.
[INFO]  --> Setting version for github.com/pmezard/go-difflib to 792786c7400a136282c1664665ae0a8db921c6c2.
[INFO]  --> Setting version for github.com/stretchr/testify to f35b8ab0b5a2cef36673838d662e249dd9c94686.
[INFO]  --> Setting version for github.com/wadey/gocovmerge to b5bfa59ec0adc420475f97f89b58045c721d761c.
[INFO]  --> Setting version for go.uber.org/tools to ce2550dad7144b81ae2f67dc5e55597643f6902b.
[INFO]  --> Setting version for golang.org/x/lint to 470b6b0bb3005eda157f0275e2e4895055396a81.
[INFO]  --> Setting version for honnef.co/go/tools to 57ee65dc7ff868f8fe21064b05f9e744a73bc9ab.
[INFO]  --> Setting version for golang.org/x/tools to c995a088887b4ae00a4c85a984117cbc8d86ca3d.
[INFO]  Exporting resolved dependencies...
[INFO]  --> Exporting github.com/cpuguy83/go-md2man
[INFO]  --> Exporting github.com/beorn7/perks
[INFO]  --> Exporting github.com/fullstorydev/grpcurl
[INFO]  --> Exporting github.com/gogo/protobuf
[INFO]  --> Exporting github.com/uber-go/tally
[INFO]  --> Exporting github.com/prometheus/client_model
[INFO]  --> Exporting github.com/grpc-ecosystem/grpc-gateway
[INFO]  --> Exporting github.com/golang/protobuf
[INFO]  --> Exporting github.com/spf13/pflag
[INFO]  --> Exporting github.com/opentracing/opentracing-go
[INFO]  --> Exporting github.com/emicklei/proto
[INFO]  --> Exporting github.com/inconshreveable/mousetrap
[INFO]  --> Exporting github.com/prometheus/client_golang
[INFO]  --> Exporting github.com/jhump/protoreflect
[INFO]  --> Exporting github.com/prometheus/common
[INFO]  --> Exporting github.com/matttproud/golang_protobuf_extensions
[INFO]  --> Exporting github.com/prometheus/procfs
[INFO]  --> Exporting github.com/russross/blackfriday
[INFO]  --> Exporting github.com/spf13/cobra
[INFO]  --> Exporting github.com/uber-go/atomic
[INFO]  --> Exporting github.com/uber/tchannel-go
[INFO]  --> Exporting google.golang.org/grpc
[INFO]  --> Exporting go.uber.org/atomic
[INFO]  --> Exporting github.com/ghodss/yaml
[INFO]  --> Exporting github.com/davecgh/go-spew
[INFO]  --> Exporting github.com/golang/glog
[INFO]  --> Exporting go.uber.org/dig
[INFO]  --> Exporting go.uber.org/fx
[INFO]  --> Exporting go.uber.org/multierr
[INFO]  --> Exporting go.uber.org/net/metrics
[INFO]  --> Exporting go.uber.org/thriftrw
[INFO]  --> Exporting go.uber.org/yarpc
[INFO]  --> Exporting github.com/golang/lint
[INFO]  --> Exporting golang.org/x/net
[INFO]  --> Exporting golang.org/x/text
[INFO]  --> Exporting google.golang.org/genproto
[INFO]  --> Exporting github.com/kisielk/errcheck
[INFO]  --> Exporting gopkg.in/yaml.v2
[INFO]  --> Exporting github.com/kisielk/gotool
[INFO]  --> Exporting github.com/pmezard/go-difflib
[INFO]  --> Exporting github.com/stretchr/testify
[INFO]  --> Exporting github.com/wadey/gocovmerge
[INFO]  --> Exporting go.uber.org/zap
[INFO]  --> Exporting golang.org/x/lint
[INFO]  --> Exporting go.uber.org/tools
[INFO]  --> Exporting honnef.co/go/tools
[INFO]  --> Exporting golang.org/x/tools
[INFO]  Replacing existing vendor dependencies
mbp88msk:prototool erakhimberdin$ 

```