### PR TITLE
Allow only one prototool.yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The protoc-commands command is now accessible via the `dry-run`
   flag for compile, format, gen, and lint.
+- If more than one `prototool.yaml` is found for the input directory or files,
+  an error is returned.
 
 ## [0.4.0] - 2018-06-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,35 +88,7 @@ The command `prototool init` will generate a config file in the current director
 
 When specifying a directory or set of files for Prototool to operate on, Prototool will search for config files for each directory starting at the given path, and going up a directory until hitting root. If no config file is found, Prototool will use default values and operate as if there was a config file in the current directory, including the current directory with `-I` to `protoc`.
 
-While almost all projects should not have multiple `prototool.yaml` files (and this [may be enforced before v1.0](https://github.com/uber/prototool/issues/10)), as of now, multiple `prototool.yaml` files corresponding to multiple found directories with Protobuf files may be used. For example, if you have the following layout:
-
-```
-.
-├── a
-│   ├── d
-│   │   ├── file.proto
-│   │   ├── file2.proto
-│   │   ├── file3.proto
-│   │   └── prototool.yaml
-│   ├── e
-│   │   └── file.proto
-│   ├── f
-│   │   └── file.proto
-│   └── file.proto
-├── b
-│   ├── file.proto
-│   ├── g
-│   │   └── h
-│   │       └── file.proto
-│   └── prototool.yaml
-├── c
-│   ├── file.proto
-│   └── i
-│       └── file.proto
-└── prototool.yaml
-```
-
-Everything under `a/d` will use `a/d/prototool.yaml`, everything under `b`, `b/g/h` will use `b/prototool.yaml`, and everything under `a`, `a/e`, `a/f`, `c`, `c/i` will use `prototool.yaml`. See [internal/file/testdata](internal/file/testdata) for the most current example.
+If multiple `prototool.yaml` files are found that match the input directory or files, an error will be returned. We have an ongoing discussion about whether to allow multiple `prototool.yaml` files, see [this issue](https://github.com/uber/prototool/issues/10) for more details.
 
 ## File Discovery
 

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -68,7 +68,7 @@ type ProtoFile struct {
 
 // ProtoSetProvider provides ProtoSets.
 type ProtoSetProvider interface {
-	// GetForDir gets the ProtoSets for the given dirPath.
+	// GetMultipleForDir gets the ProtoSets for the given dirPath.
 	// Each ProtoSet will have the config assocated with all files associated with
 	// the ProtoSet.
 	//
@@ -78,9 +78,9 @@ type ProtoSetProvider interface {
 	//
 	// Configs will be searched for starting at the directory of each .proto file
 	// and going up a directory until hitting root.
-	GetForDir(workDirPath string, dirPath string) ([]*ProtoSet, error)
+	GetMultipleForDir(workDirPath string, dirPath string) ([]*ProtoSet, error)
 
-	// GetForFiles gets the ProtoSets for the given filePaths.
+	// GetMultipleForFiles gets the ProtoSets for the given filePaths.
 	// Each ProtoSet will have the config assocated with all files associated with
 	// the ProtoSet.
 	//
@@ -88,7 +88,21 @@ type ProtoSetProvider interface {
 	// and going up a directory until hitting root.
 	//
 	// This ignores excludes, all files given will be included.
-	GetForFiles(workDirPath string, filePaths ...string) ([]*ProtoSet, error)
+	GetMultipleForFiles(workDirPath string, filePaths ...string) ([]*ProtoSet, error)
+
+	// GetForDir does the same logic as GetMultipleForDir, but returns an error if there
+	// is not exactly one ProtoSet. We keep the original logic and testing for multiple
+	// ProtoSets around as we are still discussing this pre-v1.0.
+	// https://github.com/uber/prototool/issues/10
+	// https://github.com/uber/prototool/issues/93
+	GetForDir(workDirPath string, dirPath string) (*ProtoSet, error)
+
+	// GetForFiles does the same logic as GetMultipleForFiles, but returns an error if there
+	// is not exactly one ProtoSet. We keep the original logic and testing for multiple
+	// ProtoSets around as we are still discussing this pre-v1.0.
+	// https://github.com/uber/prototool/issues/10
+	// https://github.com/uber/prototool/issues/93
+	GetForFiles(workDirPath string, filePaths ...string) (*ProtoSet, error)
 }
 
 // ProtoSetProviderOption is an option for a new ProtoSetProvider.

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -67,7 +67,7 @@ func (c *protoSetProvider) GetForDir(workDirPath string, dirPath string) (*Proto
 		for _, protoSet := range protoSets {
 			configDirPaths = append(configDirPaths, protoSet.Config.DirPath)
 		}
-		return nil, fmt.Errorf("multiple configuration files found in directories %v for proto files found for dirPath %q but expected exactly one configuration file", configDirPaths, dirPath)
+		return nil, fmt.Errorf("expected exactly one configuration file for dirPath %q, but found multiple in directories: %v", dirPath, configDirPaths)
 	}
 }
 
@@ -86,7 +86,7 @@ func (c *protoSetProvider) GetForFiles(workDirPath string, filePaths ...string) 
 		for _, protoSet := range protoSets {
 			configDirPaths = append(configDirPaths, protoSet.Config.DirPath)
 		}
-		return nil, fmt.Errorf("multiple configuration files found in directories %v for proto files found for filePaths %v but expected exactly one configuration file", configDirPaths, filePaths)
+		return nil, fmt.Errorf("expected exactly one configuration file for filePaths %v, but found multiple in directories: %v", filePaths, configDirPaths)
 	}
 }
 

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -52,7 +52,45 @@ func newProtoSetProvider(options ...ProtoSetProviderOption) *protoSetProvider {
 	return protoSetProvider
 }
 
-func (c *protoSetProvider) GetForDir(workDirPath string, dirPath string) ([]*ProtoSet, error) {
+func (c *protoSetProvider) GetForDir(workDirPath string, dirPath string) (*ProtoSet, error) {
+	protoSets, err := c.GetMultipleForDir(workDirPath, dirPath)
+	if err != nil {
+		return nil, err
+	}
+	switch len(protoSets) {
+	case 0:
+		return nil, fmt.Errorf("no proto files found for dirPath %q", dirPath)
+	case 1:
+		return protoSets[0], nil
+	default:
+		configDirPaths := make([]string, 0, len(protoSets))
+		for _, protoSet := range protoSets {
+			configDirPaths = append(configDirPaths, protoSet.Config.DirPath)
+		}
+		return nil, fmt.Errorf("multiple configuration files found in directories %v for proto files found for dirPath %q but expected exactly one configuration file", configDirPaths, dirPath)
+	}
+}
+
+func (c *protoSetProvider) GetForFiles(workDirPath string, filePaths ...string) (*ProtoSet, error) {
+	protoSets, err := c.GetMultipleForFiles(workDirPath, filePaths...)
+	if err != nil {
+		return nil, err
+	}
+	switch len(protoSets) {
+	case 0:
+		return nil, fmt.Errorf("no proto files found for filePaths %v", filePaths)
+	case 1:
+		return protoSets[0], nil
+	default:
+		configDirPaths := make([]string, 0, len(protoSets))
+		for _, protoSet := range protoSets {
+			configDirPaths = append(configDirPaths, protoSet.Config.DirPath)
+		}
+		return nil, fmt.Errorf("multiple configuration files found in directories %v for proto files found for filePaths %v but expected exactly one configuration file", configDirPaths, filePaths)
+	}
+}
+
+func (c *protoSetProvider) GetMultipleForDir(workDirPath string, dirPath string) ([]*ProtoSet, error) {
 	workDirPath, err := absClean(workDirPath)
 	if err != nil {
 		return nil, err
@@ -90,7 +128,7 @@ func (c *protoSetProvider) GetForDir(workDirPath string, dirPath string) ([]*Pro
 	return protoSets, nil
 }
 
-func (c *protoSetProvider) GetForFiles(workDirPath string, filePaths ...string) ([]*ProtoSet, error) {
+func (c *protoSetProvider) GetMultipleForFiles(workDirPath string, filePaths ...string) ([]*ProtoSet, error) {
 	workDirPath, err := absClean(workDirPath)
 	if err != nil {
 		return nil, err

--- a/internal/file/proto_set_provider_test.go
+++ b/internal/file/proto_set_provider_test.go
@@ -29,11 +29,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestProtoSetProviderGetForFilesAll(t *testing.T) {
+func TestProtoSetProviderGetMultipleForFilesAll(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetForFiles(
+	protoSets, err := protoSetProvider.GetMultipleForFiles(
 		cwd,
 		"testdata/a/file.proto",
 		"testdata/b/file.proto",
@@ -186,11 +186,11 @@ func TestProtoSetProviderGetForFilesAll(t *testing.T) {
 	)
 }
 
-func TestProtoSetProviderGetForFilesSomeMissing(t *testing.T) {
+func TestProtoSetProviderGetMultipleForFilesSomeMissing(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetForFiles(
+	protoSets, err := protoSetProvider.GetMultipleForFiles(
 		cwd,
 		"testdata/a/file.proto",
 		"testdata/c/file.proto",
@@ -298,11 +298,11 @@ func TestProtoSetProviderGetForFilesSomeMissing(t *testing.T) {
 	)
 }
 
-func TestProtoSetProviderGetForDirCwdRel(t *testing.T) {
+func TestProtoSetProviderGetMultipleForDirCwdRel(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetForDir(cwd, ".")
+	protoSets, err := protoSetProvider.GetMultipleForDir(cwd, ".")
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -434,11 +434,11 @@ func TestProtoSetProviderGetForDirCwdRel(t *testing.T) {
 	)
 }
 
-func TestProtoSetProviderGetForDirCwdAbs(t *testing.T) {
+func TestProtoSetProviderGetMultipleForDirCwdAbs(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetForDir(cwd, cwd)
+	protoSets, err := protoSetProvider.GetMultipleForDir(cwd, cwd)
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -570,11 +570,11 @@ func TestProtoSetProviderGetForDirCwdAbs(t *testing.T) {
 	)
 }
 
-func TestProtoSetProviderGetForDirCwdSubRel(t *testing.T) {
+func TestProtoSetProviderGetMultipleForDirCwdSubRel(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetForDir(cwd, "testdata/d/g")
+	protoSets, err := protoSetProvider.GetMultipleForDir(cwd, "testdata/d/g")
 	require.NoError(t, err)
 	require.Equal(
 		t,

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -122,7 +122,7 @@ func init() {
 
 // Runner runs a lint job.
 type Runner interface {
-	Run(...*file.ProtoSet) ([]*text.Failure, error)
+	Run(*file.ProtoSet) ([]*text.Failure, error)
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -40,22 +40,14 @@ func newRunner(options ...RunnerOption) *runner {
 	return runner
 }
 
-func (r *runner) Run(protoSets ...*file.ProtoSet) ([]*text.Failure, error) {
-	var failures []*text.Failure
-	for _, protoSet := range protoSets {
-		linters, err := GetLinters(protoSet.Config.Lint)
-		if err != nil {
-			return nil, err
-		}
-		dirPathToDescriptors, err := GetDirPathToDescriptors(protoSet)
-		if err != nil {
-			return nil, err
-		}
-		iFailures, err := CheckMultiple(linters, dirPathToDescriptors, protoSet.Config.Lint.IgnoreIDToFilePaths)
-		if err != nil {
-			return nil, err
-		}
-		failures = append(failures, iFailures...)
+func (r *runner) Run(protoSet *file.ProtoSet) ([]*text.Failure, error) {
+	linters, err := GetLinters(protoSet.Config.Lint)
+	if err != nil {
+		return nil, err
 	}
-	return failures, nil
+	dirPathToDescriptors, err := GetDirPathToDescriptors(protoSet)
+	if err != nil {
+		return nil, err
+	}
+	return CheckMultiple(linters, dirPathToDescriptors, protoSet.Config.Lint.IgnoreIDToFilePaths)
 }

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -120,12 +120,12 @@ type Compiler interface {
 	// and there will be no error. The caller can determine if this is
 	// an error case. If there is any other type of error, or some output
 	// from protoc cannot be interpreted, an error will be returned.
-	Compile(...*file.ProtoSet) (*CompileResult, error)
+	Compile(*file.ProtoSet) (*CompileResult, error)
 
 	// Return the protoc commands that would be run on Compile.
 	//
 	// This will ignore the CompilerWithFileDescriptorSet option.
-	ProtocCommands(...*file.ProtoSet) ([]string, error)
+	ProtocCommands(*file.ProtoSet) ([]string, error)
 }
 
 // CompilerOption is an option for a new Compiler.


### PR DESCRIPTION
Per #10 and #93, this change does the bare minimum to enforce only one `prototool.yaml` file per command. There is further refactoring that can be done after this, but this propagates the changes through the codebase while retaining the multiple `prototool.yaml` file support in the implementation for now. Putting this up for discussion, it also helps simplify the logic for #131.