### PR TITLE
Delete commands, flags, options in preparation for v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   on lint.
 - The flags --cache-path and --print-fields are deleted to reduce the
   surface area for the v1.0 release.
+- The option lint.group in the prototool.yaml configuration is deleted
+  to reduce the surface area for the v1.0 release.
 - The protoc-commands command is now accessible via the --dry-run
   flag for compile and gen.
 - The grpc command now takes flags for address, method, and data or stdin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - A linter to verify that no enum uses the option `allow_alias.`
 ### Changed
-- The protoc-commands command is now accessible via the `dry-run`
-  flag for compile, format, gen, and lint.
+- The commands binary-to-json, clean, descriptor-proto, download,
+  field-descriptor-proto, json-to-binary, list-all-linters,
+  list-all-lint-groups, list-linters, list-lint-group,
+  service-descriptor-proto are deleted to reduce the surface area
+  for the v1.0 release.
+- The commands list-all-linters and list-linters are now flags
+  on lint.
+- The flags --cache-path and --print-fields are deleted to reduce the
+  surface area for the v1.0 release.
+- The protoc-commands command is now accessible via the --dry-run
+  flag for compile and gen.
 - The grpc command now takes flags for address, method, and data or stdin
   as opposed to parsing these from variable-length command args.
 - If more than one `prototool.yaml` is found for the input directory or files,

--- a/README.md
+++ b/README.md
@@ -61,11 +61,10 @@ prototool lint idl/uber # directory mode, search for all .proto files recursivel
 prototool lint # same as "prototool lint .", by default the current directory is used in directory mode
 prototool create foo.proto # create the file foo.proto from a template that passes lint
 prototool files idl/uber # list the files that will be used after applying exclude_paths from corresponding prototool.yaml files
-prototool list-linters # list all current lint rules being used
+prototool lint --list-linters # list all current lint rules being used
 prototool compile idl/uber # make sure all .proto files in idl/uber compile, but do not generate stubs
 prototool gen idl/uber # generate stubs, see the generation directives in the config file example
-prototool grpc idl/uber 0.0.0.0:8080 foo.ExcitedService/Exclamation '{"value":"hello"}' # call the foo.ExcitedService method Exclamation with the given data on 0.0.0.0:8080
-cd $(prototool download) # download prints out the cached protoc dir, so this changes to the cache directory
+prototool grpc idl/uber --address 0.0.0.0:8080 --method foo.ExcitedService/Exclamation --data '{"value":"hello"}' # call the foo.ExcitedService method Exclamation with the given data on 0.0.0.0:8080
 ```
 
 ## Full Example

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -50,7 +50,7 @@ lint:
       - path/to/foo.proto
 
   # When specifying linters, you can only specify ids, or any combination of
-  # group,include_ids,exclude_ids, but not ids and any of those three.
+  # include_ids,exclude_ids, but not ids and any of those two.
   # Run prototool list-all-linters to see all available linters.
   # All are specified just for this example.
   # By default, the default group of linters is used.
@@ -59,10 +59,6 @@ lint:
   ids:
     - ENUM_NAMES_CAMEL_CASE
     - ENUM_NAMES_CAPITALIZED
-
-  # The lint group to use.
-  # The only valid value as of now is default, which is also the default value.
-  group: default
 
   # Linters to include that are not in the lint group.
   include_ids:

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -80,7 +80,7 @@ protoc_version: {{.ProtocVersion}}
 {{.V}}      - path/to/foo.proto
 
   # When specifying linters, you can only specify ids, or any combination of
-  # group,include_ids,exclude_ids, but not ids and any of those three.
+  # include_ids,exclude_ids, but not ids and any of those two.
   # Run prototool list-all-linters to see all available linters.
   # All are specified just for this example.
   # By default, the default group of linters is used.
@@ -89,10 +89,6 @@ protoc_version: {{.ProtocVersion}}
 {{.V}}  ids:
 {{.V}}    - ENUM_NAMES_CAMEL_CASE
 {{.V}}    - ENUM_NAMES_CAPITALIZED
-
-  # The lint group to use.
-  # The only valid value as of now is default, which is also the default value.
-{{.V}}  group: default
 
   # Linters to include that are not in the lint group.
 {{.V}}  include_ids:

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -50,22 +50,26 @@ var genManTime = time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)
 
 // Do runs the command logic.
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
-	return runRootCommand(args, stdin, stdout, stderr, (*cobra.Command).Execute)
+	return do(false, args, stdin, stdout, stderr)
+}
+
+func do(develMode bool, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
+	return runRootCommand(develMode, args, stdin, stdout, stderr, (*cobra.Command).Execute)
 }
 
 // GenBashCompletion generates a bash completion file to the writer.
 func GenBashCompletion(stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
-	return runRootCommandOutput([]string{}, stdin, stdout, stderr, (*cobra.Command).GenBashCompletion)
+	return runRootCommandOutput(false, []string{}, stdin, stdout, stderr, (*cobra.Command).GenBashCompletion)
 }
 
 // GenZshCompletion generates a zsh completion file to the writer.
 func GenZshCompletion(stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
-	return runRootCommandOutput([]string{}, stdin, stdout, stderr, (*cobra.Command).GenZshCompletion)
+	return runRootCommandOutput(false, []string{}, stdin, stdout, stderr, (*cobra.Command).GenZshCompletion)
 }
 
 // GenManpages generates the manpages to the given directory.
 func GenManpages(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
-	return runRootCommand(args, stdin, stdout, stderr, func(cmd *cobra.Command) error {
+	return runRootCommand(false, args, stdin, stdout, stderr, func(cmd *cobra.Command) error {
 		if len(args) != 1 {
 			return fmt.Errorf("usage: %s dirPath", os.Args[0])
 		}
@@ -78,11 +82,13 @@ func GenManpages(args []string, stdin io.Reader, stdout io.Writer, stderr io.Wri
 	})
 }
 
-func runRootCommandOutput(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, f func(*cobra.Command, io.Writer) error) int {
-	return runRootCommand(args, stdin, stdout, stderr, func(cmd *cobra.Command) error { return f(cmd, stdout) })
+// develMode turns on sub-commands and potentially flags that we do not expose during the build of the prototool binary
+func runRootCommandOutput(develMode bool, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, f func(*cobra.Command, io.Writer) error) int {
+	return runRootCommand(develMode, args, stdin, stdout, stderr, func(cmd *cobra.Command) error { return f(cmd, stdout) })
 }
 
-func runRootCommand(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, f func(*cobra.Command) error) (exitCode int) {
+// develMode turns on sub-commands and potentially flags that we do not expose during the build of the prototool binary
+func runRootCommand(develMode bool, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, f func(*cobra.Command) error) (exitCode int) {
 	if err := checkOS(); err != nil {
 		return printAndGetErrorExitCode(err, stdout)
 	}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -260,19 +260,12 @@ func getRootCommand(exitCodeAddr *int, develMode bool, args []string, stdin io.R
 		Use:   "lint dirOrProtoFiles...",
 		Short: "Lint proto files and compile with protoc to check for failures.",
 		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Lint(args) })
+			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, func(runner exec.Runner) error { return runner.Lint(args, flags.listAllLinters, flags.listLinters) })
 		},
 	}
 	flags.bindDirMode(lintCmd.PersistentFlags())
-
-	listAllLintersCmd := &cobra.Command{
-		Use:   "list-all-linters",
-		Short: "List all available linters.",
-		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, exec.Runner.ListAllLinters)
-		},
-	}
+	flags.bindListAllLinters(lintCmd.PersistentFlags())
+	flags.bindListLinters(lintCmd.PersistentFlags())
 
 	listAllLintGroupsCmd := &cobra.Command{
 		Use:   "list-all-lint-groups",
@@ -280,15 +273,6 @@ func getRootCommand(exitCodeAddr *int, develMode bool, args []string, stdin io.R
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, exec.Runner.ListAllLintGroups)
-		},
-	}
-
-	listLintersCmd := &cobra.Command{
-		Use:   "list-linters",
-		Short: "List the configurerd linters.",
-		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			checkCmd(exitCodeAddr, stdin, stdout, stderr, flags, exec.Runner.ListLinters)
 		},
 	}
 
@@ -344,9 +328,7 @@ func getRootCommand(exitCodeAddr *int, develMode bool, args []string, stdin io.R
 		rootCmd.AddCommand(downloadCmd)
 		rootCmd.AddCommand(fieldDescriptorProtoCmd)
 		rootCmd.AddCommand(jsonToBinaryCmd)
-		rootCmd.AddCommand(listAllLintersCmd)
 		rootCmd.AddCommand(listAllLintGroupsCmd)
-		rootCmd.AddCommand(listLintersCmd)
 		rootCmd.AddCommand(listLintGroupCmd)
 		rootCmd.AddCommand(serviceDescriptorProtoCmd)
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -894,7 +894,8 @@ func testDoInternal(stdin io.Reader, args ...string) (string, int) {
 		stdin = os.Stdin
 	}
 	buffer := bytes.NewBuffer(nil)
-	exitCode := Do(args, stdin, buffer, os.Stderr)
+	// develMode is on, so we have access to all commands
+	exitCode := do(true, args, stdin, buffer, os.Stderr)
 	return strings.TrimSpace(buffer.String()), exitCode
 }
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -637,11 +637,11 @@ func TestServiceDescriptorProto(t *testing.T) {
 }
 
 func TestListLinters(t *testing.T) {
-	assertLinters(t, lint.DefaultLinters, "list-linters")
+	assertLinters(t, lint.DefaultLinters, "lint", "--list-linters")
 }
 
 func TestListAllLinters(t *testing.T) {
-	assertLinters(t, lint.AllLinters, "list-all-linters")
+	assertLinters(t, lint.AllLinters, "lint", "--list-all-linters")
 }
 
 func assertLinters(t *testing.T, linters []lint.Linter, args ...string) {

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -39,6 +39,8 @@ type flags struct {
 	harbormaster   bool
 	headers        []string
 	keepaliveTime  string
+	listAllLinters bool
+	listLinters    bool
 	lintMode       bool
 	method         string
 	overwrite      bool
@@ -108,6 +110,14 @@ func (f *flags) bindKeepaliveTime(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindLintMode(flagSet *pflag.FlagSet) {
 	flagSet.BoolVarP(&f.lintMode, "lint", "l", false, "Write a lint error saying that the file is not formatted instead of writing the formatted file to stdout.")
+}
+
+func (f *flags) bindListAllLinters(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.listAllLinters, "list-all-linters", false, "List all available linters instead of running lint.")
+}
+
+func (f *flags) bindListLinters(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.listLinters, "list-linters", false, "List the configured linters instead of running lint.")
 }
 
 func (f *flags) bindMethod(flagSet *pflag.FlagSet) {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -56,9 +56,7 @@ type Runner interface {
 	DescriptorProto(args []string) error
 	FieldDescriptorProto(args []string) error
 	ServiceDescriptorProto(args []string) error
-	Lint(args []string) error
-	ListLinters() error
-	ListAllLinters() error
+	Lint(args []string, listAllLinters bool, listLinters bool) error
 	ListLintGroup(group string) error
 	ListAllLintGroups() error
 	Format(args []string, overwrite, diffMode, lintMode, rewrite bool) error

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -322,7 +322,16 @@ func (r *runner) printCommands(doGen bool, protoSet *file.ProtoSet) error {
 	return nil
 }
 
-func (r *runner) Lint(args []string) error {
+func (r *runner) Lint(args []string, listAllLinters bool, listLinters bool) error {
+	if listAllLinters && listLinters {
+		return newExitErrorf(255, "can only set one of list-all-linters, list-linters")
+	}
+	if listAllLinters {
+		return r.listAllLinters()
+	}
+	if listLinters {
+		return r.listLinters()
+	}
 	meta, err := r.getMeta(args)
 	if err != nil {
 		return err
@@ -349,7 +358,7 @@ func (r *runner) lint(meta *meta) error {
 	return nil
 }
 
-func (r *runner) ListLinters() error {
+func (r *runner) listLinters() error {
 	config, err := r.getConfig(r.workDirPath)
 	if err != nil {
 		return err
@@ -361,7 +370,7 @@ func (r *runner) ListLinters() error {
 	return r.printLinters(linters)
 }
 
-func (r *runner) ListAllLinters() error {
+func (r *runner) listAllLinters() error {
 	return r.printLinters(lint.AllLinters)
 }
 


### PR DESCRIPTION
Per our discussion, this:

- Deletes the commands `binary-to-json, clean, descriptor-proto, download, field-descriptor-proto, json-to-binary, list-all-linters, list-all-lint-groups, list-linters, list-lint-group, service-descriptor-proto`.
- Adds the functionality for the commands `list-all-linters, list-linters` to flags under `lint`.
- Deletes the global flags `--cache-path, --print-fields`.
- Moves the flag `--dry-run` to just be scoped to the `compile, gen` commands (I missed this in #135).
- Undocuments the option `lint.group` in the `prototool.yaml` configuration. This is still supported under the hood as there's a key test that uses the `all` group to test against all linters in the codebase, but it's not documented and therefore we make no claims to support it.
- Does some cleanup in the README.md.

We may want to reconsider keeping the `download` and maybe `clean` commands, as I think some use this to seed their CI process, and it's really useful to just go to the cache directory easily.

The old help page for `prototool`:

```
$ prototool -h
Usage:
  prototool [command]

Available Commands:
  all                      Compile, then format and overwrite, then re-compile and generate, then lint, stopping if any step fails.
  binary-to-json           Convert the data from json to binary for the message path and data.
  clean                    Delete the cache.
  compile                  Compile with protoc to check for failures.
  create                   Create the given Protobuf files according to a template that passes default prototool lint.
  descriptor-proto         Get the descriptor proto for the message path.
  download                 Download the protobuf artifacts to a cache.
  field-descriptor-proto   Get the field descriptor proto for the field path.
  files                    Print all files that match the input arguments.
  format                   Format a proto file and compile with protoc to check for failures.
  gen                      Generate with protoc.
  grpc                     Call a gRPC endpoint. Be sure to set required flags address, method, and either data or stdin.
  help                     Help about any command
  init                     Generate an initial config file in the current or given directory.
  json-to-binary           Convert the data from json to binary for the message path and data.
  lint                     Lint proto files and compile with protoc to check for failures.
  list-all-lint-groups     List all the available lint groups.
  list-all-linters         List all available linters.
  list-lint-group          List the linters in the given lint group.
  list-linters             List the configurerd linters.
  service-descriptor-proto Get the service descriptor proto for the service path.
  version                  Print the version.

Flags:
      --cache-path string     The path to use for the cache, otherwise uses the default behavior.
      --debug                 Run in debug mode, which will print out debug logging.
      --dry-run               Print the protoc commands that would have been run without actually running them.
      --harbormaster          Print failures in JSON compatible with the Harbormaster API.
  -h, --help                  help for prototool
      --print-fields string   The colon-separated fields to print out on error. (default "filename:line:column:message")
      --protoc-url string     The url to use to download the protoc zip file, otherwise uses GitHub Releases. Setting this option will ignore the config protoc_version setting.

Use "prototool [command] --help" for more information about a command.
```

The new help page for `prototool`:

```
$ prototool -h
Usage:
  prototool [command]

Available Commands:
  all         Compile, then format and overwrite, then re-compile and generate, then lint, stopping if any step fails.
  compile     Compile with protoc to check for failures.
  create      Create the given Protobuf files according to a template that passes default prototool lint.
  files       Print all files that match the input arguments.
  format      Format a proto file and compile with protoc to check for failures.
  gen         Generate with protoc.
  grpc        Call a gRPC endpoint. Be sure to set required flags address, method, and either data or stdin.
  help        Help about any command
  init        Generate an initial config file in the current or given directory.
  lint        Lint proto files and compile with protoc to check for failures.
  version     Print the version.

Flags:
      --debug               Run in debug mode, which will print out debug logging.
      --harbormaster        Print failures in JSON compatible with the Harbormaster API.
  -h, --help                help for prototool
      --protoc-url string   The url to use to download the protoc zip file, otherwise uses GitHub Releases. Setting this option will ignore the config protoc_version setting.

Use "prototool [command] --help" for more information about a command.
```