### PR TITLE
Consolidate file helper functions into internal/file

### DIFF
--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -836,11 +836,11 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 			shouldPrint = true
 		} else if meta.InDirModeSingleFilename != "" {
 			// TODO: the compiler may not return the rel path due to logic in bestFilePath
-			absSingleFilename, err := absClean(meta.InDirModeSingleFilename)
+			absSingleFilename, err := file.AbsClean(meta.InDirModeSingleFilename)
 			if err != nil {
 				return err
 			}
-			absFailureFilename, err := absClean(failure.Filename)
+			absFailureFilename, err := file.AbsClean(failure.Filename)
 			if err != nil {
 				return err
 			}
@@ -915,17 +915,6 @@ func newExitErrorf(code int, format string, args ...interface{}) *ExitError {
 		Code:    code,
 		Message: fmt.Sprintf(format, args...),
 	}
-}
-
-// TODO: this is copied in three places
-func absClean(path string) (string, error) {
-	if path == "" {
-		return path, nil
-	}
-	if !filepath.IsAbs(path) {
-		return filepath.Abs(path)
-	}
-	return filepath.Clean(path), nil
 }
 
 func newTabWriter(writer io.Writer) *tabwriter.Writer {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -21,6 +21,8 @@
 package file
 
 import (
+	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/uber/prototool/internal/settings"
@@ -131,4 +133,24 @@ func ProtoSetProviderWithWalkTimeout(walkTimeout time.Duration) ProtoSetProvider
 // NewProtoSetProvider returns a new ProtoSetProvider.
 func NewProtoSetProvider(options ...ProtoSetProviderOption) ProtoSetProvider {
 	return newProtoSetProvider(options...)
+}
+
+// AbsClean returns the cleaned absolute path of the given path.
+func AbsClean(path string) (string, error) {
+	if path == "" {
+		return path, nil
+	}
+	if !filepath.IsAbs(path) {
+		return filepath.Abs(path)
+	}
+	return filepath.Clean(path), nil
+}
+
+// CheckAbs is a convenience functions for determining
+// whether a path is an absolute path.
+func CheckAbs(path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("expected absolute path but was %s", path)
+	}
+	return nil
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package file
 
 import (

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,0 +1,66 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbsClean(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tests := []struct {
+		desc string
+		give string
+		want string
+	}{
+		{
+			desc: "Empty path",
+		},
+		{
+			desc: "Root path",
+			give: "/",
+			want: "/",
+		},
+		{
+			desc: "Clean absolute path",
+			give: "/path/to/foo",
+			want: "/path/to/foo",
+		},
+		{
+			desc: "Messy absolute path",
+			give: "/path//to///foo",
+			want: "/path/to/foo",
+		},
+		{
+			desc: "Clean relative path",
+			give: "path/to/foo",
+			want: filepath.Join(wd, "path/to/foo"),
+		},
+		{
+			desc: "Messy relative path",
+			give: "path//to///foo",
+			want: filepath.Join(wd, "path/to/foo"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			res, err := AbsClean(tt.give)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, res)
+		})
+	}
+}
+
+func TestCheckAbs(t *testing.T) {
+	t.Run("Absolute path", func(t *testing.T) {
+		assert.NoError(t, CheckAbs("/path/to/foo"))
+	})
+	t.Run("Relative path", func(t *testing.T) {
+		assert.EqualError(t, CheckAbs("path/to/foo"), "expected absolute path but was path/to/foo")
+	})
+}

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -91,11 +91,11 @@ func (c *protoSetProvider) GetForFiles(workDirPath string, filePaths ...string) 
 }
 
 func (c *protoSetProvider) GetMultipleForDir(workDirPath string, dirPath string) ([]*ProtoSet, error) {
-	workDirPath, err := absClean(workDirPath)
+	workDirPath, err := AbsClean(workDirPath)
 	if err != nil {
 		return nil, err
 	}
-	absDirPath, err := absClean(dirPath)
+	absDirPath, err := AbsClean(dirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (c *protoSetProvider) GetMultipleForDir(workDirPath string, dirPath string)
 }
 
 func (c *protoSetProvider) GetMultipleForFiles(workDirPath string, filePaths ...string) ([]*ProtoSet, error) {
-	workDirPath, err := absClean(workDirPath)
+	workDirPath, err := AbsClean(workDirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -187,11 +187,11 @@ func (c *protoSetProvider) getBaseProtoSets(dirPathToProtoFiles map[string][]*Pr
 
 func (c *protoSetProvider) walkAndGetAllProtoFiles(workDirPath string, dirPath string) ([]*ProtoFile, error) {
 	var protoFiles []*ProtoFile
-	absWorkDirPath, err := absClean(workDirPath)
+	absWorkDirPath, err := AbsClean(workDirPath)
 	if err != nil {
 		return nil, err
 	}
-	absDirPath, err := absClean(dirPath)
+	absDirPath, err := AbsClean(dirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (c *protoSetProvider) walkAndGetAllProtoFiles(workDirPath string, dirPath s
 						"timed out after %v and having seen %d files, are you sure you are operating "+
 						"in the right context?", c.walkTimeout, numWalkedFiles)
 				}
-				absFilePath, err := absClean(filePath)
+				absFilePath, err := AbsClean(filePath)
 				if err != nil {
 					return err
 				}
@@ -287,7 +287,7 @@ func getDirPathToProtoFiles(protoFiles []*ProtoFile) map[string][]*ProtoFile {
 func getProtoFiles(filePaths []string) ([]*ProtoFile, error) {
 	protoFiles := make([]*ProtoFile, 0, len(filePaths))
 	for _, filePath := range filePaths {
-		absFilePath, err := absClean(filePath)
+		absFilePath, err := AbsClean(filePath)
 		if err != nil {
 			return nil, err
 		}
@@ -297,14 +297,4 @@ func getProtoFiles(filePaths []string) ([]*ProtoFile, error) {
 		})
 	}
 	return protoFiles, nil
-}
-
-func absClean(path string) (string, error) {
-	if path == "" {
-		return path, nil
-	}
-	if !filepath.IsAbs(path) {
-		return filepath.Abs(path)
-	}
-	return filepath.Clean(path), nil
 }

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/uber/prototool/internal/file"
 	"github.com/uber/prototool/internal/settings"
 	"github.com/uber/prototool/internal/vars"
 	"go.uber.org/multierr"
@@ -258,12 +259,12 @@ func (d *downloader) getBasePathNoVersion() (string, error) {
 			return "", err
 		}
 	} else {
-		basePath, err = absClean(basePath)
+		basePath, err = file.AbsClean(basePath)
 		if err != nil {
 			return "", err
 		}
 	}
-	if err := checkAbs(basePath); err != nil {
+	if err := file.CheckAbs(basePath); err != nil {
 		return "", err
 	}
 	return filepath.Join(basePath, "protobuf"), nil

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -21,9 +21,6 @@
 package protoc
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/uber/prototool/internal/file"
 	"github.com/uber/prototool/internal/settings"
@@ -175,21 +172,4 @@ func CompilerWithFileDescriptorSet() CompilerOption {
 // NewCompiler returns a new Compiler.
 func NewCompiler(options ...CompilerOption) Compiler {
 	return newCompiler(options...)
-}
-
-func checkAbs(path string) error {
-	if !filepath.IsAbs(path) {
-		return fmt.Errorf("expected absolute path but was %s", path)
-	}
-	return nil
-}
-
-func absClean(path string) (string, error) {
-	if path == "" {
-		return path, nil
-	}
-	if !filepath.IsAbs(path) {
-		return filepath.Abs(path)
-	}
-	return filepath.Clean(path), nil
 }


### PR DESCRIPTION
I started investigating the changes required to address Prototool's Windows compatibility (https://github.com/uber/prototool/issues/9), and noticed some low-hanging fruit with respect to duplicated functionality across a few packages (https://github.com/uber/prototool/issues/133).

Simply bringing these functions into the `internal/file` directory will suffice - a new package is overkill for now. If the number of file[path]-specific helpers continues to grow, we can move these functions to a separate location then.
