### PR TITLE
Pass signals to protoc

### DIFF
--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -211,8 +211,7 @@ func (c *compiler) runCmdMeta(cmdMeta *cmdMeta) ([]*text.Failure, error) {
 	cmdMeta.execCmd.Stdout = ioutil.Discard
 
 	// Prepare a signal buffer so that we can kill the protoc
-	// process when Prototool receives a SIGINT, SIGTERM,
-	// SIGQUIT or SIGHUP.
+	// process when Prototool receives a SIGINT or SIGTERM.
 	sig := make(chan os.Signal, 1)
 	done := make(chan error, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -215,7 +215,7 @@ func (c *compiler) runCmdMeta(cmdMeta *cmdMeta) ([]*text.Failure, error) {
 	// SIGQUIT or SIGHUP.
 	sig := make(chan os.Signal, 1)
 	done := make(chan error, 1)
-	signal.Notify(sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		done <- cmdMeta.execCmd.Run()
@@ -232,13 +232,9 @@ func (c *compiler) runCmdMeta(cmdMeta *cmdMeta) ([]*text.Failure, error) {
 		)
 		return nil, cmdMeta.execCmd.Process.Kill()
 	case runErr = <-done:
-		// The command succeeded.
-		if runErr == nil {
-			break
-		}
 		// Exit errors are ok, we can probably parse them into text.Failures
 		// if not an exec.ExitError, short circuit.
-		if _, ok := runErr.(*exec.ExitError); !ok {
+		if _, ok := runErr.(*exec.ExitError); !ok && runErr != nil {
 			return nil, runErr
 		}
 	}


### PR DESCRIPTION
Re: https://github.com/uber/prototool/issues/5

This adds simple signal handling for `SIGHUP`, `SIGINT`, `SIGTERM` and `SIGQUIT` when Prototool shells out to protoc. Upon receiving one of these signals, Prototool will manually kill the protoc process, and terminate without failures. In this case, the running command, along with the string representation of the received signal, will be logged as fields at debug-level.
