### PR TITLE
Start adding long help documentation strings

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7ba018ca22cd50a2e909cb7b3e091aa378b2ae048e69d0d999af81cb0583c2a3
-updated: 2018-06-14T13:49:16.756220234-04:00
+hash: e103ef81d6b447b46f5afb30e2d4bcf841a26eb52a11b8743f9dc8f35d16e855
+updated: 2018-07-16T10:45:39.277224709+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -58,6 +58,8 @@ imports:
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/mitchellh/go-wordwrap
+  version: ad45545899c7b13c020ea92b2072220eefad42b8
 - name: github.com/opentracing/opentracing-go
   version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
@@ -99,7 +101,7 @@ imports:
 - name: github.com/uber-go/tally
   version: 79f2a33b0e55b1255ffbbaf824dcafb09ff34dda
 - name: github.com/uber/tchannel-go
-  version: cc0c40929b0dbdb755b727a8c253de2b5d4af46b
+  version: 7f5c12c66261f3ac3c5dde959d65eed59e3b63af
   subpackages:
   - internal/argreader
   - relay
@@ -110,7 +112,7 @@ imports:
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: 45540ff1846c207f109bbb7de2f2748f7198ca21
+  version: d100de9c8cc8358591507951141bc107713ba671
   subpackages:
   - internal/digreflect
 - name: go.uber.org/fx
@@ -128,7 +130,7 @@ imports:
   - push
   - tallypush
 - name: go.uber.org/thriftrw
-  version: 43dfafd7bb1c99f0460d645a1959b73f6dfa536f
+  version: fb439a9a7f5a388d8606aae1c1ff6654b8b67fbe
   subpackages:
   - version
 - name: go.uber.org/yarpc
@@ -162,7 +164,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: db08ff08e8622530d9ed3a0e8ac279f6d4c02196
+  version: afe8f62b1d6bbd81f31868121a50b06d8188e1f9
   subpackages:
   - bpf
   - context
@@ -193,13 +195,12 @@ imports:
   - protobuf/ptype
   - protobuf/source_context
 - name: google.golang.org/grpc
-  version: 24f3cca1ffddeab04708c325f8088c76c2d74972
+  version: ba63e52faf1676ef8bb26b6e0ba5acf78ff3b8e8
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
   - balancer/base
   - balancer/roundrobin
-  - channelz
   - codes
   - connectivity
   - credentials
@@ -208,6 +209,7 @@ imports:
   - grpclog
   - internal
   - internal/backoff
+  - internal/channelz
   - internal/grpcrand
   - keepalive
   - metadata

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,7 @@ import:
   - package: github.com/gogo/protobuf/protoc-gen-gogoslick
   - package: github.com/golang/protobuf/protoc-gen-go
   - package: github.com/jhump/protoreflect/dynamic
+  - package: github.com/mitchellh/go-wordwrap
   - package: github.com/spf13/cobra
   - package: github.com/spf13/pflag
   - package: go.uber.org/atomic

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -221,6 +221,86 @@ If Vim integration is set up, files will be generated when you open a new Protob
 	grpcCmdTemplate = &cmdTemplate{
 		Use:   "grpc dirOrProtoFiles...",
 		Short: "Call a gRPC endpoint. Be sure to set required flags address, method, and either data or stdin.",
+		Long: `What this does behind the scenes:
+
+- Compiles your Protobuf files with "protoc", generating a "FileDescriptorSet".
+- Uses the "FileDescriptorSet" to figure out the request and response type for
+  the endpoint, and to convert the JSON input to binary.
+- Calls the gRPC endpoint.
+- Uses the "FileDescriptorSet" to convert the resulting binary back to JSON,
+  and prints it out for you.
+
+All these steps take on the order of milliseconds, for example the overhead for a file with four dependencies is about 30ms, so there is little overhead for CLI calls to gRPC.
+
+There is a full example for gRPC in the example directory of Prototool. Run "make init example" to make sure everything is installed and generated.
+
+Start the example server in a separate terminal by doing "go run example/cmd/excited/main.go".
+
+prototool grpc dirOrProtoFiles... \
+  --address serverAddress \
+  --method package.service/Method \
+  --data 'requestData'
+
+Either use "--data 'requestData'" as the the JSON data to input, or "--stdin" which will result in the input being read from stdin as JSON.
+
+$ make init example # make sure everything is built just in case
+
+$ cat input.json
+{"value":"hello"}
+
+$ cat input.json | prototool grpc example \
+  --address 0.0.0.0:8080 \
+  --method foo.ExcitedService/Exclamation \
+  --stdin
+{
+  "value": "hello!"
+}
+
+$ cat input.json | prototool grpc example \
+  --address 0.0.0.0:8080 \
+  --method foo.ExcitedService/ExclamationServerStream \
+  --stdin
+{
+  "value": "h"
+}
+{
+  "value": "e"
+}
+{
+  "value": "l"
+}
+{
+  "value": "l"
+}
+{
+  "value": "o"
+}
+{
+  "value": "!"
+}
+
+$ cat input.json
+{"value":"hello"}
+{"value":"salutations"}
+
+$ cat input.json | prototool grpc example \
+  --address 0.0.0.0:8080 \
+  --method foo.ExcitedService/ExclamationClientStream \
+  --stdin
+{
+  "value": "hellosalutations!"
+}
+
+$ cat input.json | prototool grpc example \
+  --address 0.0.0.0:8080 \
+  --method foo.ExcitedService/ExclamationBidiStream \
+  --stdin
+{
+  "value": "hello!"
+}
+{
+  "value": "salutations!"
+}`,
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.GRPC(args, flags.headers, flags.address, flags.method, flags.data, flags.callTimeout, flags.connectTimeout, flags.keepaliveTime, flags.stdin)
 		},

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -34,9 +34,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var (
-	wordWrapLength uint = 80
+const wordWrapLength uint = 80
 
+var (
 	allCmdTemplate = &cmdTemplate{
 		Use:   "all dirOrProtoFiles...",
 		Short: "Compile, then format and overwrite, then re-compile and generate, then lint, stopping if any step fails.",

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -71,6 +72,7 @@ var (
 	compileCmdTemplate = &cmdTemplate{
 		Use:   "compile dirOrProtoFiles...",
 		Short: "Compile with protoc to check for failures.",
+		Long:  `Stubs will not be generated. To generate stubs, use the "gen" command. Calling "compile" has the effect of calling protoc with "-o /dev/null".`,
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.Compile(args, flags.dryRun)
 		},
@@ -135,6 +137,7 @@ var (
 	formatCmdTemplate = &cmdTemplate{
 		Use:   "format dirOrProtoFiles...",
 		Short: "Format a proto file and compile with protoc to check for failures.",
+		Long:  `By default, the values for "java_multiple_files", "java_outer_classname", and "java_package" are updated to reflect what is expected by the Google Cloud APIs file structure at https://cloud.google.com/apis/design/file_structure, and the value of "go_package" is updated to reflect what we expect for the default Style Guide. By formatting, the linting for these values will pass by default. See the documentation for "create" for an example. This functionality can be suppressed by passing the flag "--no-rewrite".`,
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.Format(args, flags.overwrite, flags.diffMode, flags.lintMode, !flags.noRewrite)
 		},
@@ -180,6 +183,7 @@ var (
 	initCmdTemplate = &cmdTemplate{
 		Use:   "init [dirPath]",
 		Short: "Generate an initial config file in the current or given directory.",
+		Long:  `All available options will be generated, but all options except "protoc_version" :will be commented out unless the --uncomment flag is specified.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.Init(args, flags.uncomment)
@@ -204,6 +208,7 @@ var (
 	lintCmdTemplate = &cmdTemplate{
 		Use:   "lint dirOrProtoFiles...",
 		Short: "Lint proto files and compile with protoc to check for failures.",
+		Long:  `The default rule set follows the Style Guide at https://github.com/uber/prototool/blob/master/etc/style/uber/uber.proto. You can add or exclude lint rules in your "prototool.yaml" file. The default rule set is very strict and is meant to enforce consistent development patterns.`,
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.Lint(args, flags.listAllLinters, flags.listLinters)
 		},
@@ -294,9 +299,9 @@ type cmdTemplate struct {
 func (c *cmdTemplate) Build(exitCodeAddr *int, stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags) *cobra.Command {
 	command := &cobra.Command{}
 	command.Use = c.Use
-	command.Short = c.Short
+	command.Short = strings.TrimSpace(c.Short)
 	if c.Long != "" {
-		command.Long = fmt.Sprintf("%s\n%s", c.Short, c.Long)
+		command.Long = fmt.Sprintf("%s\n\n%s", strings.TrimSpace(c.Short), strings.TrimSpace(c.Long))
 	}
 	command.Args = c.Args
 	command.Run = func(_ *cobra.Command, args []string) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -223,16 +223,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 	grpcCmdTemplate = &cmdTemplate{
 		Use:   "grpc dirOrProtoFiles...",
 		Short: "Call a gRPC endpoint. Be sure to set required flags address, method, and either data or stdin.",
-		Long: `What this does behind the scenes:
-
-- Compiles your Protobuf files with "protoc", generating a "FileDescriptorSet".
-- Uses the "FileDescriptorSet" to figure out the request and response type for
-  the endpoint, and to convert the JSON input to binary.
-- Calls the gRPC endpoint.
-- Uses the "FileDescriptorSet" to convert the resulting binary back to JSON,
-  and prints it out for you.
-
-All these steps take on the order of milliseconds, for example the overhead for a file with four dependencies is about 30ms, so there is little overhead for CLI calls to gRPC.
+		Long: `This command compiles your proto files with "protoc", converts JSON input to binary and converts the result from binary to JSON. All these steps take on the order of milliseconds. For example, the overhead for a file with four dependencies is about 30ms, so there is little overhead for CLI calls to gRPC. 
 
 There is a full example for gRPC in the example directory of Prototool. Run "make init example" to make sure everything is installed and generated.
 

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -35,6 +35,8 @@ import (
 )
 
 var (
+	wordWrapLength uint = 80
+
 	allCmdTemplate = &cmdTemplate{
 		Use:   "all dirOrProtoFiles...",
 		Short: "Compile, then format and overwrite, then re-compile and generate, then lint, stopping if any step fails.",
@@ -88,14 +90,14 @@ var (
 		Short: "Create the given Protobuf files according to a template that passes default prototool lint.",
 		Long: `Assuming the filename "example_create_file.proto", the file will look like the following:
 
-syntax = "proto3";
+  syntax = "proto3";
 
-package SOME.PKG;
+  package SOME.PKG;
 
-option go_package = "PKGpb";
-option java_multiple_files = true;
-option java_outer_classname = "ExampleCreateFileProto";
-option java_package = "com.SOME.PKG.pb";
+  option go_package = "PKGpb";
+  option java_multiple_files = true;
+  option java_outer_classname = "ExampleCreateFileProto";
+  option java_package = "com.SOME.PKG.pb";
 
 This matches what the linter expects. "SOME.PKG" will be computed as follows:
 
@@ -320,7 +322,7 @@ $ cat input.json | prototool grpc example \
 	initCmdTemplate = &cmdTemplate{
 		Use:   "init [dirPath]",
 		Short: "Generate an initial config file in the current or given directory.",
-		Long:  `All available options will be generated, but all options except "protoc_version" :will be commented out unless the --uncomment flag is specified.`,
+		Long:  `All available options will be generated and commented out except for "protoc_version". Pass the "--uncomment" flag to uncomment all options.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.Init(args, flags.uncomment)
@@ -438,7 +440,7 @@ func (c *cmdTemplate) Build(exitCodeAddr *int, stdin io.Reader, stdout io.Writer
 	command.Use = c.Use
 	command.Short = strings.TrimSpace(c.Short)
 	if c.Long != "" {
-		command.Long = wordwrap.WrapString(fmt.Sprintf("%s\n\n%s", strings.TrimSpace(c.Short), strings.TrimSpace(c.Long)), 80)
+		command.Long = wordwrap.WrapString(fmt.Sprintf("%s\n\n%s", strings.TrimSpace(c.Short), strings.TrimSpace(c.Long)), wordWrapLength)
 	}
 	command.Args = c.Args
 	command.Run = func(_ *cobra.Command, args []string) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strings"
 
+	wordwrap "github.com/mitchellh/go-wordwrap"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/uber/prototool/internal/exec"
@@ -301,7 +302,7 @@ func (c *cmdTemplate) Build(exitCodeAddr *int, stdin io.Reader, stdout io.Writer
 	command.Use = c.Use
 	command.Short = strings.TrimSpace(c.Short)
 	if c.Long != "" {
-		command.Long = fmt.Sprintf("%s\n\n%s", strings.TrimSpace(c.Short), strings.TrimSpace(c.Long))
+		command.Long = wordwrap.WrapString(fmt.Sprintf("%s\n\n%s", strings.TrimSpace(c.Short), strings.TrimSpace(c.Long)), 80)
 	}
 	command.Args = c.Args
 	command.Run = func(_ *cobra.Command, args []string) {


### PR DESCRIPTION
This starts the work to add long documentation strings to commands. This does a few things:

- Cleans up the combination of the `Short` and `Long` parameters by adding an extra newline.
- Uses https://github.com/mitchellh/go-wordwrap to wrap the documentation to 80 characters. This repository is MIT-licensed, so it's acceptable to use, and this makes the documentation look much cleaner (I was slightly surprised to find out that Cobra doesn't have an option for this). Some lines have to be manually wrapped to work, namely things in lists (so the next line is indented), and commands (where I `\-` them out to separate lines when displayed). All the long documentation strings look proper when I try them out.
- Copies over some of the documentation from README.md.

After this start, we can fill out the long documentation strings for other commands at will.

I'd recommend checking out this branch, doing `make install`, and then doing `prototool help grpc, lint,compile,...` to see how this looks.

@amckinney I know you have specific preferences for documentation, and it almost always just adds improvement, but my goal is to get this in as a start, and then iterate on the documentation. We can do one of a few things:

1. Just iterate on it on this PR like normal (which is fine if that's what you want to do! No issues!).
2. Land this, and have you do a new PR with any documentation changes you want.
3. You do a chained PR with any documentation changes.

Or...

4. You just push the changes you want directly to this branch/PR. This is probably the most efficient - instead of commenting the changes on the PR, just make the changes (which I'll almost for sure be fine with) and then we can land it.

(4) would probably be my preferred mechanism, but anything is fine, what do you think?

Fixes #146.