### PR TITLE
Print single-line field options on the same line from the formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - A linter to verify that no enum uses the option `allow_alias.`
 ### Changed
+- The formatter now prints primitive field options on the same line
+  as the field.
 - The commands binary-to-json, clean, descriptor-proto, download,
   field-descriptor-proto, json-to-binary, list-all-linters,
   list-all-lint-groups, list-linters, list-lint-group,

--- a/internal/cmd/testdata/format/bar/bar_proto2.proto.golden
+++ b/internal/cmd/testdata/format/bar/bar_proto2.proto.golden
@@ -10,13 +10,9 @@ option java_package = "com.bar";
 import "google/protobuf/descriptor.proto";
 
 extend google.protobuf.MessageOptions {
-  optional bool message_option_proto2 = 90001 [
-    default = false
-  ];
+  optional bool message_option_proto2 = 90001 [default = false];
 }
 
 extend google.protobuf.FileOptions {
-  optional bool file_option_proto2 = 90002 [
-    default = false
-  ];
+  optional bool file_option_proto2 = 90002 [default = false];
 }

--- a/internal/cmd/testdata/format/foo/foo.proto.golden
+++ b/internal/cmd/testdata/format/foo/foo.proto.golden
@@ -57,9 +57,7 @@ message Baz {
   // dep comment
   bar.Dep dep = 2;
   google.protobuf.Timestamp timestamp = 3; // inline c-style comment 
-  int64 woot = 5 [
-    (bar.field_option) = true
-  ];
+  int64 woot = 5 [(bar.field_option) = true];
   // comment17
   int64 woot2 = 6 [
     (bar.field_dep_option) = {
@@ -173,9 +171,7 @@ message Empty {}
 enum Something {
   option (bar.enum_option) = true;
   // comment25
-   SOMETHING_INVALID = 0 [
-    (bar.enum_value_option) = true
-  ]; // inline comment25
+  SOMETHING_INVALID = 0 [(bar.enum_value_option) = true]; // inline comment25
   // comment27
   SOMETHING_UNSET = 1; // inline comment27
   // comment28

--- a/internal/format/base_visitor.go
+++ b/internal/format/base_visitor.go
@@ -89,7 +89,7 @@ func (v *baseVisitor) pMessageOrEnumField(prefix string, fieldName string, field
 	}
 	if len(options) == 1 {
 		o := options[0]
-		if len(o.Constant.Array) == 0 && len(o.Constant.OrderedMap) == 0 {
+		if isSingleValueLiteral(o.Constant) {
 			if source := o.Constant.SourceRepresentation(); source != "" {
 				v.PWithInlineComment(inlineComment, prefix, fieldType, fieldName, " = ", fieldTag, " [", o.Name, ` = `, source, "];")
 				return
@@ -122,8 +122,7 @@ func (v *baseVisitor) pOptions(isFieldOption bool, options ...*proto.Option) {
 			}
 		}
 		v.PComment(o.Comment)
-		// TODO: this is a good example of the reasoning for https://github.com/uber/prototool/issues/1
-		if len(o.Constant.Array) == 0 && len(o.Constant.OrderedMap) == 0 {
+		if isSingleValueLiteral(o.Constant) {
 			// SourceRepresentation() returns an empty string if the literal is empty
 			// if empty, we do not want to print the key or empty value
 			if source := o.Constant.SourceRepresentation(); source != "" {
@@ -152,8 +151,7 @@ func (v *baseVisitor) pInnerLiteral(name string, literal proto.Literal, suffix s
 	if name != "" {
 		prefix = name + ": "
 	}
-	// TODO: this is a good example of the reasoning for https://github.com/uber/prototool/issues/1
-	if len(literal.Array) == 0 && len(literal.OrderedMap) == 0 {
+	if isSingleValueLiteral(literal) {
 		// SourceRepresentation() returns an empty string if the literal is empty
 		// if empty, we do not want to print the key or empty value
 		if source := literal.SourceRepresentation(); source != "" {
@@ -184,6 +182,11 @@ func (v *baseVisitor) pInnerLiteral(name string, literal proto.Literal, suffix s
 
 func (v *baseVisitor) PField(prefix string, fieldType string, field *proto.Field) {
 	v.pMessageOrEnumField(prefix, field.Name, fieldType, field.Sequence, field.Comment, field.InlineComment, field.Options...)
+}
+
+func isSingleValueLiteral(literal proto.Literal) bool {
+	// TODO: this is a good example of the reasoning for https://github.com/uber/prototool/issues/1
+	return len(literal.Array) == 0 && len(literal.OrderedMap) == 0
 }
 
 func (v *baseVisitor) PEnumField(element *proto.EnumField) {

--- a/internal/format/base_visitor.go
+++ b/internal/format/base_visitor.go
@@ -73,7 +73,37 @@ func (v *baseVisitor) PComment(comment *proto.Comment) {
 	}
 }
 
-func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
+func (v *baseVisitor) POptions(options ...*proto.Option) {
+	v.pOptions(false, options...)
+}
+
+// fieldType can be "" in case of enum field
+func (v *baseVisitor) pMessageOrEnumField(prefix string, fieldName string, fieldType string, fieldTag int, comment *proto.Comment, inlineComment *proto.Comment, options ...*proto.Option) {
+	if fieldType != "" {
+		fieldType = fieldType + " "
+	}
+	v.PComment(comment)
+	if len(options) == 0 {
+		v.PWithInlineComment(inlineComment, prefix, fieldType, fieldName, " = ", fieldTag, ";")
+		return
+	}
+	if len(options) == 1 {
+		o := options[0]
+		if len(o.Constant.Array) == 0 && len(o.Constant.OrderedMap) == 0 {
+			if source := o.Constant.SourceRepresentation(); source != "" {
+				v.PWithInlineComment(inlineComment, prefix, fieldType, fieldName, " = ", fieldTag, " [", o.Name, ` = `, source, "];")
+				return
+			}
+		}
+	}
+	v.P(prefix, fieldType, fieldName, " = ", fieldTag, " [")
+	v.In()
+	v.pOptions(true, options...)
+	v.Out()
+	v.PWithInlineComment(inlineComment, "];")
+}
+
+func (v *baseVisitor) pOptions(isFieldOption bool, options ...*proto.Option) {
 	if len(options) == 0 {
 		return
 	}
@@ -116,7 +146,7 @@ func (v *baseVisitor) POptions(isFieldOption bool, options ...*proto.Option) {
 	}
 }
 
-// should only be called by POptions
+// should only be called by pOptions
 func (v *baseVisitor) pInnerLiteral(name string, literal proto.Literal, suffix string) {
 	prefix := ""
 	if name != "" {
@@ -152,17 +182,16 @@ func (v *baseVisitor) pInnerLiteral(name string, literal proto.Literal, suffix s
 	}
 }
 
-func (v *baseVisitor) PField(prefix string, t string, field *proto.Field) {
-	v.PComment(field.Comment)
-	if len(field.Options) == 0 {
-		v.PWithInlineComment(field.InlineComment, prefix, t, " ", field.Name, " = ", field.Sequence, ";")
+func (v *baseVisitor) PField(prefix string, fieldType string, field *proto.Field) {
+	v.pMessageOrEnumField(prefix, field.Name, fieldType, field.Sequence, field.Comment, field.InlineComment, field.Options...)
+}
+
+func (v *baseVisitor) PEnumField(element *proto.EnumField) {
+	if element.ValueOption == nil {
+		v.pMessageOrEnumField("", element.Name, "", element.Integer, element.Comment, element.InlineComment)
 		return
 	}
-	v.P(prefix, t, " ", field.Name, " = ", field.Sequence, " [")
-	v.In()
-	v.POptions(true, field.Options...)
-	v.Out()
-	v.PWithInlineComment(field.InlineComment, "];")
+	v.pMessageOrEnumField("", element.Name, "", element.Integer, element.Comment, element.InlineComment, element.ValueOption)
 }
 
 func cleanCommentLine(line string) string {

--- a/internal/format/first_pass_visitor.go
+++ b/internal/format/first_pass_visitor.go
@@ -105,7 +105,7 @@ func (v *firstPassVisitor) Do() []*text.Failure {
 		)
 	}
 	if len(v.Options) > 0 {
-		v.POptions(false, v.Options...)
+		v.POptions(v.Options...)
 		v.P()
 	}
 	if len(v.Imports) > 0 {

--- a/internal/format/main_visitor.go
+++ b/internal/format/main_visitor.go
@@ -112,13 +112,13 @@ func (v *mainVisitor) VisitOption(element *proto.Option) {
 	}
 	switch v.parent.(type) {
 	case (*proto.Enum):
-		v.POptions(false, element)
+		v.POptions(element)
 	case (*proto.Message):
-		v.POptions(false, element)
+		v.POptions(element)
 	case (*proto.Oneof):
-		v.POptions(false, element)
+		v.POptions(element)
 	case (*proto.Service):
-		v.POptions(false, element)
+		v.POptions(element)
 	default:
 		v.AddFailure(element.Position, "unhandled child option")
 	}
@@ -149,16 +149,7 @@ func (v *mainVisitor) VisitNormalField(element *proto.NormalField) {
 
 func (v *mainVisitor) VisitEnumField(element *proto.EnumField) {
 	v.haveHitNonComment = true
-	v.PComment(element.Comment)
-	if element.ValueOption == nil {
-		v.PWithInlineComment(element.InlineComment, element.Name, " = ", element.Integer, ";")
-		return
-	}
-	v.P(" ", element.Name, " = ", element.Integer, " [")
-	v.In()
-	v.POptions(true, element.ValueOption)
-	v.Out()
-	v.PWithInlineComment(element.InlineComment, "];")
+	v.PEnumField(element)
 }
 
 func (v *mainVisitor) VisitEnum(element *proto.Enum) {
@@ -257,7 +248,7 @@ func (v *mainVisitor) VisitRPC(element *proto.RPC) {
 	}
 	v.P("rpc ", element.Name, "(", requestStream, element.RequestType, ") returns (", responseStream, element.ReturnsType, ") {")
 	v.In()
-	v.POptions(false, element.Options...)
+	v.POptions(element.Options...)
 	v.Out()
 	v.PWithInlineComment(element.InlineComment, "}")
 }


### PR DESCRIPTION
Fixes #108. See the diff on the format golden files below.

`POptions` effectively becomes `pOptions` (signaling it should not be called outside of `baseVisitor`), then the new `POptions` no longer takes `isFieldOption` bool, and fields/enum fields are special-cased in`PField` and `PEnumField`.

The code is not clean, but this is a larger symptom of how the code already is in `internal/format`, and of emicklei/proto. This is one of the smaller "transformations" from the existing code that we can make to fix #108. Let me know what you want to do with it!