### PR TITLE
Remove the protoc-url global flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - If more than one `prototool.yaml` is found for the input directory or files,
   an error is returned.
 - The `prototool` binary package is moved under `internal`.
+- Remove the `protoc-url` global flag.
 
 
 ## [0.4.0] - 2018-06-22

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -114,7 +114,6 @@ func getRootCommand(exitCodeAddr *int, develMode bool, args []string, stdin io.R
 	// flags bound to rootCmd are global flags
 	flags.bindDebug(rootCmd.PersistentFlags())
 	flags.bindHarbormaster(rootCmd.PersistentFlags())
-	flags.bindProtocURL(rootCmd.PersistentFlags())
 
 	if develMode {
 		rootCmd.AddCommand(binaryToJSONCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -46,7 +46,6 @@ type flags struct {
 	overwrite      bool
 	pkg            string
 	printFields    string
-	protocURL      string
 	stdin          bool
 	uncomment      bool
 	noRewrite      bool
@@ -134,10 +133,6 @@ func (f *flags) bindPackage(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindPrintFields(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.printFields, "print-fields", "filename:line:column:message", "The colon-separated fields to print out on error.")
-}
-
-func (f *flags) bindProtocURL(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocURL, "protoc-url", "", "The url to use to download the protoc zip file, otherwise uses GitHub Releases. Setting this option will ignore the config protoc_version setting.")
 }
 
 func (f *flags) bindStdin(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -351,12 +351,6 @@ func getRunner(stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags
 			exec.RunnerWithPrintFields(flags.printFields),
 		)
 	}
-	if flags.protocURL != "" {
-		runnerOptions = append(
-			runnerOptions,
-			exec.RunnerWithProtocURL(flags.protocURL),
-		)
-	}
 	workDirPath, err := os.Getwd()
 	if err != nil {
 		return nil, err

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -85,13 +85,6 @@ func RunnerWithCachePath(cachePath string) RunnerOption {
 	}
 }
 
-// RunnerWithProtocURL returns a RunnerOption that uses the given protoc zip file URL.
-func RunnerWithProtocURL(protocURL string) RunnerOption {
-	return func(runner *runner) {
-		runner.protocURL = protocURL
-	}
-}
-
 // RunnerWithPrintFields returns a RunnerOption that uses the given colon-separated
 // print fields. The default is filename:line:column:message.
 func RunnerWithPrintFields(printFields string) RunnerOption {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -68,7 +68,6 @@ type runner struct {
 
 	logger       *zap.Logger
 	cachePath    string
-	protocURL    string
 	printFields  string
 	dirMode      bool
 	harbormaster bool
@@ -642,12 +641,6 @@ func (r *runner) newDownloader(config settings.Config) protoc.Downloader {
 			protoc.DownloaderWithCachePath(r.cachePath),
 		)
 	}
-	if r.protocURL != "" {
-		downloaderOptions = append(
-			downloaderOptions,
-			protoc.DownloaderWithProtocURL(r.protocURL),
-		)
-	}
 	return protoc.NewDownloader(config, downloaderOptions...)
 }
 
@@ -659,12 +652,6 @@ func (r *runner) newCompiler(doGen bool, doFileDescriptorSet bool) protoc.Compil
 		compilerOptions = append(
 			compilerOptions,
 			protoc.CompilerWithCachePath(r.cachePath),
-		)
-	}
-	if r.protocURL != "" {
-		compilerOptions = append(
-			compilerOptions,
-			protoc.CompilerWithProtocURL(r.protocURL),
 		)
 	}
 	if doGen {

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -146,15 +146,6 @@ func CompilerWithCachePath(cachePath string) CompilerOption {
 	}
 }
 
-// CompilerWithProtocURL returns a CompilerOption that uses the given protoc zip file URL.
-//
-// The default is https://github.com/google/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
-func CompilerWithProtocURL(protocURL string) CompilerOption {
-	return func(compiler *compiler) {
-		compiler.protocURL = protocURL
-	}
-}
-
 // CompilerWithGen says to also generate the code.
 func CompilerWithGen() CompilerOption {
 	return func(compiler *compiler) {


### PR DESCRIPTION
Putting this up for discussion -

Given that we intend all of our users to specify the desired `protoc_version` in their `prototool.yaml`, it might not be necessary to support the `protoc-url` override in our global flag set.

I'd rather remove this override for now if we don't currently have a need for it. I can see where it might be useful (fetching a `protoc` zip file from another location), but this might better introduced as a `prototool.yaml` setting, and not as a global flag.