### PR TITLE
Merge file descriptor sets

### DIFF
--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -63,13 +63,13 @@ type Service struct {
 type Getter interface {
 	// Get the field that matches the path.
 	// Return non-nil value, or error otherwise including if nothing found.
-	GetField(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Field, error)
+	GetField(fileDescriptorSet *descriptor.FileDescriptorSet, path string) (*Field, error)
 	// Get the message that matches the path.
 	// Return non-nil value, or error otherwise including if nothing found.
-	GetMessage(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Message, error)
+	GetMessage(fileDescriptorSet *descriptor.FileDescriptorSet, path string) (*Message, error)
 	// Get the service that matches the path.
 	// Return non-nil value, or error otherwise including if nothing found.
-	GetService(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Service, error)
+	GetService(fileDescriptorSet *descriptor.FileDescriptorSet, path string) (*Service, error)
 }
 
 // GetterOption is an option for a new Getter.

--- a/internal/extract/getter.go
+++ b/internal/extract/getter.go
@@ -42,7 +42,7 @@ func newGetter(options ...GetterOption) *getter {
 	return getter
 }
 
-func (g *getter) GetField(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Field, error) {
+func (g *getter) GetField(fileDescriptorSet *descriptor.FileDescriptorSet, path string) (*Field, error) {
 	if len(path) == 0 {
 		return nil, fmt.Errorf("empty path")
 	}
@@ -53,7 +53,7 @@ func (g *getter) GetField(fileDescriptorSets []*descriptor.FileDescriptorSet, pa
 	if len(split) < 2 {
 		return nil, fmt.Errorf("no field for path %s", path)
 	}
-	message, err := g.GetMessage(fileDescriptorSets, strings.Join(split[0:len(split)-1], "."))
+	message, err := g.GetMessage(fileDescriptorSet, strings.Join(split[0:len(split)-1], "."))
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (g *getter) GetField(fileDescriptorSets []*descriptor.FileDescriptorSet, pa
 	}, nil
 }
 
-func (g *getter) GetMessage(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Message, error) {
+func (g *getter) GetMessage(fileDescriptorSet *descriptor.FileDescriptorSet, path string) (*Message, error) {
 	if len(path) == 0 {
 		return nil, fmt.Errorf("empty path")
 	}
@@ -88,26 +88,17 @@ func (g *getter) GetMessage(fileDescriptorSets []*descriptor.FileDescriptorSet, 
 	}
 	var descriptorProto *descriptor.DescriptorProto
 	var fileDescriptorProto *descriptor.FileDescriptorProto
-	var fileDescriptorSet *descriptor.FileDescriptorSet
-	for _, iFileDescriptorSet := range fileDescriptorSets {
-		for _, iFileDescriptorProto := range iFileDescriptorSet.File {
-			iDescriptorProto, err := findDescriptorProto(path, iFileDescriptorProto)
-			if err != nil {
-				return nil, err
-			}
-			if iDescriptorProto != nil {
-				if descriptorProto != nil {
-					return nil, fmt.Errorf("duplicate messages for path %s", path)
-				}
-				descriptorProto = iDescriptorProto
-				fileDescriptorProto = iFileDescriptorProto
-			}
+	for _, iFileDescriptorProto := range fileDescriptorSet.File {
+		iDescriptorProto, err := findDescriptorProto(path, iFileDescriptorProto)
+		if err != nil {
+			return nil, err
 		}
-		// return first fileDescriptorSet that matches
-		// as opposed to duplicate check within fileDescriptorSet, we easily could
-		// have multiple fileDescriptorSets that match
-		if descriptorProto != nil {
-			fileDescriptorSet = iFileDescriptorSet
+		if iDescriptorProto != nil {
+			if descriptorProto != nil {
+				return nil, fmt.Errorf("duplicate messages for path %s", path)
+			}
+			descriptorProto = iDescriptorProto
+			fileDescriptorProto = iFileDescriptorProto
 			break
 		}
 	}
@@ -122,7 +113,7 @@ func (g *getter) GetMessage(fileDescriptorSets []*descriptor.FileDescriptorSet, 
 	}, nil
 }
 
-func (g *getter) GetService(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Service, error) {
+func (g *getter) GetService(fileDescriptorSet *descriptor.FileDescriptorSet, path string) (*Service, error) {
 	if len(path) == 0 {
 		return nil, fmt.Errorf("empty path")
 	}
@@ -131,26 +122,17 @@ func (g *getter) GetService(fileDescriptorSets []*descriptor.FileDescriptorSet, 
 	}
 	var serviceDescriptorProto *descriptor.ServiceDescriptorProto
 	var fileDescriptorProto *descriptor.FileDescriptorProto
-	var fileDescriptorSet *descriptor.FileDescriptorSet
-	for _, iFileDescriptorSet := range fileDescriptorSets {
-		for _, iFileDescriptorProto := range iFileDescriptorSet.File {
-			iServiceDescriptorProto, err := findServiceDescriptorProto(path, iFileDescriptorProto)
-			if err != nil {
-				return nil, err
-			}
-			if iServiceDescriptorProto != nil {
-				if serviceDescriptorProto != nil {
-					return nil, fmt.Errorf("duplicate services for path %s", path)
-				}
-				serviceDescriptorProto = iServiceDescriptorProto
-				fileDescriptorProto = iFileDescriptorProto
-			}
+	for _, iFileDescriptorProto := range fileDescriptorSet.File {
+		iServiceDescriptorProto, err := findServiceDescriptorProto(path, iFileDescriptorProto)
+		if err != nil {
+			return nil, err
 		}
-		// return first fileDescriptorSet that matches
-		// as opposed to duplicate check within fileDescriptorSet, we easily could
-		// have multiple fileDescriptorSets that match
-		if serviceDescriptorProto != nil {
-			fileDescriptorSet = iFileDescriptorSet
+		if iServiceDescriptorProto != nil {
+			if serviceDescriptorProto != nil {
+				return nil, fmt.Errorf("duplicate services for path %s", path)
+			}
+			serviceDescriptorProto = iServiceDescriptorProto
+			fileDescriptorProto = iFileDescriptorProto
 			break
 		}
 	}

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -72,6 +72,16 @@ func (c *protoSetProvider) GetForDir(workDirPath string, dirPath string) (*Proto
 }
 
 func (c *protoSetProvider) GetForFiles(workDirPath string, filePaths ...string) (*ProtoSet, error) {
+	for _, f := range filePaths {
+		fileInfo, err := os.Stat(f)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: allow symlinks?
+		if !fileInfo.Mode().IsRegular() {
+			return nil, fmt.Errorf("failed to read from multiple files: %q is not a regular file", f)
+		}
+	}
 	protoSets, err := c.GetMultipleForFiles(workDirPath, filePaths...)
 	if err != nil {
 		return nil, err

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -38,7 +38,7 @@ const (
 
 // Handler handles gRPC calls.
 type Handler interface {
-	Invoke(fileDescriptorSets []*descriptor.FileDescriptorSet, address string, method string, inputReader io.Reader, outputWriter io.Writer) error
+	Invoke(fileDescriptorSet *descriptor.FileDescriptorSet, address string, method string, inputReader io.Reader, outputWriter io.Writer) error
 }
 
 // HandlerOption is an option for a new Handler.

--- a/internal/grpc/handler.go
+++ b/internal/grpc/handler.go
@@ -67,8 +67,8 @@ func newHandler(options ...HandlerOption) *handler {
 	return handler
 }
 
-func (h *handler) Invoke(fileDescriptorSets []*descriptor.FileDescriptorSet, address string, method string, inputReader io.Reader, outputWriter io.Writer) error {
-	descriptorSource, err := h.getDescriptorSourceForMethod(fileDescriptorSets, method)
+func (h *handler) Invoke(fileDescriptorSet *descriptor.FileDescriptorSet, address string, method string, inputReader io.Reader, outputWriter io.Writer) error {
+	descriptorSource, err := h.getDescriptorSourceForMethod(fileDescriptorSet, method)
 	if err != nil {
 		return err
 	}
@@ -116,16 +116,16 @@ func (h *handler) getDialOptions() []grpc.DialOption {
 	return dialOptions
 }
 
-func (h *handler) getDescriptorSourceForMethod(fileDescriptorSets []*descriptor.FileDescriptorSet, method string) (grpcurl.DescriptorSource, error) {
+func (h *handler) getDescriptorSourceForMethod(fileDescriptorSet *descriptor.FileDescriptorSet, method string) (grpcurl.DescriptorSource, error) {
 	servicePath, err := getServiceForMethod(method)
 	if err != nil {
 		return nil, err
 	}
-	service, err := h.getter.GetService(fileDescriptorSets, servicePath)
+	service, err := h.getter.GetService(fileDescriptorSet, servicePath)
 	if err != nil {
 		return nil, err
 	}
-	fileDescriptorSet, err := desc.SortFileDescriptorSet(service.FileDescriptorSet, service.FileDescriptorProto)
+	fileDescriptorSet, err = desc.SortFileDescriptorSet(service.FileDescriptorSet, service.FileDescriptorProto)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -106,7 +106,7 @@ type CompileResult struct {
 	//
 	// Will only be set if the CompilerWithFileDescriptorSet
 	// option is used.
-	FileDescriptorSets []*descriptor.FileDescriptorSet
+	FileDescriptorSet *descriptor.FileDescriptorSet
 }
 
 // Compiler compiles protobuf files.

--- a/internal/reflect/handler.go
+++ b/internal/reflect/handler.go
@@ -51,8 +51,8 @@ func newHandler(options ...HandlerOption) *handler {
 	return handler
 }
 
-func (h *handler) BinaryToJSON(fileDescriptorSets []*descriptor.FileDescriptorSet, messagePath string, binaryData []byte) ([]byte, error) {
-	dynamicMessage, err := h.getDynamicMessage(fileDescriptorSets, messagePath)
+func (h *handler) BinaryToJSON(fileDescriptorSet *descriptor.FileDescriptorSet, messagePath string, binaryData []byte) ([]byte, error) {
+	dynamicMessage, err := h.getDynamicMessage(fileDescriptorSet, messagePath)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +62,8 @@ func (h *handler) BinaryToJSON(fileDescriptorSets []*descriptor.FileDescriptorSe
 	return dynamicMessage.MarshalJSON()
 }
 
-func (h *handler) JSONToBinary(fileDescriptorSets []*descriptor.FileDescriptorSet, messagePath string, jsonData []byte) ([]byte, error) {
-	dynamicMessage, err := h.getDynamicMessage(fileDescriptorSets, messagePath)
+func (h *handler) JSONToBinary(fileDescriptorSet *descriptor.FileDescriptorSet, messagePath string, jsonData []byte) ([]byte, error) {
+	dynamicMessage, err := h.getDynamicMessage(fileDescriptorSet, messagePath)
 	if err != nil {
 		return nil, err
 	}
@@ -73,12 +73,12 @@ func (h *handler) JSONToBinary(fileDescriptorSets []*descriptor.FileDescriptorSe
 	return dynamicMessage.Marshal()
 }
 
-func (h *handler) getDynamicMessage(fileDescriptorSets []*descriptor.FileDescriptorSet, messagePath string) (*dynamic.Message, error) {
-	message, err := h.getter.GetMessage(fileDescriptorSets, messagePath)
+func (h *handler) getDynamicMessage(fileDescriptorSet *descriptor.FileDescriptorSet, messagePath string) (*dynamic.Message, error) {
+	message, err := h.getter.GetMessage(fileDescriptorSet, messagePath)
 	if err != nil {
 		return nil, err
 	}
-	fileDescriptorSet, err := intdesc.SortFileDescriptorSet(message.FileDescriptorSet, message.FileDescriptorProto)
+	fileDescriptorSet, err = intdesc.SortFileDescriptorSet(message.FileDescriptorSet, message.FileDescriptorProto)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reflect/reflect.go
+++ b/internal/reflect/reflect.go
@@ -27,8 +27,8 @@ import (
 
 // Handler handles reflection.
 type Handler interface {
-	BinaryToJSON(fileDescriptorSets []*descriptor.FileDescriptorSet, messagePath string, binaryData []byte) ([]byte, error)
-	JSONToBinary(fileDescriptorSets []*descriptor.FileDescriptorSet, messagePath string, jsonData []byte) ([]byte, error)
+	BinaryToJSON(fileDescriptorSet *descriptor.FileDescriptorSet, messagePath string, binaryData []byte) ([]byte, error)
+	JSONToBinary(fileDescriptorSet *descriptor.FileDescriptorSet, messagePath string, jsonData []byte) ([]byte, error)
 }
 
 // HandlerOption is an option for a new Handler.


### PR DESCRIPTION
Re: https://github.com/uber/prototool/issues/142

Now that we only support a single `prototool.yaml`, we can safely merge the collected file descriptor sets into a single set. We simply loop over the separate file descriptor sets, and verify that any duplicate files have the same byte representation. We uniquely identify each file via `*descriptor.FileDescriptorProto.GetName` and compare their bytes via `*descriptor.FileDescriptorProto.String`, which marshals the file's contents under the hood.

Seeing as this is an internal implementation detail, I didn't include a changelog entry. Let me know if you'd like me to include a note there.