### PR TITLE
Fix excludes prefix matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Delete `gen.go_options.no_default_modifiers` setting.
 - Delete `lint.group` setting.
 - Rename `create.dir_to_base_package` -> `create.dir_to_package`.
+### Fixed
 - Fix `excludes` setting to correctly match file path prefixes.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Delete `gen.go_options.no_default_modifiers` setting.
 - Delete `lint.group` setting.
 - Rename `create.dir_to_base_package` -> `create.dir_to_package`.
+- Fix `excludes` setting to correctly match file path prefixes.
 
 
 ## [0.5.0] - 2018-07-26

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -3,9 +3,7 @@
 # You probably want to set this to make your builds completely reproducible.
 protoc_version: 3.6.0
 
-# Paths to exclude when using directory mode.
-# These are prefixes, not regexes, so path/to/a will ignore anything beginning with
-# $(dirname some/dir/prototool.yaml)/path/to/a including for example $(dirname some/dir/prototool.yaml)/path/to/ab.
+# Paths to exclude from protoc.
 excludes:
   - path/to/a
   - path/to/b/file.proto

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -33,9 +33,7 @@ var tmpl = template.Must(template.New("tmpl").Parse(`# The Protobuf version to u
 # You probably want to set this to make your builds completely reproducible.
 protoc_version: {{.ProtocVersion}}
 
-# Paths to exclude when using directory mode.
-# These are prefixes, not regexes, so path/to/a will ignore anything beginning with
-# $(dirname some/dir/prototool.yaml)/path/to/a including for example $(dirname some/dir/prototool.yaml)/path/to/ab.
+# Paths to exclude from protoc.
 {{.V}}excludes:
 {{.V}}  - path/to/a
 {{.V}}  - path/to/b/file.proto

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -293,7 +293,7 @@ func getProtoFiles(filePaths []string) ([]*ProtoFile, error) {
 // isExcluded determines whether the given filePath should be excluded.
 // Note that all excludes are assumed to be cleaned absolute paths at
 // this point.
-// stopPath represnts the absolute path to the prototool configuration.
+// stopPath represents the absolute path to the prototool configuration.
 // This is used to determine when we should stop checking for excludes.
 func isExcluded(filePath, stopPath string, excludes map[string]struct{}) bool {
 	// Use the root as a fallback so that we don't loop forever.

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -188,15 +188,7 @@ func (c *protoSetProvider) getBaseProtoSets(dirPathToProtoFiles map[string][]*Pr
 // found, whereas workDirPath represents absolute path at which prototool was invoked.
 // workDirPath is only used to determine the ProtoFile.DisplayPath, also known as
 // the relative path from where prototool was invoked.
-func (c *protoSetProvider) walkAndGetAllProtoFiles(workDirPath string, dirPath string) ([]*ProtoFile, error) {
-	absWorkDirPath, err := AbsClean(workDirPath)
-	if err != nil {
-		return nil, err
-	}
-	absDirPath, err := AbsClean(dirPath)
-	if err != nil {
-		return nil, err
-	}
+func (c *protoSetProvider) walkAndGetAllProtoFiles(absWorkDirPath string, absDirPath string) ([]*ProtoFile, error) {
 	var (
 		protoFiles     []*ProtoFile
 		numWalkedFiles int

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -185,8 +185,8 @@ func (c *protoSetProvider) getBaseProtoSets(dirPathToProtoFiles map[string][]*Pr
 
 // walkAndGetAllProtoFiles collects the .proto files nested under the given absDirPath.
 // absDirPath represents the absolute path at which the prototool.yaml configuration is
-// found, whereas workDirPath represents absolute path at which prototool was invoked.
-// workDirPath is only used to determine the ProtoFile.DisplayPath, also known as
+// found, whereas absWorkDirPath represents absolute path at which prototool was invoked.
+// absWorkDirPath is only used to determine the ProtoFile.DisplayPath, also known as
 // the relative path from where prototool was invoked.
 func (c *protoSetProvider) walkAndGetAllProtoFiles(absWorkDirPath string, absDirPath string) ([]*ProtoFile, error) {
 	var (
@@ -296,9 +296,12 @@ func getProtoFiles(filePaths []string) ([]*ProtoFile, error) {
 // stopPath represnts the absolute path to the prototool configuration.
 // This is used to determine when we should stop checking for excludes.
 func isExcluded(filePath, stopPath string, excludes map[string]struct{}) bool {
+	// Use the root as a fallback so that we don't loop forever.
+	root := filepath.Dir(string(filepath.Separator))
+
 	isNested := func(curr, exclude string) bool {
 		for {
-			if curr == stopPath {
+			if curr == stopPath || curr == root {
 				return false
 			}
 			if curr == exclude {

--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -127,7 +127,7 @@ func get(filePath string) (Config, error) {
 //
 // This will return a valid Config, or an error.
 func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
-	excludePrefixes, err := getExcludePrefixes(e.Excludes, true /* Never include default excludes */, dirPath)
+	excludePrefixes, err := getExcludePrefixes(e.Excludes, dirPath)
 	if err != nil {
 		return Config{}, err
 	}
@@ -264,30 +264,22 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 func getExcludePrefixesForDir(dirPath string) ([]string, error) {
 	filePath := filepath.Join(dirPath, DefaultConfigFilename)
 	if _, err := os.Stat(filePath); err != nil {
-		excludePrefixes := make([]string, 0, len(DefaultExcludePrefixes))
-		for _, defaultExcludePrefix := range DefaultExcludePrefixes {
-			excludePrefixes = append(excludePrefixes, filepath.Join(dirPath, defaultExcludePrefix))
-		}
-		return excludePrefixes, nil
+		return []string{}, nil
 	}
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 	s := struct {
-		ExcludePaths          []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
-		NoDefaultExcludePaths bool     `json:"no_default_excludes,omitempty" yaml:"no_default_excludes,omitempty"`
+		ExcludePaths []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
 	}{}
 	if err := yaml.Unmarshal(data, &s); err != nil {
 		return nil, err
 	}
-	return getExcludePrefixes(s.ExcludePaths, s.NoDefaultExcludePaths, dirPath)
+	return getExcludePrefixes(s.ExcludePaths, dirPath)
 }
 
-func getExcludePrefixes(excludes []string, noDefaultExcludes bool, dirPath string) ([]string, error) {
-	if !noDefaultExcludes {
-		excludes = append(DefaultExcludePrefixes, excludes...)
-	}
+func getExcludePrefixes(excludes []string, dirPath string) ([]string, error) {
 	excludePrefixes := make([]string, 0, len(excludes))
 	for _, excludePrefix := range strs.DedupeSort(excludes, nil) {
 		if !filepath.IsAbs(excludePrefix) {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -259,7 +259,6 @@ type OutputPath struct {
 // It is meant to be set by a YAML or JSON config file, or flags.
 type ExternalConfig struct {
 	Excludes           []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
-	NoDefaultExcludes  bool     `json:"no_default_excludes,omitempty" yaml:"no_default_excludes,omitempty"`
 	ProtocVersion      string   `json:"protoc_version,omitempty" yaml:"protoc_version,omitempty"`
 	ProtocIncludes     []string `json:"protoc_includes,omitempty" yaml:"protoc_includes,omitempty"`
 	ProtocIncludeWKT   bool     `json:"protoc_include_wkt,omitempty" yaml:"protoc_include_wkt,omitempty"`

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -45,11 +45,6 @@ const (
 )
 
 var (
-	// DefaultExcludePrefixes are the default prefixes to exclude.
-	DefaultExcludePrefixes = []string{
-		"vendor",
-	}
-
 	_genPluginTypeToString = map[GenPluginType]string{
 		GenPluginTypeNone: "",
 		GenPluginTypeGo:   "go",


### PR DESCRIPTION
Previously, the `excludes` setting had the following comment:
```
These are prefixes, not regexes, so path/to/a will ignore anything
beginning with $(dirname some/dir/prototool.yaml)/path/to/a
including for example $(dirname some/dir/prototool.yaml)/path/to/ab
```
This fixes the prefix behavior so that we can exclude `./path/to/a/` without excluding `./path/to/ab`.

Note that this also makes a small cleanup with respect to the `NoDefaultExcludes` setting. Many of the configuration settings are left in the implementation so that they can be easily introduced later (if need be). I think it's safe to remove this particular setting though.

Default exclusions can vary from language to language, there likely won't ever be a need such a setting. Additionally, re-introducing something like this would be simple even without a reference in the implementation. I don't expect any conflict in this regard, so I included that change here since it pertains to the `excludes` setting. Please let me know if you disagree!