### PR TITLE
Fix cfginit

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -43,20 +43,20 @@ lint:
       files:
         - path/to/foo.proto
 
-# Linter rules.
-# Run prototool list-all-linters to see all available linters.
+  # Linter rules.
+  # Run prototool list-all-linters to see all available linters.
   rules:
-  # Determines whether or not to include the default set of linters.
-  no_default: true
+    # Determines whether or not to include the default set of linters.
+    no_default: true
 
-  # The specific linters to add.
-  add:
-    - ENUM_NAMES_CAMEL_CASE
-    - ENUM_NAMES_CAPITALIZED
+    # The specific linters to add.
+    add:
+      - ENUM_NAMES_CAMEL_CASE
+      - ENUM_NAMES_CAPITALIZED
 
-  # The specific linters to remove.
-  remove:
-    - ENUM_NAMES_CAMEL_CASE
+    # The specific linters to remove.
+    remove:
+      - ENUM_NAMES_CAMEL_CASE
 
 # Code generation directives.
 gen:
@@ -70,8 +70,6 @@ gen:
     extra_modifiers:
       google/api/annotations.proto: google.golang.org/genproto/googleapis/api/annotations
       google/api/http.proto: google.golang.org/genproto/googleapis/api/annotations
-
-  plugin_overrides:
 
   # The list of plugins.
   plugins:

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -73,20 +73,20 @@ protoc_version: {{.ProtocVersion}}
 {{.V}}      files:
 {{.V}}        - path/to/foo.proto
 
-# Linter rules.
-# Run prototool list-all-linters to see all available linters.
+  # Linter rules.
+  # Run prototool list-all-linters to see all available linters.
 {{.V}}  rules:
-  # Determines whether or not to include the default set of linters.
-{{.V}}  no_default: true
+    # Determines whether or not to include the default set of linters.
+{{.V}}    no_default: true
 
-  # The specific linters to add.
-{{.V}}  add:
-{{.V}}    - ENUM_NAMES_CAMEL_CASE
-{{.V}}    - ENUM_NAMES_CAPITALIZED
+    # The specific linters to add.
+{{.V}}    add:
+{{.V}}      - ENUM_NAMES_CAMEL_CASE
+{{.V}}      - ENUM_NAMES_CAPITALIZED
 
-  # The specific linters to remove.
-{{.V}}  remove:
-{{.V}}    - ENUM_NAMES_CAMEL_CASE
+    # The specific linters to remove.
+{{.V}}    remove:
+{{.V}}      - ENUM_NAMES_CAMEL_CASE
 
 # Code generation directives.
 {{.V}}gen:
@@ -100,8 +100,6 @@ protoc_version: {{.ProtocVersion}}
 {{.V}}    extra_modifiers:
 {{.V}}      google/api/annotations.proto: google.golang.org/genproto/googleapis/api/annotations
 {{.V}}      google/api/http.proto: google.golang.org/genproto/googleapis/api/annotations
-
-{{.V}}  plugin_overrides:
 
   # The list of plugins.
 {{.V}}  plugins:


### PR DESCRIPTION
The indents were off for the `lint.rules` section, and `plugin_overrides` is deprecated.