### PR TITLE
Protoc Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- Move `protoc_includes` and `protoc_version` settings under `protoc` key.
 
 
 ## [0.6.0] - 2018-08-03

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ $ cat input.json | prototool grpc example \
 
 Prototool is meant to help enforce a consistent development style for Protobuf, and as such you should follow some basic rules:
 
-- Have all your imports start from the directory your `prototool.yaml` is in. While there is a configuration option `protoc_includes` to denote extra include directories, this is not recommended.
+- Have all your imports start from the directory your `prototool.yaml` is in. While there is a configuration option `protoc.includes` to denote extra include directories, this is not recommended.
 - Have all Protobuf files in the same directory use the same `package`, and use the same values for `go_package`, `java_multiple_files`, `java_outer_classname`, and `java_package`.
 - Do not use long-form `go_package` values, ie use `foopb`, not `github.com/bar/baz/foo;foopb`. This helps `prototool gen` do the best job.
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ Prototool operates using a config file named `prototool.yaml`. For non-trivial u
 Recommended base config file:
 
 ```yaml
-protoc_version: 3.6.1
+protoc:
+  version: 3.6.1
 ```
 
-The command `prototool config init` will generate a config file in the current directory with all available configuration options commented out except `protoc_version`. See [etc/config/example/prototool.yaml](etc/config/example/prototool.yaml) for the config file that `prototool config init --uncomment` generates.
+The command `prototool config init` will generate a config file in the current directory with all available configuration options commented out except `protoc.version`. See [etc/config/example/prototool.yaml](etc/config/example/prototool.yaml) for the config file that `prototool config init --uncomment` generates.
 
 When specifying a directory or set of files for Prototool to operate on, Prototool will search for config files for each directory starting at the given path, and going up a directory until hitting root. If no config file is found, Prototool will use default values and operate as if there was a config file in the current directory, including the current directory with `-I` to `protoc`.
 
@@ -120,7 +121,7 @@ Let's go over some of the basic commands.
 
 ##### `prototool config init`
 
-Create a `prototool.yaml` file in the current directory, with all options except `protoc_version` commented out.
+Create a `prototool.yaml` file in the current directory, with all options except `protoc.version` commented out.
 
 ##### `prototool compile`
 

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -1,5 +1,4 @@
 # The Protobuf version to use from https://github.com/google/protobuf/releases.
-
 # If not set, compile will fail if there are unused imports.
 # Setting this will ignore unused imports.
 allow_unused_imports: true

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -1,22 +1,26 @@
 # The Protobuf version to use from https://github.com/google/protobuf/releases.
-# By default use 3.6.1.
-# You probably want to set this to make your builds completely reproducible.
-protoc_version: 3.6.1
+
+# If not set, compile will fail if there are unused imports.
+# Setting this will ignore unused imports.
+allow_unused_imports: true
 
 # Paths to exclude from protoc.
 excludes:
   - path/to/a
   - path/to/b/file.proto
 
-# Additional paths to include with -I to protoc.
-# By default, the directory of the config file is included,
-# or the current directory if there is no config file.
-protoc_includes:
-  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
+# Protoc directives.
+protoc:
+  # By default use 3.6.1.
+  # You probably want to set this to make your builds completely reproducible.
+  version: 3.6.1
 
-# If not set, compile will fail if there are unused imports.
-# Setting this will ignore unused imports.
-allow_unused_imports: true
+  # Additional paths to include with -I to protoc.
+  # By default, the directory of the config file is included,
+  # or the current directory if there is no config file.
+  includes:
+    - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
+
 
 # Create directives.
 create:

--- a/example/idl/uber/prototool.yaml
+++ b/example/idl/uber/prototool.yaml
@@ -1,5 +1,6 @@
 # if starting from scratch in development, run "make init example" to get/build the .gitignored files
-protoc_includes:
+protoc:
+  includes:
   # note vendor is .gitignored
   - ../../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 lint:

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -29,24 +29,27 @@ import (
 )
 
 var tmpl = template.Must(template.New("tmpl").Parse(`# The Protobuf version to use from https://github.com/google/protobuf/releases.
-# By default use {{.ProtocVersion}}.
-# You probably want to set this to make your builds completely reproducible.
-protoc_version: {{.ProtocVersion}}
+# If not set, compile will fail if there are unused imports.
+# Setting this will ignore unused imports.
+{{.V}}allow_unused_imports: true
 
 # Paths to exclude from protoc.
 {{.V}}excludes:
 {{.V}}  - path/to/a
 {{.V}}  - path/to/b/file.proto
 
-# Additional paths to include with -I to protoc.
-# By default, the directory of the config file is included,
-# or the current directory if there is no config file.
-{{.V}}protoc_includes:
-{{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
+# Protoc directives.
+{{.V}}protoc:
+  # By default use {{.ProtocVersion}}.
+  # You probably want to set this to make your builds completely reproducible.
+  version: {{.ProtocVersion}}
 
-# If not set, compile will fail if there are unused imports.
-# Setting this will ignore unused imports.
-{{.V}}allow_unused_imports: true
+  # Additional paths to include with -I to protoc.
+  # By default, the directory of the config file is included,
+  # or the current directory if there is no config file.
+  {{.V}}includes:
+  {{.V}}  - ../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
+
 
 # Create directives.
 {{.V}}create:

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -127,7 +127,7 @@ func (f *flags) bindPrintFields(flagSet *pflag.FlagSet) {
 }
 
 func (f *flags) bindProtocURL(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocURL, "protoc-url", "", "The url to use to download the protoc zip file, otherwise uses GitHub Releases. Setting this option will ignore the config protoc_version setting.")
+	flagSet.StringVar(&f.protocURL, "protoc-url", "", "The url to use to download the protoc zip file, otherwise uses GitHub Releases. Setting this option will ignore the config protoc.version setting.")
 }
 
 func (f *flags) bindStdin(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -305,7 +305,7 @@ $ cat input.json | prototool grpc example \
 	configInitCmdTemplate = &cmdTemplate{
 		Use:   "init [dirPath]",
 		Short: "Generate an initial config file in the current or given directory.",
-		Long:  `All available options will be generated and commented out except for "protoc_version". Pass the "--uncomment" flag to uncomment all options.`,
+		Long:  `All available options will be generated and commented out except for "protoc.version". Pass the "--uncomment" flag to uncomment all options.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.Init(args, flags.uncomment)

--- a/internal/cmd/testdata/compile/errors_on_import/prototool.yaml
+++ b/internal/cmd/testdata/compile/errors_on_import/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/compile/errors_on_import/prototool.yaml
+++ b/internal/cmd/testdata/compile/errors_on_import/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/compile/extra_import/prototool.yaml
+++ b/internal/cmd/testdata/compile/extra_import/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/compile/extra_import/prototool.yaml
+++ b/internal/cmd/testdata/compile/extra_import/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/compile/json/prototool.yaml
+++ b/internal/cmd/testdata/compile/json/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/compile/json/prototool.yaml
+++ b/internal/cmd/testdata/compile/json/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/compile/notimported/prototool.yaml
+++ b/internal/cmd/testdata/compile/notimported/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/compile/notimported/prototool.yaml
+++ b/internal/cmd/testdata/compile/notimported/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/compile/proto2/prototool.yaml
+++ b/internal/cmd/testdata/compile/proto2/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/compile/proto2/prototool.yaml
+++ b/internal/cmd/testdata/compile/proto2/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/compile/semicolon/prototool.yaml
+++ b/internal/cmd/testdata/compile/semicolon/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/compile/semicolon/prototool.yaml
+++ b/internal/cmd/testdata/compile/semicolon/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/compile/syntax/prototool.yaml
+++ b/internal/cmd/testdata/compile/syntax/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/compile/syntax/prototool.yaml
+++ b/internal/cmd/testdata/compile/syntax/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/foo/prototool.yaml
+++ b/internal/cmd/testdata/foo/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/foo/prototool.yaml
+++ b/internal/cmd/testdata/foo/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/format-fix/prototool.yaml
+++ b/internal/cmd/testdata/format-fix/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/format-fix/prototool.yaml
+++ b/internal/cmd/testdata/format-fix/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/format/proto2/prototool.yaml
+++ b/internal/cmd/testdata/format/proto2/prototool.yaml
@@ -1,4 +1,3 @@
-protoc_include_wkt: true
 lint:
   rules:
     remove:

--- a/internal/cmd/testdata/format/proto3/prototool.yaml
+++ b/internal/cmd/testdata/format/proto3/prototool.yaml
@@ -1,4 +1,3 @@
-protoc_include_wkt: true
 lint:
   rules:
     remove:

--- a/internal/cmd/testdata/grpc/prototool.yaml
+++ b/internal/cmd/testdata/grpc/prototool.yaml
@@ -1,4 +1,3 @@
-protoc_include_wkt: true
 lint:
   rules:
     remove:

--- a/internal/cmd/testdata/lint/allgroup/prototool.yaml
+++ b/internal/cmd/testdata/lint/allgroup/prototool.yaml
@@ -1,4 +1,3 @@
-protoc_include_wkt: true
 lint:
   rules:
     add:

--- a/internal/cmd/testdata/lint/base/prototool.yaml
+++ b/internal/cmd/testdata/lint/base/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/lint/base/prototool.yaml
+++ b/internal/cmd/testdata/lint/base/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/lint/capitalized/prototool.yaml
+++ b/internal/cmd/testdata/lint/capitalized/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/lint/capitalized/prototool.yaml
+++ b/internal/cmd/testdata/lint/capitalized/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/lint/fileoptions/prototool.yaml
+++ b/internal/cmd/testdata/lint/fileoptions/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/lint/fileoptions/prototool.yaml
+++ b/internal/cmd/testdata/lint/fileoptions/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/lint/keyword/prototool.yaml
+++ b/internal/cmd/testdata/lint/keyword/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/lint/keyword/prototool.yaml
+++ b/internal/cmd/testdata/lint/keyword/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/lint/lots/prototool.yaml
+++ b/internal/cmd/testdata/lint/lots/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/lint/lots/prototool.yaml
+++ b/internal/cmd/testdata/lint/lots/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/lint/required/prototool.yaml
+++ b/internal/cmd/testdata/lint/required/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/lint/required/prototool.yaml
+++ b/internal/cmd/testdata/lint/required/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/cmd/testdata/lint/syntaxproto2/prototool.yaml
+++ b/internal/cmd/testdata/lint/syntaxproto2/prototool.yaml
@@ -1,3 +1,3 @@
-protoc_include_wkt: true
-protoc_includes:
-  - ../
+protoc:
+  includes:
+    - ../

--- a/internal/cmd/testdata/prototool.yaml
+++ b/internal/cmd/testdata/prototool.yaml
@@ -1,2 +1,0 @@
-protoc:
-  include_wkt: true

--- a/internal/cmd/testdata/prototool.yaml
+++ b/internal/cmd/testdata/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_include_wkt: true
+protoc:
+  include_wkt: true

--- a/internal/file/testdata/a/d/prototool.yaml
+++ b/internal/file/testdata/a/d/prototool.yaml
@@ -1,3 +1,4 @@
 excludes:
   - file3.proto
-protoc_version: 3.2.0
+protoc:
+  version: 3.2.0

--- a/internal/file/testdata/b/prototool.yaml
+++ b/internal/file/testdata/b/prototool.yaml
@@ -1,3 +1,4 @@
 excludes:
   - g/h
-protoc_version: 3.3.0
+protoc:
+  version: 3.3.0

--- a/internal/file/testdata/d/prototool.yaml
+++ b/internal/file/testdata/d/prototool.yaml
@@ -1,1 +1,2 @@
-protoc_version: 3.3.0
+protoc:
+  version: 3.3.0

--- a/internal/file/testdata/prototool.yaml
+++ b/internal/file/testdata/prototool.yaml
@@ -1,4 +1,5 @@
 excludes:
   - c/i
   - d
-protoc_version: 3.4.0
+protoc:
+  version: 3.4.0

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -267,7 +267,7 @@ func (c *compiler) getCmdMetas(protoSet *file.ProtoSet) (cmdMetas []*cmdMeta, re
 		}
 	}()
 	// you need a new downloader for every ProtoSet as each prototool.yaml could
-	// have a different protoc_version value
+	// have a different protoc.version value
 	downloader := c.newDownloader(protoSet.Config)
 	if _, err := downloader.Download(); err != nil {
 		return cmdMetas, err

--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -131,8 +131,8 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	includePaths := make([]string, 0, len(e.ProtocIncludes))
-	for _, includePath := range strs.DedupeSort(e.ProtocIncludes, nil) {
+	includePaths := make([]string, 0, len(e.Protoc.Includes))
+	for _, includePath := range strs.DedupeSort(e.Protoc.Includes, nil) {
 		if !filepath.IsAbs(includePath) {
 			includePath = filepath.Join(dirPath, includePath)
 		}
@@ -211,7 +211,7 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 		DirPath:         dirPath,
 		ExcludePrefixes: excludePrefixes,
 		Compile: CompileConfig{
-			ProtobufVersion:       e.ProtocVersion,
+			ProtobufVersion:       e.Protoc.Version,
 			IncludePaths:          includePaths,
 			IncludeWellKnownTypes: true, // Always include the well-known types.
 			AllowUnusedImports:    e.AllowUnusedImports,

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -243,11 +243,13 @@ type OutputPath struct {
 // It is meant to be set by a YAML or JSON config file, or flags.
 type ExternalConfig struct {
 	Excludes           []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
-	ProtocVersion      string   `json:"protoc_version,omitempty" yaml:"protoc_version,omitempty"`
-	ProtocIncludes     []string `json:"protoc_includes,omitempty" yaml:"protoc_includes,omitempty"`
-	ProtocIncludeWKT   bool     `json:"protoc_include_wkt,omitempty" yaml:"protoc_include_wkt,omitempty"`
 	AllowUnusedImports bool     `json:"allow_unused_imports,omitempty" yaml:"allow_unused_imports,omitempty"`
-	Create             struct {
+	Protoc             struct {
+		Version    string   `json:"version,omitempty" yaml:"version,omitempty"`
+		Includes   []string `json:"includes,omitempty" yaml:"includes,omitempty"`
+		IncludeWKT bool     `json:"include_wkt,omitempty" yaml:"include_wkt,omitempty"`
+	} `json:"protoc,omitempty" yaml:"protoc,omitempty"`
+	Create struct {
 		Packages []struct {
 			Directory string `json:"directory,omitempty" yaml:"directory,omitempty"`
 			Name      string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -242,12 +242,11 @@ type OutputPath struct {
 //
 // It is meant to be set by a YAML or JSON config file, or flags.
 type ExternalConfig struct {
-	Excludes           []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
 	AllowUnusedImports bool     `json:"allow_unused_imports,omitempty" yaml:"allow_unused_imports,omitempty"`
+	Excludes           []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
 	Protoc             struct {
-		Version    string   `json:"version,omitempty" yaml:"version,omitempty"`
-		Includes   []string `json:"includes,omitempty" yaml:"includes,omitempty"`
-		IncludeWKT bool     `json:"include_wkt,omitempty" yaml:"include_wkt,omitempty"`
+		Version  string   `json:"version,omitempty" yaml:"version,omitempty"`
+		Includes []string `json:"includes,omitempty" yaml:"includes,omitempty"`
 	} `json:"protoc,omitempty" yaml:"protoc,omitempty"`
 	Create struct {
 		Packages []struct {
@@ -265,7 +264,6 @@ type ExternalConfig struct {
 			Add       []string `json:"add" yaml:"add"`
 			Remove    []string `json:"remove" yaml:"remove"`
 		}
-		Group string `json:"group,omitempty" yaml:"group,omitempty"`
 	} `json:"lint,omitempty" yaml:"lint,omitempty"`
 	Gen struct {
 		GoOptions struct {


### PR DESCRIPTION
Simple refactor to encapsulate the `protoc_includes` and `protoc_version` settings under a `protoc` key.