### PR TITLE
Fix 'config init' regression

### DIFF
--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -39,7 +39,7 @@ var tmpl = template.Must(template.New("tmpl").Parse(`# The Protobuf version to u
 {{.V}}  - path/to/b/file.proto
 
 # Protoc directives.
-{{.V}}protoc:
+protoc:
   # By default use {{.ProtocVersion}}.
   # You probably want to set this to make your builds completely reproducible.
   version: {{.ProtocVersion}}


### PR DESCRIPTION
The introduction of the separate `protoc` key caused a small regression in the `config init` command. This explicitly uncomments `protoc` (along with `version`), as before.