### PR TITLE
Cleanup cfginit

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -1,12 +1,12 @@
 # The Protobuf version to use from https://github.com/google/protobuf/releases.
-# If not set, compile will fail if there are unused imports.
-# Setting this will ignore unused imports.
-allow_unused_imports: true
-
 # Paths to exclude from protoc.
 excludes:
   - path/to/a
   - path/to/b/file.proto
+
+# If not set, compile will fail if there are unused imports.
+# Setting this will ignore unused imports.
+allow_unused_imports: true
 
 # Protoc directives.
 protoc:
@@ -63,7 +63,7 @@ lint:
 
 # Code generation directives.
 gen:
-  # Options that will apply to all plugins of type go, gogo, gogrpc, gogogrpc.
+  # Options that will apply to all plugins of type go and gogo.
   go_options:
     # The base import path. This should be the go path of the prototool.yaml file.
     # This is required if you have any go plugins.

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -1,5 +1,4 @@
-# The Protobuf version to use from https://github.com/google/protobuf/releases.
-# Paths to exclude from protoc.
+# Paths to exclude when searching for Protobuf files.
 excludes:
   - path/to/a
   - path/to/b/file.proto
@@ -10,6 +9,7 @@ allow_unused_imports: true
 
 # Protoc directives.
 protoc:
+  # The Protobuf version to use from https://github.com/google/protobuf/releases.
   # By default use 3.6.1.
   # You probably want to set this to make your builds completely reproducible.
   version: 3.6.1

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -28,8 +28,7 @@ import (
 	"html/template"
 )
 
-var tmpl = template.Must(template.New("tmpl").Parse(`# The Protobuf version to use from https://github.com/google/protobuf/releases.
-# Paths to exclude from protoc.
+var tmpl = template.Must(template.New("tmpl").Parse(`# Paths to exclude when searching for Protobuf files.
 {{.V}}excludes:
 {{.V}}  - path/to/a
 {{.V}}  - path/to/b/file.proto
@@ -40,6 +39,7 @@ var tmpl = template.Must(template.New("tmpl").Parse(`# The Protobuf version to u
 
 # Protoc directives.
 protoc:
+  # The Protobuf version to use from https://github.com/google/protobuf/releases.
   # By default use {{.ProtocVersion}}.
   # You probably want to set this to make your builds completely reproducible.
   version: {{.ProtocVersion}}

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -29,14 +29,14 @@ import (
 )
 
 var tmpl = template.Must(template.New("tmpl").Parse(`# The Protobuf version to use from https://github.com/google/protobuf/releases.
-# If not set, compile will fail if there are unused imports.
-# Setting this will ignore unused imports.
-{{.V}}allow_unused_imports: true
-
 # Paths to exclude from protoc.
 {{.V}}excludes:
 {{.V}}  - path/to/a
 {{.V}}  - path/to/b/file.proto
+
+# If not set, compile will fail if there are unused imports.
+# Setting this will ignore unused imports.
+{{.V}}allow_unused_imports: true
 
 # Protoc directives.
 protoc:
@@ -93,7 +93,7 @@ protoc:
 
 # Code generation directives.
 {{.V}}gen:
-  # Options that will apply to all plugins of type go, gogo, gogrpc, gogogrpc.
+  # Options that will apply to all plugins of type go and gogo.
 {{.V}}  go_options:
     # The base import path. This should be the go path of the prototool.yaml file.
     # This is required if you have any go plugins.


### PR DESCRIPTION
- Move `allow_unused_imports` below `excludes` as `excludes` feels like it should be a "higher" option than `allow_unused_imports` in terms of importance at the top-level.
- Remove references to plugin types `gogrpc` and `gogogrpc`, these were plugin types in an earlier development version.
- Move a comment for `protoc.version` to the correct place. It was probably missed as it was on the first line of the template.
- Have `excludes` not reference `protoc` as it is not protoc-specific.