### PR TITLE
Move global protoc-url flag under applicable commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Move `protoc_includes` and `protoc_version` settings under `protoc` key.
 - Move `allow_unused_imports` to `protoc.allow_unused_imports`.
+- Move `protoc-url` global flag under the applicable commands: all,
+  compile, format, gen, and lint.
 
 
 ## [0.6.0] - 2018-08-03

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -115,7 +115,6 @@ func getRootCommand(exitCodeAddr *int, develMode bool, args []string, stdin io.R
 
 	// flags bound to rootCmd are global flags
 	flags.bindDebug(rootCmd.PersistentFlags())
-	flags.bindProtocURL(rootCmd.PersistentFlags())
 
 	if develMode {
 		rootCmd.AddCommand(binaryToJSONCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -48,6 +48,7 @@ var (
 			flags.bindDisableFormat(flagSet)
 			flags.bindDisableLint(flagSet)
 			flags.bindFix(flagSet)
+			flags.bindProtocURL(flagSet)
 		},
 	}
 
@@ -79,6 +80,7 @@ var (
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindDryRun(flagSet)
+			flags.bindProtocURL(flagSet)
 		},
 	}
 
@@ -200,6 +202,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindLintMode(flagSet)
 			flags.bindOverwrite(flagSet)
 			flags.bindFix(flagSet)
+			flags.bindProtocURL(flagSet)
 		},
 	}
 
@@ -212,6 +215,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindDryRun(flagSet)
+			flags.bindProtocURL(flagSet)
 		},
 	}
 
@@ -299,6 +303,7 @@ $ cat input.json | prototool grpc example \
 			flags.bindKeepaliveTime(flagSet)
 			flags.bindMethod(flagSet)
 			flags.bindStdin(flagSet)
+			flags.bindProtocURL(flagSet)
 		},
 	}
 
@@ -335,6 +340,7 @@ $ cat input.json | prototool grpc example \
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindListAllLinters(flagSet)
 			flags.bindListLinters(flagSet)
+			flags.bindProtocURL(flagSet)
 		},
 	}
 


### PR DESCRIPTION
The `protoc-url` global flag only applies to several commands. This moves the flag under these commands explicitly.
