### PR TITLE
Add linter to verify that the go_package option is not of the long-form

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -331,6 +331,12 @@ func TestLint(t *testing.T) {
 		1:1:FILE_OPTIONS_REQUIRE_JAVA_PACKAGE`,
 		"testdata/lint/keyword/package_starts_with_keyword.proto",
 	)
+	assertDoLintFile(
+		t,
+		false,
+		`5:1:FILE_OPTIONS_GO_PACKAGE_NOT_LONG_FORM`,
+		"testdata/lint/gopackagelongform/gopackagelongform.proto",
+	)
 }
 
 func TestGoldenFormat(t *testing.T) {

--- a/internal/cmd/testdata/lint/gopackagelongform/gopackagelongform.proto
+++ b/internal/cmd/testdata/lint/gopackagelongform/gopackagelongform.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package foo;
+
+option go_package = "path/to/foo;foopb";
+option java_multiple_files = true;
+option java_outer_classname = "GopackagelongformProto";
+option java_package = "com.foo";

--- a/internal/cmd/testdata/lint/gopackagelongform/prototool.yaml
+++ b/internal/cmd/testdata/lint/gopackagelongform/prototool.yaml
@@ -1,0 +1,4 @@
+lint:
+  rules:
+    remove:
+      - FILE_OPTIONS_EQUAL_GO_PACKAGE_PB_SUFFIX

--- a/internal/lint/check_go_package_not_long_form.go
+++ b/internal/lint/check_go_package_not_long_form.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package lint
+
+import (
+	"strings"
+
+	"github.com/emicklei/proto"
+	"github.com/uber/prototool/internal/text"
+)
+
+var fileOptionsGoPackageNotLongFormLinter = NewLinter(
+	"FILE_OPTIONS_GO_PACKAGE_NOT_LONG_FORM",
+	`Verifies that the file option "go_package" is not of the form "go/import/path;package".`,
+	checkFileOptionsGoPackageNotLongForm,
+)
+
+func checkFileOptionsGoPackageNotLongForm(add func(*text.Failure), dirPath string, descriptors []*proto.Proto) error {
+	return runVisitor(&fileOptionsGoPackageNotLongFormVisitor{baseAddVisitor: newBaseAddVisitor(add)}, descriptors)
+}
+
+type fileOptionsGoPackageNotLongFormVisitor struct {
+	baseAddVisitor
+
+	option *proto.Option
+}
+
+func (v *fileOptionsGoPackageNotLongFormVisitor) OnStart(descriptor *proto.Proto) error {
+	v.option = nil
+	return nil
+}
+
+func (v *fileOptionsGoPackageNotLongFormVisitor) VisitOption(element *proto.Option) {
+	if element.Name == "go_package" {
+		v.option = element
+	}
+}
+
+func (v *fileOptionsGoPackageNotLongFormVisitor) Finally() error {
+	if v.option == nil {
+		return nil
+	}
+	value := v.option.Constant.Source
+	if strings.Contains(value, ";") {
+		v.AddFailuref(v.option.Position, `Option "go_package" cannot be of the long-form "go/import/path;package" and must only be of the short-form "package", but was %q.`, value)
+	}
+	return nil
+}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -48,6 +48,7 @@ var (
 		fileOptionsEqualJavaMultipleFilesTrueLinter,
 		fileOptionsEqualJavaOuterClassnameProtoSuffixLinter,
 		fileOptionsEqualJavaPackageComPrefixLinter,
+		fileOptionsGoPackageNotLongFormLinter,
 		fileOptionsGoPackageSameInDirLinter,
 		fileOptionsJavaMultipleFilesSameInDirLinter,
 		fileOptionsJavaPackageSameInDirLinter,


### PR DESCRIPTION
This doesn't actually change the current default lint setup in terms of failure or not, as the pb suffix linter would fail regardless, but this makes this explicit.