### PR TITLE
Fix spelling s/TRAFIIC/TRAFFIC/ in style guide

### DIFF
--- a/etc/style/uber/uber.proto
+++ b/etc/style/uber/uber.proto
@@ -100,7 +100,7 @@ import "google/protobuf/empty.proto";
 // must be explicitly set. For example:
 //
 // enum TrafficLight {
-//     TRAFIIC_LIGHT_INVALID = 0;
+//     TRAFFIC_LIGHT_INVALID = 0;
 //     TRAFFIC_LIGHT_UNSET = 1;
 //     TRAFFIC_LIGHT_GREEN = 2;
 //     TRAFFIC_LIGHT_YELLOW = 3;


### PR DESCRIPTION
Thank you for maintaining this style guide. It's turning out to be very useful for reducing review comments on protobuf schemas.