### PR TITLE
Do not duplicate Golang modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Fixed an issue where Golang `Mname=package` modifiers were being duplicated.
 
 
 ## [0.7.0] - 2018-08-09

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -457,19 +457,20 @@ func getPluginFlagSetProtoFlags(protoSet *file.ProtoSet, dirPath string, genPlug
 				modifiers[path] = filepath.Clean(filepath.Join(genGoPluginOptions.ImportPath, genPlugin.OutputPath.RelPath, filepath.Dir(path)))
 			}
 		}
-		for key, value := range modifiers {
-			goFlags = append(goFlags, fmt.Sprintf("M%s=%s", key, value))
+	}
+	for key, value := range modifiers {
+		goFlags = append(goFlags, fmt.Sprintf("M%s=%s", key, value))
+	}
+	if protoSet.Config.Compile.IncludeWellKnownTypes {
+		var wktModifiers map[string]string
+		// one of these two must be true, we validate this above
+		if genPlugin.Type.IsGo() {
+			wktModifiers = wkt.FilenameToGoModifierMap
+		} else if genPlugin.Type.IsGogo() {
+			wktModifiers = wkt.FilenameToGogoModifierMap
 		}
-		if protoSet.Config.Compile.IncludeWellKnownTypes {
-			// one of these two must be true, we validate this above
-			if genPlugin.Type.IsGo() {
-				modifiers = wkt.FilenameToGoModifierMap
-			} else if genPlugin.Type.IsGogo() {
-				modifiers = wkt.FilenameToGogoModifierMap
-			}
-			for key, value := range modifiers {
-				goFlags = append(goFlags, fmt.Sprintf("M%s=%s", key, value))
-			}
+		for key, value := range wktModifiers {
+			goFlags = append(goFlags, fmt.Sprintf("M%s=%s", key, value))
 		}
 	}
 	for key, value := range genGoPluginOptions.ExtraModifiers {


### PR DESCRIPTION
Fixes #187. We were duplicating the `Mname=package` values in almost an n^2 way.