### PR TITLE
Fix reference to vars package in releasegen.sh and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ vendor:
 .PHONY: install
 install:
 	go install \
-		-ldflags "-X 'github.com/uber/prototool/internal/x/vars.GitCommit=$(shell git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/x/vars.BuiltTimestamp=$(shell date -u)'" \
+		-ldflags "-X 'github.com/uber/prototool/internal/vars.GitCommit=$(shell git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/vars.BuiltTimestamp=$(shell date -u)'" \
 		$(BINS)
 
 .PHONY: license

--- a/etc/bin/releasegen.sh
+++ b/etc/bin/releasegen.sh
@@ -39,7 +39,7 @@ for os in Darwin Linux; do
       go build \
       -a \
       -installsuffix cgo \
-      -ldflags "-X 'github.com/uber/prototool/internal/x/vars.GitCommit=$(git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/x/vars.BuiltTimestamp=$(date -u)'" \
+      -ldflags "-X 'github.com/uber/prototool/internal/vars.GitCommit=$(git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/vars.BuiltTimestamp=$(date -u)'" \
       -o "${dir}/bin/prototool" \
       internal/cmd/prototool/main.go
     tar -C "${tar_context_dir}" -cvzf "${BASE_DIR}/prototool-${os}-${arch}.tar.gz" "${tar_dir}"


### PR DESCRIPTION
The `GitCommit` and `BuiltTimestamp` variables are set when building the `prototool` binary. This is useful information for debugging that is printed out when calling `prototool version`. These used to be printed, but since we moved the `internal/x/vars` package to `internal/vars`, they no longer were due to the name being incorrect in `etc/bin/releasegen.sh` and `Makefile`.

This fixes the output of `prototool version` from:

```
Version:                 0.8.0-dev
Default protoc version:  3.6.1
Go version:              go1.10.3
OS/Arch:                 darwin/amd64
```

to:

```
Version:                 0.8.0-dev
Default protoc version:  3.6.1
Go version:              go1.10.3
Git commit:              27ff56cd54bbd3944b8639a5ffe7afc47572f30e
Built:                   Wed Aug 15 20:04:48 UTC 2018
OS/Arch:                 darwin/amd64
```

For the record, this was originally loosely patterned after the output of `docker version`:

```
$ docker version
Client:
 Version:	18.03.0-ce-rc1
 API version:	1.37
 Go version:	go1.9.4
 Git commit:	c160c73
 Built:	Thu Feb 22 02:34:03 2018
 OS/Arch:	darwin/amd64
 Experimental:	false
 Orchestrator:	swarm

Server:
 Engine:
  Version:	18.03.0-ce-rc1
  API version:	1.37 (minimum version 1.12)
  Go version:	go1.9.4
  Git commit:	c160c73
  Built:	Thu Feb 22 02:42:37 2018
  OS/Arch:	linux/amd64
  Experimental:	true
```