### PR TITLE
Move from github.com/google/protobuf to github.com/protocolbuffers/protobuf

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -5,7 +5,7 @@ excludes:
 
 # Protoc directives.
 protoc:
-  # The Protobuf version to use from https://github.com/google/protobuf/releases.
+  # The Protobuf version to use from https://github.com/protocolbuffers/protobuf/releases.
   # By default use 3.6.1.
   # You probably want to set this to make your builds completely reproducible.
   version: 3.6.1

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -35,7 +35,7 @@ var tmpl = template.Must(template.New("tmpl").Parse(`# Paths to exclude when sea
 
 # Protoc directives.
 protoc:
-  # The Protobuf version to use from https://github.com/google/protobuf/releases.
+  # The Protobuf version to use from https://github.com/protocolbuffers/protobuf/releases.
   # By default use {{.ProtocVersion}}.
   # You probably want to set this to make your builds completely reproducible.
   version: {{.ProtocVersion}}

--- a/internal/extract/getter.go
+++ b/internal/extract/getter.go
@@ -166,7 +166,7 @@ func (g *getter) GetService(fileDescriptorSets []*descriptor.FileDescriptorSet, 
 }
 
 // TODO: we don't actually do full path resolution per the descriptor.proto spec
-// https://github.com/google/protobuf/blob/master/src/google/protobuf/descriptor.proto#L185
+// https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L185
 
 func findDescriptorProto(path string, fileDescriptorProto *descriptor.FileDescriptorProto) (*descriptor.DescriptorProto, error) {
 	if fileDescriptorProto.GetPackage() == "" {

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -221,7 +221,7 @@ func (d *downloader) getDownloadData(goos string, goarch string) (_ []byte, retE
 			// download this from GitHub Releases, so add
 			// extra context to the error message
 			if d.protocURL == "" {
-				return nil, fmt.Errorf("error downloading %s: %v\nMake sure GitHub Releases has a proper protoc zip file of the form protoc-VERSION-OS-ARCH.zip at https://github.com/google/protobuf/releases/v%s\nNote that many micro versions do not have this, and no version before 3.0.0-beta-2 has this", url, err, d.config.Compile.ProtobufVersion)
+				return nil, fmt.Errorf("error downloading %s: %v\nMake sure GitHub Releases has a proper protoc zip file of the form protoc-VERSION-OS-ARCH.zip at https://github.com/protocolbuffers/protobuf/releases/v%s\nNote that many micro versions do not have this, and no version before 3.0.0-beta-2 has this", url, err, d.config.Compile.ProtobufVersion)
 			}
 			return nil, err
 		}
@@ -250,7 +250,7 @@ func (d *downloader) getProtocURL(goos string, goarch string) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf(
-		"https://github.com/google/protobuf/releases/download/v%s/protoc-%s-%s-%s.zip",
+		"https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s-%s.zip",
 		d.config.Compile.ProtobufVersion,
 		d.config.Compile.ProtobufVersion,
 		protocS,

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -86,7 +86,7 @@ func DownloaderWithCachePath(cachePath string) DownloaderOption {
 
 // DownloaderWithProtocURL returns a DownloaderOption that uses the given protoc zip file URL.
 //
-// The default is https://github.com/google/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
+// The default is https://github.com/protocolbuffers/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
 func DownloaderWithProtocURL(protocURL string) DownloaderOption {
 	return func(downloader *downloader) {
 		downloader.protocURL = protocURL
@@ -148,7 +148,7 @@ func CompilerWithCachePath(cachePath string) CompilerOption {
 
 // CompilerWithProtocURL returns a CompilerOption that uses the given protoc zip file URL.
 //
-// The default is https://github.com/google/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
+// The default is https://github.com/protocolbuffers/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
 func CompilerWithProtocURL(protocURL string) CompilerOption {
 	return func(compiler *compiler) {
 		compiler.protocURL = protocURL

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -140,7 +140,7 @@ type Config struct {
 
 // CompileConfig is the compile config.
 type CompileConfig struct {
-	// The Protobuf version to use from https://github.com/google/protobuf/releases.
+	// The Protobuf version to use from https://github.com/protocolbuffers/protobuf/releases.
 	// Must have a valid protoc zip file asset, so for example 3.5.0 is a valid version
 	// but 3.5.0.1 is not.
 	ProtobufVersion string

--- a/internal/vars/vars.go
+++ b/internal/vars/vars.go
@@ -28,9 +28,9 @@ const (
 	Version = "1.0.0-dev"
 
 	// DefaultProtocVersion is the default version of protoc from
-	// github.com/google/protobuf to use.
+	// github.com/protocolbuffers/protobuf to use.
 	//
-	// See https://github.com/google/protobuf/releases for the latest release.
+	// See https://github.com/protocolbuffers/protobuf/releases for the latest release.
 	DefaultProtocVersion = "3.6.1"
 )
 


### PR DESCRIPTION
Google just moved the protobuf repository to another organization. The code would likely be functionally the same via redirects, but this updates the references. Note this is effectively just for downloading `protoc`, the Golang Protobuf library is still at github.com/golang/protobuf.