### PR TITLE
Add script to generate assets for Homebrew and update README.md installation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.glide
 /.idea
+/brew
 /example/gen/proto/java
 /cover
 /cover.html

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,10 @@ releasegen: internalgen
 		$(DOCKER_IMAGE) \
 		bash -x etc/bin/releasegen.sh
 
+.PHONY: brewgen
+brewgen:
+	sh etc/bin/brewgen.sh
+
 .PHONY: releaseinstall
 releaseinstall: releasegen releaseclean
 	tar -C /usr/local --strip-components 1 -xzf release/prototool-$(shell uname -s)-$(shell uname -m).tar.gz

--- a/README.md
+++ b/README.md
@@ -37,7 +37,22 @@ Prototool accomplishes this by downloading and calling protoc on the fly for you
 
 ## Installation
 
-Install Prototool from GitHub Releases.
+Prototool can be installed on Mac OS X via [Homebrew](https://brew.sh/).
+
+```
+brew install prototool
+```
+
+This installs the `prototool` binary, along with bash completion, zsh completion, and man pages.
+You can also install all of the assets on Linux or without Homebrew from GitHub Releases.
+
+```
+curl -sSL https://github.com/uber/prototool/releases/download/v1.0.0/prototool-$(uname -s)-$(uname -m).tar.gz | \
+  tar -C /usr/local --strip-components 1 -xz`
+```
+
+If you do not want to install bash completion, zsh completion, or man mages, you can install just the
+`prototool` binary from GitHub Releases as well.
 
 ```
 curl -sSL https://github.com/uber/prototool/releases/download/v1.0.0/prototool-$(uname -s)-$(uname -m) \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -133,7 +133,7 @@ This document outlines how to create a release of prototool.
     ```
 
     Then, fork github.com/homebrew/homebrew-core if you have not already, and create
-    a new branch named "prototool-$VERSION". Update `Formula/prototool.pb` to use
+    a new branch named "prototool-$VERSION". Update `Formula/prototool.rb` to use
     the new version and SHA-256 hash.
 
     ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -137,8 +137,8 @@ This document outlines how to create a release of prototool.
     the new version and SHA-256 hash.
 
     ```
-    #url "https://github.com/uber/prototool/archive/v1.22.0.tar.gz"
-    #sha256 "NEW_SHA_256_HASH_FROM_ABOVE"
+    url "https://github.com/uber/prototool/archive/v1.22.0.tar.gz"
+    sha256 "NEW_SHA_256_HASH_FROM_ABOVE"
     ```
 
     Create a commit with the message "prototool $VERSION" and open a PR with the same name.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -122,3 +122,23 @@ This document outlines how to create a release of prototool.
     git commit -m 'Back to development'
     git push origin $BRANCH
     ```
+
+15. Update the formula in https://github.com/homebrew/homebrew-core. First, download
+    the newly created source tarball and compute the SHA-256 hash.
+
+    ```
+    # Use "sha256sum" instead of "shasum -a 256" on Linux.
+    # Do not forget the -sSL or you will get the wrong hash.
+    curl -sSL https://github.com/uber/prototool/archive/v1.22.0.tar.gz | shasum -a 256 | cut -f 1 -d ' '
+    ```
+
+    Then, fork github.com/homebrew/homebrew-core if you have not already, and create
+    a new branch named "prototool-$VERSION". Update `Formula/prototool.pb` to use
+    the new version and SHA-256 hash.
+
+    ```
+    #url "https://github.com/uber/prototool/archive/v1.22.0.tar.gz"
+    #sha256 "NEW_SHA_256_HASH_FROM_ABOVE"
+    ```
+
+    Create a commit with the message "prototool $VERSION" and open a PR with the same name.

--- a/etc/bin/brewgen.sh
+++ b/etc/bin/brewgen.sh
@@ -15,7 +15,7 @@ mkdir -p "${BUILD_DIR}/etc/bash_completion.d"
 mkdir -p "${BUILD_DIR}/etc/zsh/site-functions"
 mkdir -p "${BUILD_DIR}/share/man/man1"
 go run internal/cmd/gen-prototool-bash-completion/main.go > "${BUILD_DIR}/etc/bash_completion.d/prototool"
-go run internal/cmd/gen-prototool-zsh-completion/main.go > "${BUILD_DIR}/etc/zsh/site-functions/prototool"
+go run internal/cmd/gen-prototool-zsh-completion/main.go > "${BUILD_DIR}/etc/zsh/site-functions/_prototool"
 go run internal/cmd/gen-prototool-manpages/main.go "${BUILD_DIR}/share/man/man1"
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
   go build \

--- a/etc/bin/brewgen.sh
+++ b/etc/bin/brewgen.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${0}")/../.." && pwd)"
+cd "${DIR}"
+
+BUILD_DIR="brew"
+
+rm -rf vendor
+glide install
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}/bin"
+mkdir -p "${BUILD_DIR}/etc/bash_completion.d"
+mkdir -p "${BUILD_DIR}/etc/zsh_completion.d"
+mkdir -p "${BUILD_DIR}/share/man/man1"
+go run internal/cmd/gen-prototool-bash-completion/main.go > "${BUILD_DIR}/etc/bash_completion.d/prototool"
+go run internal/cmd/gen-prototool-zsh-completion/main.go > "${BUILD_DIR}/etc/zsh_completion.d/prototool"
+go run internal/cmd/gen-prototool-manpages/main.go "${BUILD_DIR}/share/man/man1"
+CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
+  go build \
+  -a \
+  -installsuffix cgo \
+  -ldflags "-X 'github.com/uber/prototool/internal/vars.GitCommit=$(git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/vars.BuiltTimestamp=$(date -u)'" \
+  -o "${BUILD_DIR}/bin/prototool" \
+  internal/cmd/prototool/main.go

--- a/etc/bin/brewgen.sh
+++ b/etc/bin/brewgen.sh
@@ -12,10 +12,10 @@ glide install
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}/bin"
 mkdir -p "${BUILD_DIR}/etc/bash_completion.d"
-mkdir -p "${BUILD_DIR}/etc/zsh_completion.d"
+mkdir -p "${BUILD_DIR}/etc/zsh/site-functions"
 mkdir -p "${BUILD_DIR}/share/man/man1"
 go run internal/cmd/gen-prototool-bash-completion/main.go > "${BUILD_DIR}/etc/bash_completion.d/prototool"
-go run internal/cmd/gen-prototool-zsh-completion/main.go > "${BUILD_DIR}/etc/zsh_completion.d/prototool"
+go run internal/cmd/gen-prototool-zsh-completion/main.go > "${BUILD_DIR}/etc/zsh/site-functions/prototool"
 go run internal/cmd/gen-prototool-manpages/main.go "${BUILD_DIR}/share/man/man1"
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
   go build \

--- a/etc/bin/releasegen.sh
+++ b/etc/bin/releasegen.sh
@@ -35,7 +35,7 @@ for os in Darwin Linux; do
     mkdir -p "${dir}/etc/zsh/site-functions"
     mkdir -p "${dir}/share/man/man1"
     go run internal/cmd/gen-prototool-bash-completion/main.go > "${dir}/etc/bash_completion.d/prototool"
-    go run internal/cmd/gen-prototool-zsh-completion/main.go > "${dir}/etc/zsh/site-functions/prototool"
+    go run internal/cmd/gen-prototool-zsh-completion/main.go > "${dir}/etc/zsh/site-functions/_prototool"
     go run internal/cmd/gen-prototool-manpages/main.go "${dir}/share/man/man1"
     CGO_ENABLED=0 GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
       go build \

--- a/etc/bin/releasegen.sh
+++ b/etc/bin/releasegen.sh
@@ -21,8 +21,10 @@ goarch() {
 }
 
 BASE_DIR="release"
-rm -rf "${BASE_DIR}"
 
+rm -rf vendor
+glide install
+rm -rf "${BASE_DIR}"
 for os in Darwin Linux; do
   for arch in x86_64; do
     dir="${BASE_DIR}/${os}/${arch}/prototool"
@@ -30,10 +32,10 @@ for os in Darwin Linux; do
     tar_dir="prototool"
     mkdir -p "${dir}/bin"
     mkdir -p "${dir}/etc/bash_completion.d"
-    mkdir -p "${dir}/etc/zsh_completion.d"
+    mkdir -p "${dir}/etc/zsh/site-functions"
     mkdir -p "${dir}/share/man/man1"
     go run internal/cmd/gen-prototool-bash-completion/main.go > "${dir}/etc/bash_completion.d/prototool"
-    go run internal/cmd/gen-prototool-zsh-completion/main.go > "${dir}/etc/zsh_completion.d/prototool"
+    go run internal/cmd/gen-prototool-zsh-completion/main.go > "${dir}/etc/zsh/site-functions/prototool"
     go run internal/cmd/gen-prototool-manpages/main.go "${dir}/share/man/man1"
     CGO_ENABLED=0 GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
       go build \


### PR DESCRIPTION
This fixes #203, and also inadvertently fixes #191. This also updates the zsh location for `/usr/local` to the correct location, and calls `rm -rf vendor` and then `glide install` in `etc/bin/releasegen.sh` as I mentioned we should do in #204.

This adds helper functionality to build Prototool for Homebrew. In #203, there's a question about whether to do this in our own Tap versus homebrew-core - I personally vote for homebrew-core, as once the initial formula is added, the maintainers are *extremely* quick to update to new versions, and it reduces the complexity for external developers. We've gotten some great feedback, including discovery of some nasty bugs, from external developers, so anything we can do to increase that pipeline, especially now that this is v1.0, would be valuable. If there's a separate tap, external developers will instinctively be less likely to install (at least that would be my instinct, for whatever that's worth).

For the same reason, I'm in favor of doing this sooner than later - customer demand is sort of a chicken and egg problem, if we make it easier for customers to install Prototool, we'll have more demand. @AlexAPB @amckinney @abhinav thoughts?

This adds `etc/bin/brewgen.sh`, which is effectively a customized `etc/bin/releasegen.sh`. We could merge the two scripts, but doing so (and then having options in each script) ends up being just as complicated, if not more bug prone.

This also adds `make brewgen`, which is what the formula calls. We could just call the script directly in the Homebrew formula and remove the `automake` dependency, but we later might want to move more functionality into the Makefile for the build, so this makes it easier to do so.

The corresponding formula can be seen at https://github.com/peter-edge/homebrew-core/compare/master...peter-edge:prototool-1.0.0?expand=1 - note that `--HEAD` will not work right now, as this PR would need to be merged first. I've tested this locally, and it's pretty cool.

```
$ brew info prototool
prototool: stable v1.0.0, HEAD
Your Swiss Army Knife for Protocol Buffers
https://github.com/uber/prototool
/usr/local/Cellar/prototool/v1.0.0 (17 files, 16.6MB) *
  Built from source on 2018-08-24 at 17:26:56
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/prototool.rb
==> Dependencies
Build: automake ✔, glide ✔, go ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh functions have been installed to:
  /usr/local/share/zsh/site-functions
```

This formula will also need to be updated - assumedly, if we merge this, we'll need to do a `v1.1.0` for the changes here, and then the Formula will be updated to have this version and sha256, as opposed to pointing to this branch.

Homebrew is really easy to use, so this results in the bash completion, zsh completion, and man pages being installed as well. Future updates to homebrew-core will be extremely easy since all the build functionality is wrapped in the `etc/bin/brewgen.sh` script.