### PR TITLE
Fix etc/bin/releasegen.sh and CHANGELOG.md link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial release.
 
 [Unreleased]: https://github.com/uber/prototool/compare/v1.1.0...HEAD
-[1.1.0]: https://github.com/uber/prototool/compare/v1.1.0...v1.0.0
+[1.1.0]: https://github.com/uber/prototool/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/uber/prototool/compare/v1.0.0-rc1...v1.0.0
 [1.0.0-rc1]: https://github.com/uber/prototool/compare/v0.7.1...v1.0.0-rc1
 [0.7.1]: https://github.com/uber/prototool/compare/v0.7.0...v0.7.1

--- a/etc/bin/releasegen.sh
+++ b/etc/bin/releasegen.sh
@@ -22,6 +22,7 @@ goarch() {
 
 BASE_DIR="release"
 
+go get github.com/Masterminds/glide
 rm -rf vendor
 glide install
 rm -rf "${BASE_DIR}"


### PR DESCRIPTION
The release script had an issue where `glide` needed to be installed, and I also got the links backward for `v1.1.0`.