### PR TITLE
TEMPORARY FIX: Note that brew install prototool will not work until the homebrew-core PR is merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Prototool accomplishes this by downloading and calling protoc on the fly for you
 
 ## Installation
 
-Prototool can be installed on Mac OS X via [Homebrew](https://brew.sh/).
+NEW: Once [this PR](https://github.com/Homebrew/homebrew-core/pull/31440) is merged, Prototool will be able to be installed on Mac OS X via [Homebrew](https://brew.sh/).
 
 ```bash
 brew install prototool


### PR DESCRIPTION
I jumped the gun a bit here - we want to make sure the homebrew-core maintainers are OK with Prototool being added and that the [PR](https://github.com/Homebrew/homebrew-core/pull/31440) is merged. As of now, the installation instructions are incorrect. We'll revert this once the PR is (hopefully) merged.