### PR TITLE
Add go 1.11 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
   - "1.10"
+  - "1.11"
 script:
   - make ci


### PR DESCRIPTION
The newest golang version is released at 1.11
(https://golang.org/doc/go1.11).
