### PR TITLE
Add JSON flag for JSON-encoded compile and lint failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- Add `json` flag to `all`, `compile`, `format`, `generate` and `lint` commands.
 
 
 ## [1.1.0] - 2018-08-24

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -38,6 +38,7 @@ type flags struct {
 	fix            bool
 	headers        []string
 	keepaliveTime  string
+	json           bool
 	listAllLinters bool
 	listLinters    bool
 	lintMode       bool
@@ -96,6 +97,10 @@ func (f *flags) bindHeaders(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindKeepaliveTime(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.keepaliveTime, "keepalive-time", "", "The maximum idle time after which a keepalive probe is sent.")
+}
+
+func (f *flags) bindJSON(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.json, "json", false, "Output as JSON.")
 }
 
 func (f *flags) bindLintMode(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -47,6 +47,7 @@ var (
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindDisableFormat(flagSet)
 			flags.bindDisableLint(flagSet)
+			flags.bindJSON(flagSet)
 			flags.bindFix(flagSet)
 			flags.bindProtocURL(flagSet)
 		},
@@ -80,6 +81,7 @@ var (
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindDryRun(flagSet)
+			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
 		},
 	}
@@ -199,6 +201,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindDiffMode(flagSet)
+			flags.bindJSON(flagSet)
 			flags.bindLintMode(flagSet)
 			flags.bindOverwrite(flagSet)
 			flags.bindFix(flagSet)
@@ -215,6 +218,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindDryRun(flagSet)
+			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
 		},
 	}
@@ -338,6 +342,7 @@ $ cat input.json | prototool grpc example \
 			return runner.Lint(args, flags.listAllLinters, flags.listLinters)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindJSON(flagSet)
 			flags.bindListAllLinters(flagSet)
 			flags.bindListLinters(flagSet)
 			flags.bindProtocURL(flagSet)
@@ -458,6 +463,12 @@ func getRunner(stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags
 		runnerOptions = append(
 			runnerOptions,
 			exec.RunnerWithCachePath(flags.cachePath),
+		)
+	}
+	if flags.json {
+		runnerOptions = append(
+			runnerOptions,
+			exec.RunnerWithJSON(),
 		)
 	}
 	if flags.printFields != "" {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -85,10 +85,10 @@ func RunnerWithCachePath(cachePath string) RunnerOption {
 	}
 }
 
-// RunnerWithProtocURL returns a RunnerOption that uses the given protoc zip file URL.
-func RunnerWithProtocURL(protocURL string) RunnerOption {
+// RunnerWithJSON returns a RunnerOption that will print failures as JSON.
+func RunnerWithJSON() RunnerOption {
 	return func(runner *runner) {
-		runner.protocURL = protocURL
+		runner.json = true
 	}
 }
 
@@ -97,6 +97,13 @@ func RunnerWithProtocURL(protocURL string) RunnerOption {
 func RunnerWithPrintFields(printFields string) RunnerOption {
 	return func(runner *runner) {
 		runner.printFields = printFields
+	}
+}
+
+// RunnerWithProtocURL returns a RunnerOption that uses the given protoc zip file URL.
+func RunnerWithProtocURL(protocURL string) RunnerOption {
+	return func(runner *runner) {
+		runner.protocURL = protocURL
 	}
 }
 

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -23,6 +23,7 @@ package exec
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -68,6 +69,7 @@ type runner struct {
 	cachePath   string
 	protocURL   string
 	printFields string
+	json        bool
 }
 
 func newRunner(workDirPath string, input io.Reader, output io.Writer, options ...RunnerOption) *runner {
@@ -806,7 +808,15 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 			}
 		}
 		if shouldPrint {
-			if err := failure.Fprintln(bufWriter, failureFields...); err != nil {
+			if r.json {
+				data, err := json.Marshal(failure)
+				if err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(bufWriter, string(data)); err != nil {
+					return err
+				}
+			} else if err := failure.Fprintln(bufWriter, failureFields...); err != nil {
 				return err
 			}
 		}

--- a/internal/lint/base_linter.go
+++ b/internal/lint/base_linter.go
@@ -63,7 +63,7 @@ func (c *baseLinter) Check(dirPath string, descriptors []*proto.Proto) ([]*text.
 		descriptors,
 	)
 	for _, failure := range failures {
-		failure.ID = c.id
+		failure.LintID = c.id
 	}
 	return failures, err
 }

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -111,7 +111,7 @@ type Failure struct {
 	Filename string `json:"filename,omitempty"`
 	Line     int    `json:"line,omitempty"`
 	Column   int    `json:"column,omitempty"`
-	LintID   string `json:"lintID,omitempty"`
+	LintID   string `json:"lint_id,omitempty"`
 	Message  string `json:"message,omitempty"`
 }
 

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -111,7 +111,7 @@ type Failure struct {
 	Filename string
 	Line     int
 	Column   int
-	ID       string
+	LintID   string
 	Message  string
 }
 
@@ -160,8 +160,8 @@ func (f *Failure) Fprintln(writer FailureWriter, fields ...FailureField) error {
 			}
 			written = true
 		case FailureFieldID:
-			if f.ID != "" {
-				if _, err := writer.WriteString(f.ID); err != nil {
+			if f.LintID != "" {
+				if _, err := writer.WriteString(f.LintID); err != nil {
 					return err
 				}
 				written = true
@@ -215,8 +215,8 @@ func (f *Failure) String() string {
 	buffer.WriteString(":")
 	buffer.WriteString(column)
 	buffer.WriteString(":")
-	if f.ID != "" {
-		buffer.WriteString(f.ID)
+	if f.LintID != "" {
+		buffer.WriteString(f.LintID)
 		buffer.WriteString(" ")
 	}
 	buffer.WriteString(f.Message)
@@ -224,9 +224,9 @@ func (f *Failure) String() string {
 }
 
 // NewFailuref is a helper that returns a new Failure.
-func NewFailuref(position scanner.Position, id string, format string, args ...interface{}) *Failure {
+func NewFailuref(position scanner.Position, lintID string, format string, args ...interface{}) *Failure {
 	return &Failure{
-		ID:       id,
+		LintID:   lintID,
 		Filename: position.Filename,
 		Line:     position.Line,
 		Column:   position.Column,
@@ -271,10 +271,10 @@ func (f sortFailures) Less(i int, j int) bool {
 	if f[i].Column > f[j].Column {
 		return false
 	}
-	if f[i].ID < f[j].ID {
+	if f[i].LintID < f[j].LintID {
 		return true
 	}
-	if f[i].ID > f[j].ID {
+	if f[i].LintID > f[j].LintID {
 		return false
 	}
 	if f[i].Message < f[j].Message {

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -108,11 +108,11 @@ func ParseColonSeparatedFailureFields(s string) ([]FailureField, error) {
 
 // Failure is a failure with a position in text.
 type Failure struct {
-	Filename string
-	Line     int
-	Column   int
-	LintID   string
-	Message  string
+	Filename string `json:"filename,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Column   int    `json:"column,omitempty"`
+	LintID   string `json:"lintID,omitempty"`
+	Message  string `json:"message,omitempty"`
 }
 
 // FailureWriter is a writer that Failure.Println can accept.


### PR DESCRIPTION
We originally supported a `--harbormaster` flag to format our `protoc` and `lint` failures in a JSON format. This tied us to the Harbormaster API spec as detailed [here](https://secure.phabricator.com/conduit/method/harbormaster.sendmessage/). 

This proposes a more general solution that formats these failures in terms of Prototool's vocabulary (i.e. `lintID` instead of `code`, and removing `severity` and `name` altogether).

The implementation is largely inspired by https://github.com/uber/prototool/pull/53, but we can now include the `json` tags on the `text.Failure` directly because it includes all of the fields we seek to model.

Example output for `compile` and `lint` is shown below:
```
$ prototool compile --json
{"filename":"idl/foo/foo.proto","line":13,"column":14,"message":"\"Foo\" is not defined."}

$ prototool lint --json
{"filename":"idl/foo/foo.proto","lint_id":"FILE_OPTIONS_REQUIRE_JAVA_MULTIPLE_FILES","message":"File option \"java_multiple_files\" is required."}
```

Note that this will be potentially relevant for other commands that could leverage JSON output, such as in https://github.com/uber/prototool/pull/195.