### PR TITLE
Add support for transport credentials

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -25,30 +25,31 @@ import (
 )
 
 type flags struct {
-	address        string
-	cachePath      string
-	callTimeout    string
-	connectTimeout string
-	data           string
-	debug          bool
-	diffMode       bool
-	disableFormat  bool
-	disableLint    bool
-	dryRun         bool
-	fix            bool
-	headers        []string
-	keepaliveTime  string
-	json           bool
-	listAllLinters bool
-	listLinters    bool
-	lintMode       bool
-	method         string
-	overwrite      bool
-	pkg            string
-	printFields    string
-	protocURL      string
-	stdin          bool
-	uncomment      bool
+	address         string
+	cachePath       string
+	callTimeout     string
+	certificateFile string
+	connectTimeout  string
+	data            string
+	debug           bool
+	diffMode        bool
+	disableFormat   bool
+	disableLint     bool
+	dryRun          bool
+	fix             bool
+	headers         []string
+	keepaliveTime   string
+	json            bool
+	listAllLinters  bool
+	listLinters     bool
+	lintMode        bool
+	method          string
+	overwrite       bool
+	pkg             string
+	printFields     string
+	protocURL       string
+	stdin           bool
+	uncomment       bool
 }
 
 func (f *flags) bindAddress(flagSet *pflag.FlagSet) {
@@ -61,6 +62,10 @@ func (f *flags) bindCachePath(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindCallTimeout(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.callTimeout, "call-timeout", "60s", "The maximum time to for all calls to be completed.")
+}
+
+func (f *flags) bindCertificateFile(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.certificateFile, "certificate", "", "SSL Certificate to make requests with.")
 }
 
 func (f *flags) bindConnectTimeout(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -296,11 +296,12 @@ $ cat input.json | prototool grpc example \
 }`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.GRPC(args, flags.headers, flags.address, flags.method, flags.data, flags.callTimeout, flags.connectTimeout, flags.keepaliveTime, flags.stdin)
+			return runner.GRPC(args, flags.headers, flags.address, flags.method, flags.data, flags.callTimeout, flags.connectTimeout, flags.keepaliveTime, flags.certificateFile, flags.stdin)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindAddress(flagSet)
 			flags.bindCallTimeout(flagSet)
+			flags.bindCertificateFile(flagSet)
 			flags.bindConnectTimeout(flagSet)
 			flags.bindData(flagSet)
 			flags.bindHeaders(flagSet)

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -63,7 +63,7 @@ type Runner interface {
 	BinaryToJSON(args []string) error
 	JSONToBinary(args []string) error
 	All(args []string, disableFormat, disableLint, fix bool) error
-	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime string, stdin bool) error
+	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime, certificateFile string, stdin bool) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"time"
 
+	"google.golang.org/grpc/credentials"
+
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"go.uber.org/zap"
 )
@@ -89,6 +91,13 @@ func HandlerWithHeader(key string, value string) HandlerOption {
 		// it takes care of validation
 		// if we switch out grpcurl we will probably change to a metadata.MD object
 		handler.headers = append(handler.headers, fmt.Sprintf("%s:%s", key, value))
+	}
+}
+
+// HandlerWithCredentials returns a HandlerOption that adds the given credentials.
+func HandlerWithCredentials(credentials credentials.TransportCredentials) HandlerOption {
+	return func(handler *handler) {
+		handler.credentials = credentials
 	}
 }
 

--- a/internal/grpc/handler.go
+++ b/internal/grpc/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber/prototool/internal/extract"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -43,6 +44,7 @@ type handler struct {
 	connectTimeout time.Duration
 	keepaliveTime  time.Duration
 	headers        []string
+	credentials    credentials.TransportCredentials
 
 	getter extract.Getter
 }
@@ -97,7 +99,7 @@ func (h *handler) Invoke(fileDescriptorSets []*descriptor.FileDescriptorSet, add
 func (h *handler) dial(address string) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), h.connectTimeout)
 	defer cancel()
-	return grpcurl.BlockingDial(ctx, "tcp", address, nil, h.getDialOptions()...)
+	return grpcurl.BlockingDial(ctx, "tcp", address, h.credentials, h.getDialOptions()...)
 }
 
 func (h *handler) getDialOptions() []grpc.DialOption {


### PR DESCRIPTION
This adds the ability to configure transport credentials from a file for `prototool grpc`. I'd appreciate some help testing this as I wasn't able to run it against one of our services due to (what I believe is) an unrelated error. However, running without the `--certificate` flag gives a connection error, and running with it just gives me one related to the method, so I believe that it is working correctly.