### PR TITLE
Add installation support via a Homebrew Tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Add installation support via a Homebrew Tap.
 
 
 ## [1.2.0] - 2018-08-29

--- a/HomebrewFormula/prototool.rb
+++ b/HomebrewFormula/prototool.rb
@@ -1,0 +1,30 @@
+class Prototool < Formula
+  desc "Your Swiss Army Knife for Protocol Buffers"
+  homepage "https://github.com/uber/prototool"
+  url "https://github.com/uber/prototool/archive/v1.2.0.tar.gz"
+  sha256 "16654242f1f22eaeb2df0c33366ef7a22fda674b51bd4c8da38e0ffab62ce236"
+
+  depends_on "glide" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/github.com/uber/prototool"
+    dir.install buildpath.children
+    cd dir do
+      system "make", "brewgen"
+      cd "brew" do
+        bin.install "bin/prototool"
+        bash_completion.install "etc/bash_completion.d/prototool"
+        zsh_completion.install "etc/zsh/site-functions/_prototool"
+        man1.install Dir["share/man/man1/*.1"]
+        prefix.install_metafiles
+      end
+    end
+  end
+
+  test do
+    system bin/"prototool", "config", "init"
+    assert_predicate testpath/"prototool.yaml", :exist?
+  end
+end

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Prototool accomplishes this by downloading and calling protoc on the fly for you
 
 ## Installation
 
-NEW: Once [this PR](https://github.com/Homebrew/homebrew-core/pull/31440) is merged, Prototool will be able to be installed on Mac OS X via [Homebrew](https://brew.sh/).
+Prototool can be installed on Mac OS X via [Homebrew](https://brew.sh/).
 
 ```bash
-brew install prototool
+brew install uber/prototool/prototool
 ```
 
 This installs the `prototool` binary, along with bash completion, zsh completion, and man pages.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -115,16 +115,8 @@ This document outlines how to create a release of prototool.
     +const Version = "1.22.0-dev"
     ```
 
-14. Commit and push your changes.
-
-    ```
-    git add CHANGELOG.md internal/vars/vars.go
-    git commit -m 'Back to development'
-    git push origin $BRANCH
-    ```
-
-15. Update the formula in https://github.com/homebrew/homebrew-core. First, download
-    the newly created source tarball and compute the SHA-256 hash.
+14. Update the formula in [HomebrewFormula/prototool.rb](HomebrewFormula/prototool.rb).
+    First, download the newly created source tarball and compute the SHA-256 hash.
 
     ```
     # Use "sha256sum" instead of "shasum -a 256" on Linux.
@@ -132,13 +124,18 @@ This document outlines how to create a release of prototool.
     curl -sSL https://github.com/uber/prototool/archive/v1.22.0.tar.gz | shasum -a 256 | cut -f 1 -d ' '
     ```
 
-    Then, fork github.com/homebrew/homebrew-core if you have not already, and create
-    a new branch named "prototool-$VERSION". Update `Formula/prototool.rb` to use
-    the new version and SHA-256 hash.
+    Then, update the formula in `HomebrewFormula/prototool.rb` to use to use the
+    new version and SHA-256 hash.
 
     ```
     url "https://github.com/uber/prototool/archive/v1.22.0.tar.gz"
     sha256 "NEW_SHA_256_HASH_FROM_ABOVE"
     ```
 
-    Create a commit with the message "prototool $VERSION" and open a PR with the same name.
+15. Commit and push your changes.
+
+    ```
+    git add CHANGELOG.md internal/vars/vars.go HomebrewFormula/prototool.rb
+    git commit -m 'Back to development'
+    git push origin $BRANCH
+    ```


### PR DESCRIPTION
**Update** this does not work, the repository has to be prefixed with `homebrew-`. We're looking into other solutions, and keeping the homebrew-core PR open in the hope it gets merged.

Re: #203, this changes the Homebrew strategy from using homebrew-core to having Prototool be it's own Homebrew Tap https://github.com/Homebrew/brew/blob/master/docs/How-to-Create-and-Maintain-a-Tap.md. https://github.com/Homebrew/homebrew-core/pull/31440 has been open for 12 days without it being merged, which concerns me in terms of future version updates. This allows us to have Prototool be a Homebrew Tap that can be updated when a new version is released.

Installation is just as simple:

```bash
brew install uber/prototool/prototool
```

Homebrew will get the Tap from the default branch (dev), so when we do a release, we compute the checksum of the newly released tarball and push the change to dev. The instructions in RELEASE.md are updated as well. Note there is no need to do a new release after this - the dev branch is where the Tap is read from, and the instructions in RELEASE.md update dev after the release tag and master have been pushed, which has to happen anyways as you need to compute the checksum of the released tarball for the Tap.

The downside to this is that we won't get pre-built binaries (which are automatically created via homebrew-core), so users will be building from source indefinitely as of now. However, we could make our own Bottles in the future https://docs.brew.sh/Bottles.html. Additionally, if we wanted to keep on pursuing https://github.com/Homebrew/homebrew-core/pull/31440 and are able to get versions merged more quickly, homebrew-core is prioritized over separate Taps, so if we later changed the advice to `brew install prototool`, this would take precedence over `uber/prototool/prototool` https://github.com/Homebrew/brew/blob/master/docs/Taps.md, meaning both could live next to each other simultaneously.

After this PR is merged, we need to quickly test to make sure this works as intended.