### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,12 +15,10 @@ Please do not @ individual maintainers in the description! We appreciate it.
 
 If your issue doesn't meet the guidelines, we'll comment as such and close the issue - we don't
 mean to be impersonal, but we have to reduce the support burden and cannot be supporting all
-of Protobuf (in the case of Protobuf questions or Protoc issues) or have longstanding issues
-without specifics (in the case of feature requests or bug reports). If the issue is a feature
-request and we don't think it meets the guidelines, don't feel like us closing the issue means
-we can't ever address it, unless we specifically note that we won't be adding a given feature
-(in which case the issue should stay closed) - provide more specifics and re-open the issue.
-If the issue is a bug report, unless we respond that Prototool is working as intended, add
-steps to reproduce the issue and re-open the issue.
+of Protobuf. If the issue is a feature request and we don't think it meets the guidelines,
+don't feel like us closing the issue means we can't ever address it, unless we specifically
+note that we won't be adding a given feature (in which case the issue should stay closed)
+- provide more specifics and re-open the issue. If the issue is a bug report, unless we respond
+that Prototool is working as intended, add steps to reproduce the issue and re-open the issue.
 
 Again, thanks for your input, and we hope Prototool helps your development!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,6 +11,8 @@ Before filing, a couple guidelines:
   you'd like to see with as many specifics as you can provide.
 - If this is a bug report, please provide specific steps to reproduce your issue.
 
+Please do not @ individual maintainers in the description! We appreciate it.
+
 If your issue doesn't meet the guidelines, we'll comment as such and close the issue - we don't
 mean to be impersonal, but we have to reduce the support burden and cannot be supporting all
 of Protobuf (in the case of Protobuf questions or Protoc issues) or have longstanding issues

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@ of Protobuf (in the case of Protobuf questions or Protoc issues) or have longsta
 without specifics (in the case of feature requests or bug reports). If the issue is a feature
 request and we don't think it meets the guidelines, don't feel like us closing the issue means
 we can't ever address it, unless we specifically note that we won't be adding a given feature
-(in which case the issue should be closed)- provide more specifics and re-open the issue.
+(in which case the issue should stay closed) - provide more specifics and re-open the issue.
 If the issue is a bug report, unless we respond that Prototool is working as intended, add
 steps to reproduce the issue and re-open the issue.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+Thanks for filing an issue! We appreciate the input.
+
+Before filing, a couple guidelines:
+
+- If this is a question about Protobuf, do not file an issue here. Consult the
+  Protobuf Language Guide at https://developers.google.com/protocol-buffers/docs/proto3
+  or ask your question on the Protobuf Mailing List at https://groups.google.com/forum/#!forum/protobuf.
+- If this is an issue with Protoc, do not file an issue here. File your issue
+  on the Protobuf repository at https://github.com/protocolbuffers/protobuf.
+- If this is a feature request, please provide a rough outline of the actual changes
+  you'd like to see with as many specifics as you can provide.
+- If this is a bug report, please provide specific steps to reproduce your issue.
+
+If your issue doesn't meet the guidelines, we'll comment as such and close the issue - we don't
+mean to be impersonal, but we have to reduce the support burden and cannot be supporting all
+of Protobuf (in the case of Protobuf questions or Protoc issues) or have longstanding issues
+without specifics (in the case of feature requests or bug reports). If the issue is a feature
+request and we don't think it meets the guidelines, don't feel like us closing the issue means
+we can't ever address it, unless we specifically note that we won't be adding a given feature
+(in which case the issue should be closed)- provide more specifics and re-open the issue.
+If the issue is a bug report, unless we respond that Prototool is working as intended, add
+steps to reproduce the issue and re-open the issue.
+
+Again, thanks for your input, and we hope Prototool helps your development!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,5 @@ Before submitting, make sure to:
 PRs will not be properly evaluated until they pass CI - we've done what we can to make this easy
 to replicate locally, and we apologize if this comes across as impersonal. Our goal is to streamline
 Prototool development and make sure everyone is on the same page here.
+
+Please do not @ individual maintainers in the description! We appreciate it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@ Thanks for your pull request! We really appreciate all OSS efforts, big or small
 
 Before submitting, make sure to:
 
+- Review the issue template at https://github.com/uber/prototool/blob/dev/.github/ISSUE_TEMPLATE.md for
+  general guidance on filing Prototool requests.
 - Run `make init` if you have not already to download dependencies to `vendor`.
 - Run `make generate` to make sure there is no diff.
 - Run `make` to make sure all tests pass. This is functionally equivalent to the tests run on CI.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,7 @@ Before submitting, make sure to:
 - Run `make init` if you have not already to download dependencies to `vendor`.
 - Run `make generate` to make sure there is no diff.
 - Run `make` to make sure all tests pass. This is functionally equivalent to the tests run on CI.
+
+PRs will not be properly evaluated until they pass CI - we've done what we can to make this easy
+to replicate locally, and we apologize if this comes across as impersonal. Our goal is to streamline
+Prototool development and make sure everyone is on the same page here.

--- a/README.md
+++ b/README.md
@@ -366,10 +366,16 @@ Editor integration is a key goal of Prototool. We've demonstrated support intern
 
 ## Development
 
-Prototool is under active development, if you want to help, here's some places to start:
+Prototool is under active development. If you want to help, here's some places to start:
 
-- Try out `prototool` and file issues, including points that are unclear in the documentation.
-- Put up PRs with any changes you'd like to see made. We appreciate any input!
+- Try out `prototool` and file feature requests or bug reports.
+- Submit PRs with any changes you'd like to see made.
+
+We appreciate any input you have!
+
+Before filing an issue or submitting a PR, make sure to review the [Issue Guidelines](https://github.com/uber/prototool/blob/dev/.github/ISSUE_TEMPLATE.md), and before submitting a PR, make sure to also review
+the [PR Guidelines](https://github.com/uber/prototool/blob/dev/.github/PULL_REQUEST_TEMPLATE.md). The Issue Guidelines will show up in the description field when filing a new issue, and the PR guidelines will show up in the
+description field when submitting a PR, but clear the description field of this pre-populated text once you've read it :-)
 
 Note that development of Prototool will only work with Golang 1.10 or newer. On initially cloning the repository, run `make init` if you have not already to download dependencies to `vendor`.
 


### PR DESCRIPTION
I added a new GitHub Issue label "does not meet issue guidelines" to mark issues as such.