### PR TITLE
Add `compile --out` to write FileDescriptorSet to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Added `--out` flag to `compile` for writing a FileDescriptorSet to file.
 
 
 ## [1.2.0] - 2018-08-29

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -35,6 +35,7 @@ type flags struct {
 	disableFormat  bool
 	disableLint    bool
 	dryRun         bool
+	compileOut     string
 	fix            bool
 	headers        []string
 	keepaliveTime  string
@@ -65,6 +66,10 @@ func (f *flags) bindCallTimeout(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindConnectTimeout(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.connectTimeout, "connect-timeout", "10s", "The maximum time to wait for the connection to be established.")
+}
+
+func (f *flags) bindCompileOut(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.compileOut, "out", "", "File path to compile file descriptor set to.")
 }
 
 func (f *flags) bindData(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -73,16 +73,22 @@ var (
 
 	compileCmdTemplate = &cmdTemplate{
 		Use:   "compile [dirOrFile]",
-		Short: "Compile with protoc to check for failures.",
-		Long:  `Stubs will not be generated. To generate stubs, use the "gen" command. Calling "compile" has the effect of calling protoc with "-o /dev/null".`,
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Compile with protoc to check for failures and get the FileDescriptorSet.",
+		Long: `Stubs will not be generated. To generate stubs, use the "generate" command.
+
+Calling "compile" with no arguments has the effect of calling protoc with "-o /dev/null". This can be used to validate proto files.
+
+If "--out" is specifed with a file name, "compile" will write the FileDescriptorSet to the given file. eg "prototool compile foo.proto --out desc.out".
+	`,
+		Args: cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.Compile(args, flags.dryRun)
+			return runner.Compile(args, flags.dryRun, flags.compileOut)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindDryRun(flagSet)
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
+			flags.bindCompileOut(flagSet)
 		},
 	}
 

--- a/internal/cmd/testdata/compile/out/bar/bar_imports_foo.proto
+++ b/internal/cmd/testdata/compile/out/bar/bar_imports_foo.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package bar;
+
+import "google/protobuf/timestamp.proto";
+import "foo/foo.proto";
+
+message Bar {
+  int64 hello = 1;
+  google.protobuf.Timestamp timestamp = 2;
+  foo.Dep foodep = 3;
+}

--- a/internal/cmd/testdata/compile/out/foo/foo.proto
+++ b/internal/cmd/testdata/compile/out/foo/foo.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package foo;
+
+option go_package = "foopb";
+option java_multiple_files = true;
+option java_outer_classname = "FooProto";
+option java_package = "com.foo";
+
+// Dep is a dependency.
+message Dep {
+  int64 hello = 1;
+}

--- a/internal/cmd/testdata/compile/out/protoc.out
+++ b/internal/cmd/testdata/compile/out/protoc.out
@@ -1,0 +1,18 @@
+
+W
+foo/foo.protofoo"
+Dep
+hello (RhelloB
+com.fooBFooProtoPZfoopbbproto3
+÷
+google/protobuf/timestamp.protogoogle.protobuf";
+	Timestamp
+seconds (Rseconds
+nanos (RnanosB~
+com.google.protobufBTimestampProtoPZ+github.com/golang/protobuf/ptypes/timestampø¢GPBªGoogle.Protobuf.WellKnownTypesbproto3
+Ñ
+bar/bar_imports_foo.protobargoogle/protobuf/timestamp.protofoo/foo.proto"w
+Bar
+hello (Rhello8
+	timestamp (2.google.protobuf.TimestampR	timestamp 
+foodep (2.foo.DepRfoodepbproto3

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -51,7 +51,7 @@ type Runner interface {
 	Download() error
 	Clean() error
 	Files(args []string) error
-	Compile(args []string, dryRun bool) error
+	Compile(args []string, dryRun bool, outputPath string) error
 	Gen(args []string, dryRun bool) error
 	DescriptorProto(args []string) error
 	FieldDescriptorProto(args []string) error

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -38,9 +38,11 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/uber/prototool/internal/cfginit"
 	"github.com/uber/prototool/internal/create"
+	"github.com/uber/prototool/internal/desc"
 	"github.com/uber/prototool/internal/diff"
 	"github.com/uber/prototool/internal/extract"
 	"github.com/uber/prototool/internal/file"
@@ -179,14 +181,45 @@ func (r *runner) Files(args []string) error {
 	return nil
 }
 
-func (r *runner) Compile(args []string, dryRun bool) error {
+func (r *runner) Compile(args []string, dryRun bool, outputPath string) error {
 	meta, err := r.getMeta(args, 1)
 	if err != nil {
 		return err
 	}
 	r.printAffectedFiles(meta)
-	_, err = r.compile(false, false, dryRun, meta)
-	return err
+
+	if outputPath == "" {
+		// validate the protobuf files and return
+		_, err = r.compile(false, false, dryRun, meta)
+		return err
+	}
+
+	// otherwise, dump FileDescriptorSets to outputPath
+	fileDescriptorSets, err := r.compile(false, true, dryRun, meta)
+	if err != nil {
+		return err
+	}
+	return r.fileDescriptorSetsToFile(outputPath, fileDescriptorSets)
+}
+
+// writes a single FileDescriptorSet containing all given FileDescriptorProtos
+func (r *runner) fileDescriptorSetsToFile(outputPath string, sets []*descriptor.FileDescriptorSet) error {
+	// TODO(peats-bond): have an option (-w) to overwrite output file
+	file := filepath.Join(r.workDirPath, outputPath)
+	if _, err := os.Stat(file); err == nil {
+		return fmt.Errorf("%s already exists", file)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755 /*user:rwx group:rx other: rx*/); err != nil {
+		return err
+	}
+
+	data, err := proto.Marshal(desc.MergeFileDescriptorSets(sets))
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(file, data, 0644 /*user:rw group:r other: r*/)
 }
 
 func (r *runner) Gen(args []string, dryRun bool) error {

--- a/internal/grpc/handler.go
+++ b/internal/grpc/handler.go
@@ -125,7 +125,7 @@ func (h *handler) getDescriptorSourceForMethod(fileDescriptorSets []*descriptor.
 	if err != nil {
 		return nil, err
 	}
-	fileDescriptorSet, err := desc.SortFileDescriptorSet(service.FileDescriptorSet, service.FileDescriptorProto)
+	fileDescriptorSet, err := desc.SortFileDescriptorSetAtEnd(service.FileDescriptorSet, service.FileDescriptorProto)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reflect/handler.go
+++ b/internal/reflect/handler.go
@@ -78,7 +78,7 @@ func (h *handler) getDynamicMessage(fileDescriptorSets []*descriptor.FileDescrip
 	if err != nil {
 		return nil, err
 	}
-	fileDescriptorSet, err := intdesc.SortFileDescriptorSet(message.FileDescriptorSet, message.FileDescriptorProto)
+	fileDescriptorSet, err := intdesc.SortFileDescriptorSetAtEnd(message.FileDescriptorSet, message.FileDescriptorProto)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds an additional `--out` flag to `prototool compile` to enable
writing a FileDescriptorSet to file.

Fixes #211 