### PR TITLE
Update README.md to note that Prototool can be installed via Linuxbrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Prototool accomplishes this by downloading and calling protoc on the fly for you
 
 ## Installation
 
-Prototool can be installed on Mac OS X via [Homebrew](https://brew.sh/).
+Prototool can be installed on Mac OS X via [Homebrew](https://brew.sh/) or Linux via [Linuxbrew](http://linuxbrew.sh/).
 
 ```bash
 brew install prototool

--- a/etc/bin/brewgen.sh
+++ b/etc/bin/brewgen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -euo pipefail
+set -eu
 
 DIR="$(cd "$(dirname "${0}")/../.." && pwd)"
 cd "${DIR}"


### PR DESCRIPTION
It turns out that this got automatically pushed to [Linuxbrew](http://linuxbrew.sh/) as well.

I also updated `etc/bin/brewgen.sh` to not do `set -o pipefail`, which turns out is only a `bash` flag, not an `sh` flag, and we don't want to depend on bash (which I why I invoke this with `sh` in the `Makefile`). For most users nowadays (and at least for me on my Mac), `sh` is actually `bash`, but this isn't true in i.e. a `ubuntu:18.04' Docker image, where I was testing this. Since `etc/bin/brewgen.sh` doesn't do any piping anyways, this extra check shouldn't have had any effect anyways.