### PR TITLE
Add protoc-bin-path and protoc-wkt-path flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Accept `prototool.json` files for configuation in addition to
   `prototool.yaml` files.
 - Add `--config-data` flag.
-- Add a `no-cache` flag to disable protoc caching.
+- Add `protoc-bin-path` and `protoc-wkt-path` flags to manually
+  set the paths for where `protoc` is run and where the
+  well-known types are included from.
 
 
 ## [1.2.0] - 2018-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Accept `prototool.json` files for configuation in addition to
   `prototool.yaml` files.
 - Add `--config-data` flag.
+- Add a `no-cache` flag to disable protoc caching.
 
 
 ## [1.2.0] - 2018-08-29

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -48,7 +48,7 @@ type flags struct {
 	pkg            string
 	printFields    string
 	protocBinPath  string
-	protocWktPath  string
+	protocWKTPath  string
 	protocURL      string
 	stdin          bool
 	uncomment      bool
@@ -146,8 +146,8 @@ func (f *flags) bindProtocBinPath(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-wkt-path.")
 }
 
-func (f *flags) bindProtocWktPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocWktPath, "protoc-wkt-path", "", "The path to the well-known types. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-bin-path.")
+func (f *flags) bindProtocWKTPath(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.protocWKTPath, "protoc-wkt-path", "", "The path to the well-known types. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-bin-path.")
 }
 
 func (f *flags) bindStdin(flagSet *pflag.FlagSet) {

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -44,6 +44,7 @@ type flags struct {
 	listLinters    bool
 	lintMode       bool
 	method         string
+	noCache        bool
 	overwrite      bool
 	pkg            string
 	printFields    string
@@ -122,6 +123,10 @@ func (f *flags) bindListLinters(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindMethod(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.method, "method", "", "The GRPC method to call in the form package.Service/Method. This is required.")
+}
+
+func (f *flags) bindNoCache(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.noCache, "no-cache", false, "Disable the Prototool cache for protoc.")
 }
 
 func (f *flags) bindOverwrite(flagSet *pflag.FlagSet) {

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -44,10 +44,11 @@ type flags struct {
 	listLinters    bool
 	lintMode       bool
 	method         string
-	noCache        bool
 	overwrite      bool
 	pkg            string
 	printFields    string
+	protocBinPath  string
+	protocWktPath  string
 	protocURL      string
 	stdin          bool
 	uncomment      bool
@@ -125,10 +126,6 @@ func (f *flags) bindMethod(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.method, "method", "", "The GRPC method to call in the form package.Service/Method. This is required.")
 }
 
-func (f *flags) bindNoCache(flagSet *pflag.FlagSet) {
-	flagSet.BoolVar(&f.noCache, "no-cache", false, "Disable the Prototool cache for protoc.")
-}
-
 func (f *flags) bindOverwrite(flagSet *pflag.FlagSet) {
 	flagSet.BoolVarP(&f.overwrite, "overwrite", "w", false, "Overwrite the existing file instead of writing the formatted file to stdout.")
 }
@@ -143,6 +140,14 @@ func (f *flags) bindPrintFields(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindProtocURL(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.protocURL, "protoc-url", "", "The url to use to download the protoc zip file, otherwise uses GitHub Releases. Setting this option will ignore the config protoc.version setting.")
+}
+
+func (f *flags) bindProtocBinPath(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-wkt-path.")
+}
+
+func (f *flags) bindProtocWktPath(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.protocWktPath, "protoc-wkt-path", "", "The path to the well-known types. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-bin-path.")
 }
 
 func (f *flags) bindStdin(flagSet *pflag.FlagSet) {

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -143,11 +143,11 @@ func (f *flags) bindProtocURL(flagSet *pflag.FlagSet) {
 }
 
 func (f *flags) bindProtocBinPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-wkt-path.")
+	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-wkt-path and must not be used with the protoc-url flag.")
 }
 
 func (f *flags) bindProtocWKTPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocWKTPath, "protoc-wkt-path", "", "The path to the well-known types. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-bin-path.")
+	flagSet.StringVar(&f.protocWKTPath, "protoc-wkt-path", "", "The path to the well-known types. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-bin-path and must not be used with the protoc-url flag.")
 }
 
 func (f *flags) bindStdin(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -51,6 +51,7 @@ var (
 			flags.bindJSON(flagSet)
 			flags.bindFix(flagSet)
 			flags.bindProtocURL(flagSet)
+			flags.bindNoCache(flagSet)
 		},
 	}
 
@@ -88,6 +89,7 @@ var (
 			flags.bindDryRun(flagSet)
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
+			flags.bindNoCache(flagSet)
 		},
 	}
 
@@ -225,6 +227,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindOverwrite(flagSet)
 			flags.bindFix(flagSet)
 			flags.bindProtocURL(flagSet)
+			flags.bindNoCache(flagSet)
 		},
 	}
 
@@ -240,6 +243,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindDryRun(flagSet)
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
+			flags.bindNoCache(flagSet)
 		},
 	}
 
@@ -329,6 +333,7 @@ $ cat input.json | prototool grpc example \
 			flags.bindMethod(flagSet)
 			flags.bindStdin(flagSet)
 			flags.bindProtocURL(flagSet)
+			flags.bindNoCache(flagSet)
 		},
 	}
 
@@ -371,6 +376,7 @@ $ cat input.json | prototool grpc example \
 			flags.bindListAllLinters(flagSet)
 			flags.bindListLinters(flagSet)
 			flags.bindProtocURL(flagSet)
+			flags.bindNoCache(flagSet)
 		},
 	}
 
@@ -506,6 +512,12 @@ func getRunner(stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags
 		runnerOptions = append(
 			runnerOptions,
 			exec.RunnerWithJSON(),
+		)
+	}
+	if flags.noCache {
+		runnerOptions = append(
+			runnerOptions,
+			exec.RunnerWithNoCache(),
 		)
 	}
 	if flags.printFields != "" {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -52,7 +52,7 @@ var (
 			flags.bindFix(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
-			flags.bindProtocWktPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
 		},
 	}
 
@@ -91,7 +91,7 @@ var (
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
-			flags.bindProtocWktPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
 		},
 	}
 
@@ -230,7 +230,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindFix(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
-			flags.bindProtocWktPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
 		},
 	}
 
@@ -247,7 +247,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
-			flags.bindProtocWktPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
 		},
 	}
 
@@ -338,7 +338,7 @@ $ cat input.json | prototool grpc example \
 			flags.bindStdin(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
-			flags.bindProtocWktPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
 		},
 	}
 
@@ -382,7 +382,7 @@ $ cat input.json | prototool grpc example \
 			flags.bindListLinters(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
-			flags.bindProtocWktPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
 		},
 	}
 
@@ -526,10 +526,10 @@ func getRunner(stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags
 			exec.RunnerWithProtocBinPath(flags.protocBinPath),
 		)
 	}
-	if flags.protocWktPath != "" {
+	if flags.protocWKTPath != "" {
 		runnerOptions = append(
 			runnerOptions,
-			exec.RunnerWithProtocWktPath(flags.protocWktPath),
+			exec.RunnerWithProtocWKTPath(flags.protocWKTPath),
 		)
 	}
 	if flags.printFields != "" {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -51,7 +51,8 @@ var (
 			flags.bindJSON(flagSet)
 			flags.bindFix(flagSet)
 			flags.bindProtocURL(flagSet)
-			flags.bindNoCache(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWktPath(flagSet)
 		},
 	}
 
@@ -89,7 +90,8 @@ var (
 			flags.bindDryRun(flagSet)
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
-			flags.bindNoCache(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWktPath(flagSet)
 		},
 	}
 
@@ -227,7 +229,8 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindOverwrite(flagSet)
 			flags.bindFix(flagSet)
 			flags.bindProtocURL(flagSet)
-			flags.bindNoCache(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWktPath(flagSet)
 		},
 	}
 
@@ -243,7 +246,8 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindDryRun(flagSet)
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
-			flags.bindNoCache(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWktPath(flagSet)
 		},
 	}
 
@@ -333,7 +337,8 @@ $ cat input.json | prototool grpc example \
 			flags.bindMethod(flagSet)
 			flags.bindStdin(flagSet)
 			flags.bindProtocURL(flagSet)
-			flags.bindNoCache(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWktPath(flagSet)
 		},
 	}
 
@@ -376,7 +381,8 @@ $ cat input.json | prototool grpc example \
 			flags.bindListAllLinters(flagSet)
 			flags.bindListLinters(flagSet)
 			flags.bindProtocURL(flagSet)
-			flags.bindNoCache(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWktPath(flagSet)
 		},
 	}
 
@@ -514,10 +520,16 @@ func getRunner(stdin io.Reader, stdout io.Writer, stderr io.Writer, flags *flags
 			exec.RunnerWithJSON(),
 		)
 	}
-	if flags.noCache {
+	if flags.protocBinPath != "" {
 		runnerOptions = append(
 			runnerOptions,
-			exec.RunnerWithNoCache(),
+			exec.RunnerWithProtocBinPath(flags.protocBinPath),
+		)
+	}
+	if flags.protocWktPath != "" {
+		runnerOptions = append(
+			runnerOptions,
+			exec.RunnerWithProtocWktPath(flags.protocWktPath),
 		)
 	}
 	if flags.printFields != "" {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -99,18 +99,25 @@ func RunnerWithJSON() RunnerOption {
 	}
 }
 
-// RunnerWithNoCache returns a RunnerOption that will disable the protoc cache.
-func RunnerWithNoCache() RunnerOption {
-	return func(runner *runner) {
-		runner.noCache = true
-	}
-}
-
 // RunnerWithPrintFields returns a RunnerOption that uses the given colon-separated
 // print fields. The default is filename:line:column:message.
 func RunnerWithPrintFields(printFields string) RunnerOption {
 	return func(runner *runner) {
 		runner.printFields = printFields
+	}
+}
+
+// RunnerWithProtocBinPath returns a RunnerOption that uses the given protoc binary path.
+func RunnerWithProtocBinPath(protocBinPath string) RunnerOption {
+	return func(runner *runner) {
+		runner.protocBinPath = protocBinPath
+	}
+}
+
+// RunnerWithProtocWktPath returns a RunnerOption that uses the given path to include the well-known types.
+func RunnerWithProtocWktPath(protocWktPath string) RunnerOption {
+	return func(runner *runner) {
+		runner.protocWktPath = protocWktPath
 	}
 }
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -114,10 +114,10 @@ func RunnerWithProtocBinPath(protocBinPath string) RunnerOption {
 	}
 }
 
-// RunnerWithProtocWktPath returns a RunnerOption that uses the given path to include the well-known types.
-func RunnerWithProtocWktPath(protocWktPath string) RunnerOption {
+// RunnerWithProtocWKTPath returns a RunnerOption that uses the given path to include the well-known types.
+func RunnerWithProtocWKTPath(protocWKTPath string) RunnerOption {
 	return func(runner *runner) {
-		runner.protocWktPath = protocWktPath
+		runner.protocWKTPath = protocWKTPath
 	}
 }
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -99,6 +99,13 @@ func RunnerWithJSON() RunnerOption {
 	}
 }
 
+// RunnerWithNoCache returns a RunnerOption that will disable the protoc cache.
+func RunnerWithNoCache() RunnerOption {
+	return func(runner *runner) {
+		runner.noCache = true
+	}
+}
+
 // RunnerWithPrintFields returns a RunnerOption that uses the given colon-separated
 // print fields. The default is filename:line:column:message.
 func RunnerWithPrintFields(printFields string) RunnerOption {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -69,7 +69,7 @@ type runner struct {
 	cachePath     string
 	configData    string
 	protocBinPath string
-	protocWktPath string
+	protocWKTPath string
 	protocURL     string
 	printFields   string
 	json          bool
@@ -675,10 +675,10 @@ func (r *runner) newDownloader(config settings.Config) (protoc.Downloader, error
 			protoc.DownloaderWithProtocBinPath(r.protocBinPath),
 		)
 	}
-	if r.protocWktPath != "" {
+	if r.protocWKTPath != "" {
 		downloaderOptions = append(
 			downloaderOptions,
-			protoc.DownloaderWithProtocWktPath(r.protocWktPath),
+			protoc.DownloaderWithProtocWKTPath(r.protocWKTPath),
 		)
 	}
 	if r.protocURL != "" {
@@ -706,10 +706,10 @@ func (r *runner) newCompiler(doGen bool, doFileDescriptorSet bool) protoc.Compil
 			protoc.CompilerWithProtocBinPath(r.protocBinPath),
 		)
 	}
-	if r.protocWktPath != "" {
+	if r.protocWKTPath != "" {
 		compilerOptions = append(
 			compilerOptions,
-			protoc.CompilerWithProtocWktPath(r.protocWktPath),
+			protoc.CompilerWithProtocWKTPath(r.protocWKTPath),
 		)
 	}
 	if r.protocURL != "" {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -65,13 +65,14 @@ type runner struct {
 	input       io.Reader
 	output      io.Writer
 
-	logger      *zap.Logger
-	cachePath   string
-	configData  string
-	protocURL   string
-	printFields string
-	noCache     bool
-	json        bool
+	logger        *zap.Logger
+	cachePath     string
+	configData    string
+	protocBinPath string
+	protocWktPath string
+	protocURL     string
+	printFields   string
+	json          bool
 }
 
 func newRunner(workDirPath string, input io.Reader, output io.Writer, options ...RunnerOption) *runner {
@@ -668,16 +669,22 @@ func (r *runner) newDownloader(config settings.Config) (protoc.Downloader, error
 			protoc.DownloaderWithCachePath(r.cachePath),
 		)
 	}
+	if r.protocBinPath != "" {
+		downloaderOptions = append(
+			downloaderOptions,
+			protoc.DownloaderWithProtocBinPath(r.protocBinPath),
+		)
+	}
+	if r.protocWktPath != "" {
+		downloaderOptions = append(
+			downloaderOptions,
+			protoc.DownloaderWithProtocWktPath(r.protocWktPath),
+		)
+	}
 	if r.protocURL != "" {
 		downloaderOptions = append(
 			downloaderOptions,
 			protoc.DownloaderWithProtocURL(r.protocURL),
-		)
-	}
-	if r.noCache {
-		downloaderOptions = append(
-			downloaderOptions,
-			protoc.DownloaderWithNoCache(),
 		)
 	}
 	return protoc.NewDownloader(config, downloaderOptions...)
@@ -693,16 +700,22 @@ func (r *runner) newCompiler(doGen bool, doFileDescriptorSet bool) protoc.Compil
 			protoc.CompilerWithCachePath(r.cachePath),
 		)
 	}
+	if r.protocBinPath != "" {
+		compilerOptions = append(
+			compilerOptions,
+			protoc.CompilerWithProtocBinPath(r.protocBinPath),
+		)
+	}
+	if r.protocWktPath != "" {
+		compilerOptions = append(
+			compilerOptions,
+			protoc.CompilerWithProtocWktPath(r.protocWktPath),
+		)
+	}
 	if r.protocURL != "" {
 		compilerOptions = append(
 			compilerOptions,
 			protoc.CompilerWithProtocURL(r.protocURL),
-		)
-	}
-	if r.noCache {
-		compilerOptions = append(
-			compilerOptions,
-			protoc.CompilerWithNoCache(),
 		)
 	}
 	if doGen {

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -515,12 +515,10 @@ func getIncludes(downloader Downloader, config settings.Config, dirPath string, 
 		if err != nil {
 			return nil, err
 		}
-		if wellKnownTypesIncludePath != "" {
-			includes = append(includes, wellKnownTypesIncludePath)
-			// TODO: not exactly platform independent
-			if strings.HasPrefix(dirPath, wellKnownTypesIncludePath) {
-				fileInIncludePath = true
-			}
+		includes = append(includes, wellKnownTypesIncludePath)
+		// TODO: not exactly platform independent
+		if strings.HasPrefix(dirPath, wellKnownTypesIncludePath) {
+			fileInIncludePath = true
 		}
 	}
 	// you want your proto files to be in at least one of the -I directories

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -272,7 +272,7 @@ func (c *compiler) getCmdMetas(protoSet *file.ProtoSet) (cmdMetas []*cmdMeta, re
 	// have a different protoc.version value
 	downloader, err := c.newDownloader(protoSet.Config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create downloader: %v", err)
+		return nil, err
 	}
 	if _, err := downloader.Download(); err != nil {
 		return cmdMetas, err

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -69,7 +69,7 @@ type compiler struct {
 	logger              *zap.Logger
 	cachePath           string
 	protocBinPath       string
-	protocWktPath       string
+	protocWKTPath       string
 	protocURL           string
 	doGen               bool
 	doFileDescriptorSet bool
@@ -375,10 +375,10 @@ func (c *compiler) newDownloader(config settings.Config) (Downloader, error) {
 			DownloaderWithProtocBinPath(c.protocBinPath),
 		)
 	}
-	if c.protocWktPath != "" {
+	if c.protocWKTPath != "" {
 		downloaderOptions = append(
 			downloaderOptions,
-			DownloaderWithProtocWktPath(c.protocWktPath),
+			DownloaderWithProtocWKTPath(c.protocWKTPath),
 		)
 	}
 	if c.protocURL != "" {

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -68,8 +68,9 @@ var (
 type compiler struct {
 	logger              *zap.Logger
 	cachePath           string
+	protocBinPath       string
+	protocWktPath       string
 	protocURL           string
-	noCache             bool
 	doGen               bool
 	doFileDescriptorSet bool
 }
@@ -271,7 +272,7 @@ func (c *compiler) getCmdMetas(protoSet *file.ProtoSet) (cmdMetas []*cmdMeta, re
 	// have a different protoc.version value
 	downloader, err := c.newDownloader(protoSet.Config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create downloader")
+		return nil, fmt.Errorf("failed to create downloader: %v", err)
 	}
 	if _, err := downloader.Download(); err != nil {
 		return cmdMetas, err
@@ -368,10 +369,16 @@ func (c *compiler) newDownloader(config settings.Config) (Downloader, error) {
 			DownloaderWithCachePath(c.cachePath),
 		)
 	}
-	if c.noCache {
+	if c.protocBinPath != "" {
 		downloaderOptions = append(
 			downloaderOptions,
-			DownloaderWithNoCache(),
+			DownloaderWithProtocBinPath(c.protocBinPath),
+		)
+	}
+	if c.protocWktPath != "" {
+		downloaderOptions = append(
+			downloaderOptions,
+			DownloaderWithProtocWktPath(c.protocWktPath),
 		)
 	}
 	if c.protocURL != "" {

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -508,10 +508,12 @@ func getIncludes(downloader Downloader, config settings.Config, dirPath string, 
 		if err != nil {
 			return nil, err
 		}
-		includes = append(includes, wellKnownTypesIncludePath)
-		// TODO: not exactly platform independent
-		if strings.HasPrefix(dirPath, wellKnownTypesIncludePath) {
-			fileInIncludePath = true
+		if wellKnownTypesIncludePath != "" {
+			includes = append(includes, wellKnownTypesIncludePath)
+			// TODO: not exactly platform independent
+			if strings.HasPrefix(dirPath, wellKnownTypesIncludePath) {
+				fileInIncludePath = true
+			}
 		}
 	}
 	// you want your proto files to be in at least one of the -I directories

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -86,8 +86,13 @@ func newDownloader(config settings.Config, options ...DownloaderOption) (*downlo
 		if _, err := os.Stat(cleanWKTPath); os.IsNotExist(err) {
 			return nil, err
 		}
-		if _, err := os.Stat(filepath.Join(cleanWKTPath, "google", "protobuf")); os.IsNotExist(err) {
+		protobufPath := filepath.Join(cleanWKTPath, "google", "protobuf")
+		info, err := os.Stat(protobufPath)
+		if os.IsNotExist(err) {
 			return nil, err
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("%q is not a valid well-known types directory", protobufPath)
 		}
 		downloader.protocBinPath = cleanBinPath
 		downloader.protocWKTPath = cleanWKTPath

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -86,6 +86,9 @@ func newDownloader(config settings.Config, options ...DownloaderOption) (*downlo
 		if _, err := os.Stat(cleanWKTPath); os.IsNotExist(err) {
 			return nil, err
 		}
+		if _, err := os.Stat(filepath.Join(cleanWKTPath, "google", "protobuf")); os.IsNotExist(err) {
+			return nil, err
+		}
 		downloader.protocBinPath = cleanBinPath
 		downloader.protocWKTPath = cleanWKTPath
 	}

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -60,7 +60,6 @@ type downloader struct {
 	// and wktPath.
 	noCache bool
 	binPath string
-	wktPath string
 }
 
 func newDownloader(config settings.Config, options ...DownloaderOption) (*downloader, error) {
@@ -82,28 +81,7 @@ func newDownloader(config settings.Config, options ...DownloaderOption) (*downlo
 		if _, err := os.Stat(binPath); os.IsNotExist(err) {
 			return nil, err
 		}
-		// Assume that the well-known types are adjacent to the protoc binary
-		// since this is how protoc is packaged by default.
-		//
-		//  Ex:
-		//   protoc-3.6.1.zip
-		//     bin/
-		//     bin/protoc
-		//     include/
-		//     include/google
-		//     ...
-		//
-		// TODO: This makes strong assumptions with regard to
-		//       the file layout.
-		//       Consider adding a protoc.no_defaults flag (similar
-		//       to the previously removed protoc_include_wkt
-		//       setting).
-		wktPath := filepath.Join(binPath, "../..", "include")
-		if _, err := os.Stat(wktPath); os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to find the well-known types in %q", wktPath)
-		}
 		downloader.binPath = binPath
-		downloader.wktPath = wktPath
 	}
 	return downloader, nil
 }
@@ -130,8 +108,8 @@ func (d *downloader) ProtocPath() (string, error) {
 }
 
 func (d *downloader) WellKnownTypesIncludePath() (string, error) {
-	if d.wktPath != "" {
-		return d.wktPath, nil
+	if d.noCache {
+		return "", nil
 	}
 	basePath, err := d.Download()
 	if err != nil {

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -57,7 +57,7 @@ type downloader struct {
 	// the well-known-types, from the configured binPath
 	// and wktPath.
 	protocBinPath string
-	protocWktPath string
+	protocWKTPath string
 }
 
 func newDownloader(config settings.Config, options ...DownloaderOption) (*downloader, error) {
@@ -71,23 +71,23 @@ func newDownloader(config settings.Config, options ...DownloaderOption) (*downlo
 	if downloader.config.Compile.ProtobufVersion == "" {
 		downloader.config.Compile.ProtobufVersion = vars.DefaultProtocVersion
 	}
-	if downloader.protocBinPath != "" || downloader.protocWktPath != "" {
+	if downloader.protocBinPath != "" || downloader.protocWKTPath != "" {
 		if downloader.protocURL != "" {
 			return nil, fmt.Errorf("cannot use protoc-url in combination with either protoc-bin-path or protoc-wkt-path")
 		}
-		if downloader.protocBinPath == "" || downloader.protocWktPath == "" {
+		if downloader.protocBinPath == "" || downloader.protocWKTPath == "" {
 			return nil, fmt.Errorf("both protoc-bin-path and protoc-wkt-path must be set")
 		}
 		cleanBinPath := filepath.Clean(downloader.protocBinPath)
 		if _, err := os.Stat(cleanBinPath); os.IsNotExist(err) {
 			return nil, err
 		}
-		cleanWktPath := filepath.Clean(downloader.protocWktPath)
-		if _, err := os.Stat(cleanWktPath); os.IsNotExist(err) {
+		cleanWKTPath := filepath.Clean(downloader.protocWKTPath)
+		if _, err := os.Stat(cleanWKTPath); os.IsNotExist(err) {
 			return nil, err
 		}
 		downloader.protocBinPath = cleanBinPath
-		downloader.protocWktPath = cleanWktPath
+		downloader.protocWKTPath = cleanWKTPath
 	}
 	return downloader, nil
 }
@@ -114,8 +114,8 @@ func (d *downloader) ProtocPath() (string, error) {
 }
 
 func (d *downloader) WellKnownTypesIncludePath() (string, error) {
-	if d.protocWktPath != "" {
-		return d.protocWktPath, nil
+	if d.protocWKTPath != "" {
+		return d.protocWKTPath, nil
 	}
 	basePath, err := d.Download()
 	if err != nil {

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -93,8 +93,17 @@ func DownloaderWithProtocURL(protocURL string) DownloaderOption {
 	}
 }
 
+// DownloaderWithNoCache returns a DownloaderOption that disables caching.
+//
+// The default is https://github.com/protocolbuffers/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
+func DownloaderWithNoCache() DownloaderOption {
+	return func(downloader *downloader) {
+		downloader.noCache = true
+	}
+}
+
 // NewDownloader returns a new Downloader for the given config and DownloaderOptions.
-func NewDownloader(config settings.Config, options ...DownloaderOption) Downloader {
+func NewDownloader(config settings.Config, options ...DownloaderOption) (Downloader, error) {
 	return newDownloader(config, options...)
 }
 
@@ -152,6 +161,13 @@ func CompilerWithCachePath(cachePath string) CompilerOption {
 func CompilerWithProtocURL(protocURL string) CompilerOption {
 	return func(compiler *compiler) {
 		compiler.protocURL = protocURL
+	}
+}
+
+// CompilerWithNoCache disables caching.
+func CompilerWithNoCache() CompilerOption {
+	return func(compiler *compiler) {
+		compiler.noCache = true
 	}
 }
 

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -84,21 +84,27 @@ func DownloaderWithCachePath(cachePath string) DownloaderOption {
 	}
 }
 
+// DownloaderWithProtocBinPath returns a DownloaderOption that uses the given protoc binary path.
+func DownloaderWithProtocBinPath(protocBinPath string) DownloaderOption {
+	return func(downloader *downloader) {
+		downloader.protocBinPath = protocBinPath
+	}
+}
+
+// DownloaderWithProtocWktPath returns a DownloaderOption that uses the given path to include
+// the well-known types.
+func DownloaderWithProtocWktPath(protocWktPath string) DownloaderOption {
+	return func(downloader *downloader) {
+		downloader.protocWktPath = protocWktPath
+	}
+}
+
 // DownloaderWithProtocURL returns a DownloaderOption that uses the given protoc zip file URL.
 //
 // The default is https://github.com/protocolbuffers/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
 func DownloaderWithProtocURL(protocURL string) DownloaderOption {
 	return func(downloader *downloader) {
 		downloader.protocURL = protocURL
-	}
-}
-
-// DownloaderWithNoCache returns a DownloaderOption that disables caching.
-//
-// The default is https://github.com/protocolbuffers/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
-func DownloaderWithNoCache() DownloaderOption {
-	return func(downloader *downloader) {
-		downloader.noCache = true
 	}
 }
 
@@ -155,19 +161,28 @@ func CompilerWithCachePath(cachePath string) CompilerOption {
 	}
 }
 
+// CompilerWithProtocBinPath returns a CompilerOption that uses the given protoc binary path.
+//
+func CompilerWithProtocBinPath(protocBinPath string) CompilerOption {
+	return func(compiler *compiler) {
+		compiler.protocBinPath = protocBinPath
+	}
+}
+
+// CompilerWithProtocWktPath returns a CompilerOption that uses the given path to include the
+// well-known types.
+func CompilerWithProtocWktPath(protocWktPath string) CompilerOption {
+	return func(compiler *compiler) {
+		compiler.protocWktPath = protocWktPath
+	}
+}
+
 // CompilerWithProtocURL returns a CompilerOption that uses the given protoc zip file URL.
 //
 // The default is https://github.com/protocolbuffers/protobuf/releases/download/vVERSION/protoc-VERSION-OS-ARCH.zip.
 func CompilerWithProtocURL(protocURL string) CompilerOption {
 	return func(compiler *compiler) {
 		compiler.protocURL = protocURL
-	}
-}
-
-// CompilerWithNoCache disables caching.
-func CompilerWithNoCache() CompilerOption {
-	return func(compiler *compiler) {
-		compiler.noCache = true
 	}
 }
 

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -91,11 +91,11 @@ func DownloaderWithProtocBinPath(protocBinPath string) DownloaderOption {
 	}
 }
 
-// DownloaderWithProtocWktPath returns a DownloaderOption that uses the given path to include
+// DownloaderWithProtocWKTPath returns a DownloaderOption that uses the given path to include
 // the well-known types.
-func DownloaderWithProtocWktPath(protocWktPath string) DownloaderOption {
+func DownloaderWithProtocWKTPath(protocWKTPath string) DownloaderOption {
 	return func(downloader *downloader) {
-		downloader.protocWktPath = protocWktPath
+		downloader.protocWKTPath = protocWKTPath
 	}
 }
 
@@ -169,11 +169,11 @@ func CompilerWithProtocBinPath(protocBinPath string) CompilerOption {
 	}
 }
 
-// CompilerWithProtocWktPath returns a CompilerOption that uses the given path to include the
+// CompilerWithProtocWKTPath returns a CompilerOption that uses the given path to include the
 // well-known types.
-func CompilerWithProtocWktPath(protocWktPath string) CompilerOption {
+func CompilerWithProtocWKTPath(protocWKTPath string) CompilerOption {
 	return func(compiler *compiler) {
-		compiler.protocWktPath = protocWktPath
+		compiler.protocWKTPath = protocWKTPath
 	}
 }
 


### PR DESCRIPTION
This proposes two new flags: `--protoc-bin-path` and  `protoc-wkt-path`. This will let users effectively disable Prototool's caching feature. In general, caching is nice-to-have and desirable. However, Prototool needs to handle cases when the `protoc` binary is already compiled from another local file path (as opposed to being copied into its cache). This is especially relevant in build systems, such as [Buck](https://buckbuild.com/) or [Bazel](https://bazel.build/). 

Note that we purposefully add a separate `protoc-wkt-path` flag so that we guarantee that users are including the well-known types. An error is returned if either of these flags are set without the other.

I've tested this manually for the time being. If we think that this is the best approach forward, then I'm happy to add tests. I'd prefer to gather feedback before doing so because this is a potentially controversial change.
