### PR TITLE
Remove setting of GOOS and GOARCH in etc/bin/brewgen.sh

### DIFF
--- a/etc/bin/brewgen.sh
+++ b/etc/bin/brewgen.sh
@@ -17,7 +17,7 @@ mkdir -p "${BUILD_DIR}/share/man/man1"
 go run internal/cmd/gen-prototool-bash-completion/main.go > "${BUILD_DIR}/etc/bash_completion.d/prototool"
 go run internal/cmd/gen-prototool-zsh-completion/main.go > "${BUILD_DIR}/etc/zsh/site-functions/_prototool"
 go run internal/cmd/gen-prototool-manpages/main.go "${BUILD_DIR}/share/man/man1"
-CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
+CGO_ENABLED=0 \
   go build \
   -a \
   -installsuffix cgo \


### PR DESCRIPTION
This was copy/pasted from the release build script, where these are actually needed. With Homebrew, these do not need to be set as you are building on your actual machine, and with Linuxbrew, setting these will actually produce the wrong binary.