### PR TITLE
update example with the new syntax

### DIFF
--- a/example/idl/uber/prototool.yaml
+++ b/example/idl/uber/prototool.yaml
@@ -4,7 +4,7 @@ protoc:
   # note vendor is .gitignored
   - ../../../vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
 lint:
-  # run "prototool list-linters" to see the currently configured linters
+  # run "prototool lint --list-linters" to see the currently configured linters
   # add "exclude_ids" to ignore specific linter IDs for all files
   ignores:
     - id: REQUEST_RESPONSE_TYPES_IN_SAME_FILE


### PR DESCRIPTION
This PR fixes command in `prototool.yaml` example. Since [v0.5.0](https://github.com/uber/prototool/releases/tag/v0.5.0) `list-linters` is a flag of `lint` command.

Minor change but let's safe someone's time.