### PR TITLE
Add backward-compatibility checker

### DIFF
--- a/internal/compatible/check.go
+++ b/internal/compatible/check.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import "github.com/uber/prototool/internal/location"

--- a/internal/compatible/check.go
+++ b/internal/compatible/check.go
@@ -1,0 +1,88 @@
+package compatible
+
+import "github.com/uber/prototool/internal/location"
+
+// descriptorProtoGroup represents a collection of descriptorProto
+// types.
+//
+// We define a separate interface here so that we can act upon
+// both the concrete type for type-specific validation (e.g.
+// a field's label), and a generic type for general validation
+// (e.g. whether a type was removed).
+//
+// In general, the key is the descriptorProto's name.
+// Numbered descriptorProto types, such as fields and enum
+// values, use the string-equivalent representation of their
+// number.
+type descriptorProtoGroup interface {
+	Items() map[string]descriptorProto
+}
+
+// descriptorProto is an interface implemented by all of the
+// Protobuf types we have defined internally.
+//
+//  For example,
+//   m := &message{name: "foo", path: [4, 0]}
+//   m.Name() == "foo"
+//   m.Path() == [4, 0]
+//   m.Type() == `Message "foo"`
+//
+//   f := &field{name: "bar", number: 0, path: [4, 0, 2, 0]}
+//   f.Name() == "bar"
+//   f.Path() == [4, 0, 2, 0]
+//   f.Type() == `Field "bar" (0)`
+type descriptorProto interface {
+	Name() string
+	Path() location.Path
+	Type() string
+}
+
+// checkRemovedItems determines if any of the descriptorProto types in the
+// original collection were removed from updated collection.
+func (c *fileChecker) checkRemovedItems(original, updated descriptorProtoGroup, id location.ID) {
+	originalItems, updatedItems := original.Items(), updated.Items()
+	for name, u := range updatedItems {
+		if o, ok := originalItems[name]; ok {
+			c.checkRenamedItem(o, u)
+		}
+	}
+	for name, o := range originalItems {
+		if _, ok := updatedItems[name]; !ok {
+			c.AddErrorf(
+				o.Path().Target(id),
+				Wire,
+				"%s was removed.",
+				o.Type(),
+			)
+		}
+	}
+}
+
+// checkRenamedItem is a short-hand function for determining if the original
+// decsriptorProto had its name updated.
+func (c *fileChecker) checkRenamedItem(original, updated descriptorProto) {
+	c.checkUpdatedAttribute(
+		original,
+		Source,
+		"name",
+		original.Name(),
+		updated.Name(),
+		location.Name,
+	)
+}
+
+// checkUpdatedAttribute determines if the original descriptorProto's attribute
+// was updated.
+func (c *fileChecker) checkUpdatedAttribute(typ descriptorProto, severity Severity, attribute, original, updated string, id location.ID) {
+	if original != updated {
+		c.AddErrorf(
+			typ.Path().Target(id),
+			severity,
+			"%s had its %s updated from %q to %q.",
+			typ.Type(),
+			attribute,
+			original,
+			updated,
+		)
+	}
+}

--- a/internal/compatible/check_test.go
+++ b/internal/compatible/check_test.go
@@ -1,0 +1,24 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// checkerFn is is a generic representation for compatibility
+// check functions.
+type checkerFn func(descriptorProtoGroup, descriptorProtoGroup)
+
+// check executes the given fn, and asserts that the expected error,
+// if any, is equivalent to the one found on the fileChecker.
+func check(t *testing.T, c *fileChecker, fn checkerFn, original, updated descriptorProtoGroup, err string) {
+	fn(original, updated)
+	if err == "" {
+		assert.Empty(t, c.errors)
+		return
+	}
+	require.Len(t, c.errors, 1)
+	assert.Equal(t, c.errors[0].String(), err)
+}

--- a/internal/compatible/check_test.go
+++ b/internal/compatible/check_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/checker.go
+++ b/internal/compatible/checker.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/checker.go
+++ b/internal/compatible/checker.go
@@ -1,0 +1,74 @@
+package compatible
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+// fileChecker collects compatibility errors for a specific file.
+type fileChecker struct {
+	filename string
+	finder   *location.Finder
+	errors   Errors
+}
+
+func newFileChecker(from *descriptor.FileDescriptorProto) *fileChecker {
+	return &fileChecker{
+		filename: from.GetName(),
+		finder:   location.NewFinder(from.GetSourceCodeInfo()),
+	}
+}
+
+// Check determines whether "to" is backward-compatible with "from".
+func Check(from, to *descriptor.FileDescriptorSet) []Error {
+	var (
+		basePath location.Path
+		errs     Errors
+	)
+
+	fs := newFileSet(from)
+	for _, updated := range to.GetFile() {
+		if original, ok := fs[updated.GetName()]; ok {
+			c := newFileChecker(original.descriptor)
+			errs = append(errs, c.checkFile(original, newFile(updated, basePath))...)
+		}
+	}
+
+	fs = newFileSet(to)
+	for _, original := range from.GetFile() {
+		filename := original.GetName()
+		if _, ok := fs[filename]; !ok {
+			errs = append(
+				errs,
+				Error{
+					Filename: filename,
+					Severity: Warn,
+					Message:  fmt.Sprintf("Failed to validate file %q: the file no longer exists.", filename),
+				},
+			)
+		}
+	}
+
+	sort.Sort(errs)
+	return errs
+}
+
+// AddErrorf adds an Error to the fileChecker using the given path and formatted message.
+func (c *fileChecker) AddErrorf(path location.Path, severity Severity, format string, args ...interface{}) {
+	// If a location does not exist for
+	// the given path, we fall back to
+	// the default location.Span value.
+	loc, _ := c.finder.Find(path)
+
+	err := Error{
+		Filename: c.filename,
+		Line:     loc.Span.Line(),
+		Column:   loc.Span.Col(),
+		Severity: severity,
+		Message:  fmt.Sprintf(format, args...),
+	}
+	c.errors = append(c.errors, err)
+}

--- a/internal/compatible/checker_test.go
+++ b/internal/compatible/checker_test.go
@@ -1,0 +1,51 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+const _testFilename = "test.proto"
+
+func newTestChecker(t *testing.T) *fileChecker {
+	return newFileChecker(
+		&descriptor.FileDescriptorProto{
+			Name: proto.String(_testFilename),
+		},
+	)
+}
+
+func TestCheck(t *testing.T) {
+	t.Run("bar.proto", func(t *testing.T) {
+		t.Skip("re-add when proper breakage tests are standardized in prototool")
+		//original, err := encoding.UnmarshalDescriptorSet("../../internal/testdata/compatible/bar/bar.fd")
+		//require.NoError(t, err)
+
+		//updated, err := encoding.UnmarshalDescriptorSet("../../internal/testdata/compatible/bar/bar.updated.fd")
+		//require.NoError(t, err)
+
+		//actErrs := Check(original, updated)
+
+		//expErrs := []string{
+		//`bar.proto:1:1:wire:File "bar.proto" had its package updated from "" to "bar.bar".`,
+		//`bar.proto:4:16:wire:Field "name" (1) had its json name updated from "NameJSON" to "name".`,
+		//`bar.proto:6:15:wire:Oneof "only" was removed.`,
+		//`bar.proto:7:17:wire:Field "this" (2) had its type updated from "int32" to "sfixed32".`,
+		//`bar.proto:7:23:wire:Field "this" (2) had its oneof declaration updated from "only" to "none".`,
+		//`bar.proto:8:17:wire:Field "that" (3) had its type updated from "int64" to "sfixed64".`,
+		//`bar.proto:8:23:wire:Field "that" (3) had its oneof declaration updated from "only" to "none".`,
+		//`bar.proto:12:9:wire:Message "Request" was removed.`,
+		//`bar.proto:13:9:wire:Message "Response" was removed.`,
+		//`bar.proto:16:19:wire:Method "Write" had its request type updated from "Request" to "bar.bar.Bar".`,
+		//`bar.proto:16:37:wire:Method "Write" had its response type updated from "Response" to "bar.bar.Bar".`,
+		//}
+
+		//require.Len(t, expErrs, len(actErrs))
+
+		//for i, err := range actErrs {
+		//assert.Equal(t, err.String(), expErrs[i])
+		//}
+	})
+}

--- a/internal/compatible/checker_test.go
+++ b/internal/compatible/checker_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/enum.go
+++ b/internal/compatible/enum.go
@@ -1,0 +1,116 @@
+package compatible
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+type enums map[string]*enum
+
+var _ descriptorProtoGroup = (enums)(nil)
+
+func (es enums) Items() map[string]descriptorProto {
+	items := make(map[string]descriptorProto)
+	for s, e := range es {
+		items[s] = e
+	}
+	return items
+}
+
+// enum represents a *descriptor.EnumDescriptorProto.
+type enum struct {
+	path   location.Path
+	name   string
+	values enumValues
+}
+
+var _ descriptorProto = (*enum)(nil)
+
+func (e *enum) Name() string        { return e.name }
+func (e *enum) Path() location.Path { return e.path }
+func (e *enum) Type() string        { return fmt.Sprintf("Enum %q", e.name) }
+
+type enumValues map[string]*enumValue
+
+var _ descriptorProtoGroup = (enumValues)(nil)
+
+func (es enumValues) Items() map[string]descriptorProto {
+	m := make(map[string]descriptorProto)
+	for i, e := range es {
+		m[i] = e
+	}
+	return m
+}
+
+// enumValue represents a *descriptor.EnumValueDescriptorProto.
+type enumValue struct {
+	path   location.Path
+	name   string
+	number int32
+}
+
+var _ descriptorProto = (*enumValue)(nil)
+
+func (e *enumValue) Name() string        { return e.name }
+func (e *enumValue) Path() location.Path { return e.path }
+func (e *enumValue) Type() string        { return fmt.Sprintf("Enum value %q (%d)", e.name, e.number) }
+
+// hasEnums is implemented by both the *descriptor.FileDescriptorProto
+// and *descriptor.DescriptorProto types.
+type hasEnums interface {
+	GetEnumType() []*descriptor.EnumDescriptorProto
+}
+
+// getEnums is used to construct a collection of enums from a
+// type that has enums. Note that the location identifier
+// differs based on the parent type. For file descriptors, the
+// identifier is location.Enum, whereas for message descriptors
+// the identifier is location.MessageEnum.
+func getEnums(d hasEnums, p location.Path, id location.ID) enums {
+	enums := make(enums, len(d.GetEnumType()))
+	for i, e := range d.GetEnumType() {
+		enums[e.GetName()] = newEnum(e, p.Scope(id, i))
+	}
+	return enums
+}
+
+func newEnum(ed *descriptor.EnumDescriptorProto, p location.Path) *enum {
+	return &enum{
+		path:   p,
+		name:   ed.GetName(),
+		values: getEnumValues(ed, p),
+	}
+}
+
+func getEnumValues(ed *descriptor.EnumDescriptorProto, p location.Path) enumValues {
+	values := make(enumValues, len(ed.GetValue()))
+	for i, vd := range ed.GetValue() {
+		values[strconv.Itoa(int(vd.GetNumber()))] = newEnumValue(vd, p.Scope(location.EnumValue, i))
+	}
+	return values
+}
+
+func newEnumValue(vd *descriptor.EnumValueDescriptorProto, p location.Path) *enumValue {
+	return &enumValue{
+		path:   p,
+		name:   vd.GetName(),
+		number: vd.GetNumber(),
+	}
+}
+
+// checkEnums verifies that,
+//  - None of the enum types were removed.
+//  - None of an enum's values/numbers were removed.
+//  - None of an enum's value names were updated.
+func (c *fileChecker) checkEnums(original, updated enums) {
+	c.checkRemovedItems(original, updated, location.Name)
+	for i, ue := range updated {
+		oe, ok := original[i]
+		if ok {
+			c.checkRemovedItems(oe.values, ue.values, location.EnumValueNumber)
+		}
+	}
+}

--- a/internal/compatible/enum.go
+++ b/internal/compatible/enum.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/enum_test.go
+++ b/internal/compatible/enum_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/enum_test.go
+++ b/internal/compatible/enum_test.go
@@ -1,0 +1,104 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+type testHasEnums struct {
+	enums []*descriptor.EnumDescriptorProto
+}
+
+func (c *testHasEnums) GetEnumType() []*descriptor.EnumDescriptorProto {
+	if c != nil {
+		return c.enums
+	}
+	return nil
+}
+
+func newTestEnumContainer(t *testing.T, name string, values map[int32]string) *testHasEnums {
+	return &testHasEnums{
+		enums: []*descriptor.EnumDescriptorProto{
+			{
+				Name:  proto.String(name),
+				Value: newTestEnumValues(t, values),
+			},
+		},
+	}
+}
+
+func newTestEnumValues(t *testing.T, values map[int32]string) []*descriptor.EnumValueDescriptorProto {
+	ev := make([]*descriptor.EnumValueDescriptorProto, len(values))
+	var i int
+	for num, name := range values {
+		ev[i] = &descriptor.EnumValueDescriptorProto{
+			Name:   proto.String(name),
+			Number: proto.Int32(num),
+		}
+		i++
+	}
+	return ev
+}
+
+func TestEnum(t *testing.T) {
+	tests := []struct {
+		desc           string
+		originalType   string
+		updatedType    string
+		originalValues map[int32]string
+		updatedValues  map[int32]string
+		err            string
+	}{
+		{
+			desc:          "Valid update",
+			originalType:  "foo",
+			updatedType:   "foo",
+			updatedValues: map[int32]string{1: "new"},
+		},
+		{
+			desc:         "Removed enum type",
+			originalType: "old",
+			updatedType:  "new",
+			err:          `test.proto:1:1:wire:Enum "old" was removed.`,
+		},
+		{
+			desc:           "Removed enum value number",
+			originalType:   "foo",
+			updatedType:    "foo",
+			originalValues: map[int32]string{1: "foo", 2: "foo"},
+			updatedValues:  map[int32]string{1: "foo"},
+			err:            `test.proto:1:1:wire:Enum value "foo" (2) was removed.`,
+		},
+		{
+			desc:           "Renamed enum value number",
+			originalType:   "foo",
+			updatedType:    "foo",
+			originalValues: map[int32]string{1: "old"},
+			updatedValues:  map[int32]string{1: "new", 2: "another"},
+			err:            `test.proto:1:1:source:Enum value "old" (1) had its name updated from "old" to "new".`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			original := getEnums(
+				newTestEnumContainer(t, tt.originalType, tt.originalValues),
+				nil,           // location.Path
+				location.Name, // location.ID
+			)
+			updated := getEnums(
+				newTestEnumContainer(t, tt.updatedType, tt.updatedValues),
+				nil,           // location.Path
+				location.Name, // location.ID
+			)
+
+			c := newTestChecker(t)
+			fn := func(o, u descriptorProtoGroup) {
+				c.checkEnums(o.(enums), u.(enums))
+			}
+			check(t, c, fn, original, updated, tt.err)
+		})
+	}
+}

--- a/internal/compatible/error.go
+++ b/internal/compatible/error.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/error.go
+++ b/internal/compatible/error.go
@@ -1,0 +1,73 @@
+package compatible
+
+import (
+	"fmt"
+)
+
+// Severity represents the signficance of a
+// backward-incompatible change.
+type Severity string
+
+// The different levels of severity.
+const (
+	Source Severity = "source"
+	Warn   Severity = "warn"
+	Wire   Severity = "wire"
+)
+
+// Error represents an API-compatibility error.
+type Error struct {
+	// The full path to the filename, as in foo/bar.proto.
+	Filename string   `json:"filename"`
+	Line     int32    `json:"line"`
+	Column   int32    `json:"column"`
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+}
+
+// String returns a string representation of the Error type.
+// The string is of the following form,
+//
+//  $(FILENAME):$(LINE):$(COLUMN):$(SEVERITY):$(MESSAGE)
+//
+//  For example,
+//   "foo.proto:5:10:wire:Field number (1) with name "foo" was removed."
+func (e Error) String() string {
+	return fmt.Sprintf("%s:%d:%d:%s:%s", e.Filename, e.Line, e.Column, e.Severity, e.Message)
+}
+
+// Errors is defined in order to sort a slice of Errors.
+type Errors []Error
+
+// Less defines the precedence for sorting a slice of Errors.
+// The order is as follows,
+//  - Filename
+//  - Line
+//  - Column
+//  - Severity
+//  - Message
+func (errs Errors) Less(i, j int) bool {
+	if errs[i].Filename != errs[j].Filename {
+		return errs[i].Filename < errs[j].Filename
+	}
+	if errs[i].Line != errs[j].Line {
+		return errs[i].Line < errs[j].Line
+	}
+	if errs[i].Column != errs[j].Column {
+		return errs[i].Column < errs[j].Column
+	}
+	if errs[i].Severity != errs[j].Severity {
+		return errs[i].Severity < errs[j].Severity
+	}
+	return errs[i].Message < errs[j].Message
+}
+
+// Len returns the length of this slice of Errors.
+func (errs Errors) Len() int {
+	return len(errs)
+}
+
+// Swap swaps two elements in the slice of Errors.
+func (errs Errors) Swap(i, j int) {
+	errs[i], errs[j] = errs[j], errs[i]
+}

--- a/internal/compatible/error_test.go
+++ b/internal/compatible/error_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/error_test.go
+++ b/internal/compatible/error_test.go
@@ -1,0 +1,50 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		desc     string
+		filename string
+		line     int32
+		column   int32
+		severity Severity
+		message  string
+		wantErr  string
+	}{
+		{
+			desc:     "Error with default Span",
+			filename: _testFilename,
+			line:     1,
+			column:   1,
+			severity: Wire,
+			message:  "Unable to locate error!",
+			wantErr:  "test.proto:1:1:wire:Unable to locate error!",
+		},
+		{
+			desc:     "Error with non-zero Span",
+			filename: _testFilename,
+			line:     6,
+			column:   11,
+			severity: Source,
+			message:  "Error located!",
+			wantErr:  "test.proto:6:11:source:Error located!",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := Error{
+				Filename: tt.filename,
+				Line:     tt.line,
+				Column:   tt.column,
+				Severity: tt.severity,
+				Message:  tt.message,
+			}
+			assert.Equal(t, err.String(), tt.wantErr)
+		})
+	}
+}

--- a/internal/compatible/field.go
+++ b/internal/compatible/field.go
@@ -1,0 +1,231 @@
+package compatible
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+const (
+	_labelPrefix   = "LABEL_"
+	_typePrefix    = "TYPE_"
+	_repeatedLabel = "repeated"
+	_singularLabel = "singular"
+	_none          = "none"
+)
+
+type fields map[string]*field
+
+var _ descriptorProtoGroup = (fields)(nil)
+
+func (fs fields) Items() map[string]descriptorProto {
+	items := make(map[string]descriptorProto)
+	for i, f := range fs {
+		items[i] = f
+	}
+	return items
+}
+
+// field represents a *descriptor.FieldDescriptorProto.
+type field struct {
+	path     location.Path
+	typeID   location.ID
+	name     string
+	typeName string
+	jsonName string
+	label    string
+	oneof    string
+	number   int32
+}
+
+var _ descriptorProto = (*field)(nil)
+
+func (f *field) Name() string        { return f.name }
+func (f *field) Path() location.Path { return f.path }
+func (f *field) Type() string        { return fmt.Sprintf("Field %q (%d)", f.name, f.number) }
+
+func newField(fd *descriptor.FieldDescriptorProto, os []*descriptor.OneofDescriptorProto, p location.Path) *field {
+	typeName, id := getFieldType(fd)
+	return &field{
+		path:     p,
+		name:     fd.GetName(),
+		jsonName: fd.GetJsonName(),
+		typeName: typeName,
+		typeID:   id,
+		label:    getFieldLabel(fd),
+		number:   fd.GetNumber(),
+		oneof:    getOneof(fd, os),
+	}
+}
+
+// checkFields verifies that,
+//  - None of the field values/numbers were removed.
+//  - None of the field names were updated.
+//  - None of the field json names were updated.
+//  - None of the field types were updated.
+//  - None of the field labels were updated.
+//  - None of the field oneof declarations were updated.
+func (c *fileChecker) checkFields(original, updated fields) {
+	c.checkRemovedItems(original, updated, location.FieldNumber)
+	for i, uf := range updated {
+		if of, ok := original[i]; ok {
+			c.checkField(of, uf)
+		}
+	}
+}
+
+func (c *fileChecker) checkField(original, updated *field) {
+	c.checkUpdatedAttribute(
+		original,
+		Wire,
+		"json name",
+		original.jsonName,
+		updated.jsonName,
+		location.Name,
+	)
+	c.checkUpdatedAttribute(
+		original,
+		getFieldTypeSeverity(original.typeName, updated.typeName),
+		"type",
+		original.typeName,
+		updated.typeName,
+		original.typeID,
+	)
+	c.checkUpdatedAttribute(
+		original,
+		Wire,
+		"oneof declaration",
+		original.oneof,
+		updated.oneof,
+		location.Name,
+	)
+	// The label can be safely evolved from "singular" to
+	// "repeated" with respect to wire-compatibility.
+	//
+	// In the case of a "singular" label, the label
+	// doesn't actually exist, so we set our target
+	// to the field's name.
+	severity, target := Source, location.Name
+	if original.label == _repeatedLabel {
+		// If the original label was "repeated", then
+		// any update is wire-incompatible, i.e.
+		// an update from "repeated" to "singular".
+		severity, target = Wire, location.FieldLabel
+	}
+	c.checkUpdatedAttribute(
+		original,
+		severity,
+		"label",
+		original.label,
+		updated.label,
+		target,
+	)
+}
+
+// getFieldType maps the given field's type to a more aesthetically appropriate
+// representation. We prioritize the TypeName representation if it is set.
+// Note that the location.ID changes based on whether the type was derived from
+// the field's type name or its plain type.
+//
+//  For example,
+//   FieldDescriptorProto.TypeName == ".foo.Bar"
+//   FieldDescriptorProto.Type     == "TYPE_DOUBLE"
+func getFieldType(fd *descriptor.FieldDescriptorProto) (string, location.ID) {
+	if typeName := strings.TrimPrefix(fd.GetTypeName(), "."); typeName != "" {
+		return typeName, location.FieldTypeName
+	}
+	return lowerTrimPrefix(fd.GetType().String(), _typePrefix), location.FieldType
+}
+
+// getFieldLabel maps the given field's label to a more aesthetically
+// appropriate representation. Note that this also handles
+// the mapping of the default label values to "singular".
+//
+// In proto3, the only valid label is "repeated"; "optional"
+// and "required" are no longer valid.
+func getFieldLabel(fd *descriptor.FieldDescriptorProto) string {
+	if l := lowerTrimPrefix(fd.GetLabel().String(), _labelPrefix); l == _repeatedLabel {
+		return l
+	}
+	return _singularLabel
+}
+
+// getOneof maps the given field's oneof index to a more aesthetically
+// appropriate representation. The field contains a reference to the
+// index of the containing message's oneof declarations, so we map
+// the index to its corresponding name.
+//
+// Given that the default value of the oneof index is 0, yet this also
+// represents a valid index (the first oneof, zero-indexed), we instead
+// transform a missing oneof declaration to "none".
+func getOneof(fd *descriptor.FieldDescriptorProto, os []*descriptor.OneofDescriptorProto) string {
+	if fd.OneofIndex != nil {
+		return os[fd.GetOneofIndex()].GetName()
+	}
+	return _none
+}
+
+// lowerTrimPrefix trims the prefix from the given string and
+// transforms it to its lowercase equivalent.
+// This is useful for strings received from fields, such as
+// FieldDescriptorProto.Type and FielDescriptor.Label.
+//
+//  For example,
+//   FieldDescriptorProto.Type:  "TYPE_STRING"     -> "string"
+//   FieldDescriptorProto.Label: "LABEL_REPEATED"  -> "repeated"
+func lowerTrimPrefix(s, prefix string) string {
+	return strings.ToLower(
+		strings.TrimPrefix(
+			s,
+			prefix,
+		),
+	)
+}
+
+// getFieldTypeSeverity determines the severity of a field type update.
+// An int32 can change into a sint32 and still be wire-compatible,
+// for example. In this case, this function would return a "source"
+// severity, since it would only affect the generated source code.
+//
+// For more details, see:
+// https://developers.google.com/protocol-buffers/docs/proto3#updating
+func getFieldTypeSeverity(original, updated string) Severity {
+	if compatibleWireFormat(original, updated) {
+		return Source
+	}
+	return Wire
+}
+
+var (
+	// Each []string group contains interchangeable types.
+	_interchangeableGroups = [][]string{
+		{"int32", "uint32", "int64", "uint64", "bool"},
+		{"sint32", "sint64"},
+		{"fixed32", "sfixed32"},
+		{"fixed64", "sfixed64"},
+	}
+	_interchangeableGroupIndexes []map[string]struct{}
+)
+
+func init() {
+	_interchangeableGroupIndexes = make([]map[string]struct{}, len(_interchangeableGroups))
+	for i, group := range _interchangeableGroups {
+		m := make(map[string]struct{}, len(group))
+		for _, g := range group {
+			m[g] = struct{}{}
+		}
+		_interchangeableGroupIndexes[i] = m
+	}
+}
+
+func compatibleWireFormat(original, updated string) bool {
+	for _, interchangeable := range _interchangeableGroupIndexes {
+		if _, ok := interchangeable[updated]; ok {
+			_, ok = interchangeable[original]
+			return ok
+		}
+	}
+	return false
+}

--- a/internal/compatible/field.go
+++ b/internal/compatible/field.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/field_test.go
+++ b/internal/compatible/field_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/field_test.go
+++ b/internal/compatible/field_test.go
@@ -1,0 +1,200 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestField(t *testing.T) {
+	tests := []struct {
+		desc     string
+		original fields
+		updated  fields
+		err      string
+	}{
+		{
+			desc:     "Valid update",
+			original: fields{"1": &field{number: 1, name: "unchanged"}},
+			updated:  fields{"1": &field{number: 1, name: "unchanged"}, "2": &field{number: 2, name: "new"}},
+		},
+		{
+			desc:     "Removed field number",
+			original: fields{"1": &field{number: 1, name: "old"}},
+			updated:  fields{"2": &field{number: 2, name: "new"}},
+			err:      `test.proto:1:1:wire:Field "old" (1) was removed.`,
+		},
+		{
+			desc:     "Updated json name",
+			original: fields{"1": &field{number: 1, name: "old", jsonName: "old"}},
+			updated:  fields{"1": &field{number: 1, name: "old", jsonName: "new"}},
+			err:      `test.proto:1:1:wire:Field "old" (1) had its json name updated from "old" to "new".`,
+		},
+		{
+			desc:     "Updated type name with wire-compatible types",
+			original: fields{"1": &field{number: 1, name: "old", typeName: "int32"}},
+			updated:  fields{"1": &field{number: 1, name: "old", typeName: "int64"}},
+			err:      `test.proto:1:1:source:Field "old" (1) had its type updated from "int32" to "int64".`,
+		},
+		{
+			desc:     "Updated type name with wire-incompatible types",
+			original: fields{"1": &field{number: 1, name: "old", typeName: "fixed32"}},
+			updated:  fields{"1": &field{number: 1, name: "old", typeName: "int64"}},
+			err:      `test.proto:1:1:wire:Field "old" (1) had its type updated from "fixed32" to "int64".`,
+		},
+		{
+			desc:     "Updated oneof declaration",
+			original: fields{"1": &field{number: 1, name: "old", oneof: "old"}},
+			updated:  fields{"1": &field{number: 1, name: "old", oneof: "new"}},
+			err:      `test.proto:1:1:wire:Field "old" (1) had its oneof declaration updated from "old" to "new".`,
+		},
+		{
+			desc:     `Updated label from "singular" to "repeated" (wire-compatible)`,
+			original: fields{"1": &field{number: 1, name: "old", label: "singular"}},
+			updated:  fields{"1": &field{number: 1, name: "old", label: "repeated"}},
+			err:      `test.proto:1:1:source:Field "old" (1) had its label updated from "singular" to "repeated".`,
+		},
+		{
+			desc:     `Updated label from "repeated" to "singular" (wire-incompatible)`,
+			original: fields{"1": &field{number: 1, name: "old", label: "repeated"}},
+			updated:  fields{"1": &field{number: 1, name: "old", label: "singular"}},
+			err:      `test.proto:1:1:wire:Field "old" (1) had its label updated from "repeated" to "singular".`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := newTestChecker(t)
+			fn := func(o, u descriptorProtoGroup) {
+				c.checkFields(o.(fields), u.(fields))
+			}
+			check(t, c, fn, tt.original, tt.updated, tt.err)
+		})
+	}
+}
+
+func TestNewField(t *testing.T) {
+	t.Run("Hydrated field", func(t *testing.T) {
+		typ := descriptor.FieldDescriptorProto_TYPE_MESSAGE
+		fd := &descriptor.FieldDescriptorProto{
+			Name:     proto.String("name"),
+			TypeName: proto.String(".foo.Bar"),
+			Type:     &typ,
+			JsonName: proto.String("json"),
+			Number:   proto.Int32(1),
+		}
+		f := newField(fd, nil /* Oneofs */, nil /* location.Path */)
+		assert.Equal(t, "name", f.name)
+		assert.Equal(t, "foo.Bar", f.typeName)
+		assert.Equal(t, "json", f.jsonName)
+		assert.Equal(t, "singular", f.label)
+		assert.Equal(t, int32(1), f.number)
+	})
+	t.Run("Type name is not set", func(t *testing.T) {
+		typ := descriptor.FieldDescriptorProto_TYPE_MESSAGE
+		fd := &descriptor.FieldDescriptorProto{
+			Name:   proto.String("name"),
+			Type:   &typ,
+			Number: proto.Int32(1),
+		}
+		f := newField(fd, nil /* Oneofs */, nil /* location.Path */)
+		assert.Equal(t, fd.GetName(), f.name)
+		assert.Equal(t, "message", f.typeName)
+		assert.Equal(t, "singular", f.label)
+	})
+	t.Run("Repeated field", func(t *testing.T) {
+		label := descriptor.FieldDescriptorProto_LABEL_REPEATED
+		fd := &descriptor.FieldDescriptorProto{
+			Name:  proto.String("name"),
+			Label: &label,
+		}
+		f := newField(fd, nil /* Oneofs */, nil /* location.Path */)
+		assert.Equal(t, fd.GetName(), f.name)
+		assert.Equal(t, "repeated", f.label)
+	})
+	t.Run("Oneof declaration", func(t *testing.T) {
+		oneofs := []*descriptor.OneofDescriptorProto{
+			{
+				Name: proto.String("oneof"),
+			},
+		}
+		fd := &descriptor.FieldDescriptorProto{
+			Name:       proto.String("name"),
+			OneofIndex: proto.Int32(0),
+		}
+		f := newField(fd, oneofs, nil /* location.Path */)
+		assert.Equal(t, fd.GetName(), f.name)
+		assert.Equal(t, "oneof", f.oneof)
+	})
+}
+
+func TestWireCompatibleTypes(t *testing.T) {
+	tests := []struct {
+		desc           string
+		original       string
+		updated        string
+		wantCompatible bool
+	}{
+		{
+			desc:           "Identity",
+			original:       "int32",
+			updated:        "int32",
+			wantCompatible: true,
+		},
+		{
+			desc:           "Unsigned integer types",
+			original:       "uint32",
+			updated:        "uint64",
+			wantCompatible: true,
+		},
+		{
+			desc:           "Signed integer types",
+			original:       "sint32",
+			updated:        "sint64",
+			wantCompatible: true,
+		},
+		{
+			desc:           "Bool with compatible integer",
+			original:       "bool",
+			updated:        "int64",
+			wantCompatible: true,
+		},
+		{
+			desc:           "Bool with incompatible integer",
+			original:       "bool",
+			updated:        "sint32",
+			wantCompatible: false,
+		},
+		{
+			desc:           "Fixed 32-bit types",
+			original:       "fixed32",
+			updated:        "sfixed32",
+			wantCompatible: true,
+		},
+		{
+			desc:           "Fixed 64-bit types",
+			original:       "fixed64",
+			updated:        "sfixed64",
+			wantCompatible: true,
+		},
+		{
+			desc:           "Incompatible fixed types",
+			original:       "fixed32",
+			updated:        "fixed64",
+			wantCompatible: false,
+		},
+		{
+			desc:           "Primitive mixed with custom type",
+			original:       "int32",
+			updated:        "foo.Bar",
+			wantCompatible: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			compatible := compatibleWireFormat(tt.original, tt.updated)
+			assert.Equal(t, tt.wantCompatible, compatible)
+		})
+	}
+}

--- a/internal/compatible/file.go
+++ b/internal/compatible/file.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/file.go
+++ b/internal/compatible/file.go
@@ -1,0 +1,75 @@
+package compatible
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+type fileSet map[string]*file
+
+func newFileSet(from *descriptor.FileDescriptorSet) fileSet {
+	var basePath location.Path
+	files := make(map[string]*file, len(from.GetFile()))
+	for _, f := range from.GetFile() {
+		files[f.GetName()] = newFile(f, basePath)
+	}
+	return files
+}
+
+// file represents a *descriptor.FileDescriptorProto.
+type file struct {
+	descriptor *descriptor.FileDescriptorProto
+	path       location.Path
+	name       string
+	pkg        string
+	enums      enums
+	messages   messages
+	services   services
+}
+
+func (f *file) Name() string        { return f.name }
+func (f *file) Path() location.Path { return f.path }
+func (f *file) Type() string        { return fmt.Sprintf("File %q", f.name) }
+
+func newFile(fd *descriptor.FileDescriptorProto, p location.Path) *file {
+	messages := make(messages, len(fd.GetMessageType()))
+	for i, m := range fd.GetMessageType() {
+		messages[m.GetName()] = newMessage(m, p.Scope(location.Message, i))
+	}
+	services := make(services, len(fd.GetService()))
+	for i, s := range fd.GetService() {
+		services[s.GetName()] = newService(s, p.Scope(location.Service, i))
+	}
+
+	return &file{
+		descriptor: fd,
+		path:       p,
+		name:       fd.GetName(),
+		pkg:        fd.GetPackage(),
+		messages:   messages,
+		enums:      getEnums(fd, p, location.Enum),
+		services:   services,
+	}
+}
+
+// checkFile verifies that,
+//  - The file's package was not updated.
+//  - None of the file's messages were inappropriately updated.
+//  - None of the file's enums were inappropriately updated.
+//  - None of the file's services were inappropriately updated.
+func (c *fileChecker) checkFile(original, updated *file) []Error {
+	c.checkUpdatedAttribute(
+		original,
+		Wire,
+		"package",
+		original.pkg,
+		updated.pkg,
+		location.Package,
+	)
+	c.checkMessages(original.messages, updated.messages)
+	c.checkEnums(original.enums, updated.enums)
+	c.checkServices(original.services, updated.services)
+	return c.errors
+}

--- a/internal/compatible/file_test.go
+++ b/internal/compatible/file_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/file_test.go
+++ b/internal/compatible/file_test.go
@@ -1,0 +1,59 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFile(t *testing.T) {
+	t.Run("No change", func(t *testing.T) {
+		c := newTestChecker(t)
+		c.checkFile(&file{name: _testFilename, pkg: "foo"}, &file{name: _testFilename, pkg: "foo"})
+		assert.Len(t, c.errors, 0)
+	})
+	t.Run("Updated file package", func(t *testing.T) {
+		c := newTestChecker(t)
+		c.checkFile(&file{name: _testFilename, pkg: ""}, &file{name: _testFilename, pkg: "foo"})
+		require.Len(t, c.errors, 1)
+		assert.Equal(t, c.errors[0].String(), `test.proto:1:1:wire:File "test.proto" had its package updated from "" to "foo".`)
+	})
+}
+
+func TestNewFileSet(t *testing.T) {
+	t.Run("Empty file set", func(t *testing.T) {
+		fs := newFileSet(&descriptor.FileDescriptorSet{})
+		assert.Len(t, fs, 0)
+	})
+	t.Run("Non-empty file set", func(t *testing.T) {
+		fs := newFileSet(&descriptor.FileDescriptorSet{
+			File: []*descriptor.FileDescriptorProto{
+				{
+					Name: proto.String("filename.proto"),
+					MessageType: []*descriptor.DescriptorProto{
+						{
+							Name: proto.String("msg"),
+						},
+					},
+					Service: []*descriptor.ServiceDescriptorProto{
+						{
+							Name: proto.String("service"),
+						},
+					},
+				},
+			},
+		})
+		require.Len(t, fs, 1)
+
+		f := fs["filename.proto"]
+		require.Len(t, f.messages, 1)
+		require.Len(t, f.services, 1)
+
+		assert.Equal(t, "filename.proto", f.name)
+		assert.Equal(t, "msg", f.messages["msg"].name)
+		assert.Equal(t, "service", f.services["service"].name)
+	})
+}

--- a/internal/compatible/message.go
+++ b/internal/compatible/message.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/message.go
+++ b/internal/compatible/message.go
@@ -1,0 +1,82 @@
+package compatible
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+type messages map[string]*message
+
+var _ descriptorProtoGroup = (messages)(nil)
+
+func (ms messages) Items() map[string]descriptorProto {
+	items := make(map[string]descriptorProto)
+	for i, m := range ms {
+		items[i] = m
+	}
+	return items
+}
+
+// message represents a *descriptor.DescriptorProto.
+type message struct {
+	path     location.Path
+	name     string
+	fields   fields
+	enums    enums
+	messages messages
+	oneofs   oneofs
+}
+
+var _ descriptorProto = (*message)(nil)
+
+func (m *message) Name() string        { return m.name }
+func (m *message) Path() location.Path { return m.path }
+func (m *message) Type() string        { return fmt.Sprintf("Message %q", m.name) }
+
+func newMessage(md *descriptor.DescriptorProto, p location.Path) *message {
+	oneofs := make(oneofs, len(md.GetOneofDecl()))
+	for i, o := range md.GetOneofDecl() {
+		oneofs[o.GetName()] = newOneof(o, p.Scope(location.Oneof, i))
+	}
+	fields := make(fields, len(md.GetField()))
+	for i, f := range md.GetField() {
+		fields[strconv.Itoa(int(f.GetNumber()))] = newField(f, md.GetOneofDecl(), p.Scope(location.Field, i))
+	}
+	messages := make(messages, len(md.GetNestedType()))
+	for i, m := range md.GetNestedType() {
+		messages[m.GetName()] = newMessage(m, p.Scope(location.NestedType, i))
+	}
+	return &message{
+		path:     p,
+		name:     md.GetName(),
+		fields:   fields,
+		enums:    getEnums(md, p, location.MessageEnum),
+		messages: messages,
+		oneofs:   oneofs,
+	}
+}
+
+// checkMessages verifies that,
+//  - None of the messages were removed.
+//  - None of the messages' fields were inappropriately updated.
+//  - None of the messages' enums were inappropriately updated.
+//  - None of the messages' nested messages were inappropriately updated.
+//  - None of the messages' oneofs were inappropriately updated.
+func (c *fileChecker) checkMessages(original, updated messages) {
+	c.checkRemovedItems(original, updated, location.Name)
+	for i, um := range updated {
+		if om, ok := original[i]; ok {
+			c.checkMessage(om, um)
+		}
+	}
+}
+
+func (c *fileChecker) checkMessage(original, updated *message) {
+	c.checkFields(original.fields, updated.fields)
+	c.checkEnums(original.enums, updated.enums)
+	c.checkMessages(original.messages, updated.messages)
+	c.checkOneofs(original.oneofs, updated.oneofs)
+}

--- a/internal/compatible/message_test.go
+++ b/internal/compatible/message_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/message_test.go
+++ b/internal/compatible/message_test.go
@@ -1,0 +1,77 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessage(t *testing.T) {
+	tests := []struct {
+		desc     string
+		original messages
+		updated  messages
+		err      string
+	}{
+		{
+			desc:     "Valid update",
+			original: messages{"foo": &message{name: "foo"}},
+			updated:  messages{"foo": &message{name: "foo"}, "bar": &message{name: "bar"}},
+		},
+		{
+			desc:     "Removed message",
+			original: messages{"foo": &message{name: "foo"}},
+			updated:  messages{"bar": &message{name: "bar"}},
+			err:      `test.proto:1:1:wire:Message "foo" was removed.`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := newTestChecker(t)
+			fn := func(o, u descriptorProtoGroup) {
+				c.checkMessages(o.(messages), u.(messages))
+			}
+			check(t, c, fn, tt.original, tt.updated, tt.err)
+		})
+	}
+}
+
+func TestNewMessage(t *testing.T) {
+	t.Run("Empty message", func(t *testing.T) {
+		m := newMessage(&descriptor.DescriptorProto{Name: proto.String("msg")}, nil /* location.Path */)
+		assert.Equal(t, "msg", m.name)
+	})
+	t.Run("Non-empty message", func(t *testing.T) {
+		m := newMessage(&descriptor.DescriptorProto{
+			Name: proto.String("msg"),
+			Field: []*descriptor.FieldDescriptorProto{
+				{
+					Name:   proto.String("field"),
+					Number: proto.Int32(1),
+				},
+			},
+			NestedType: []*descriptor.DescriptorProto{
+				{
+					Name: proto.String("nested"),
+				},
+			},
+			OneofDecl: []*descriptor.OneofDescriptorProto{
+				{
+					Name: proto.String("oneof"),
+				},
+			},
+		}, nil /* location.Path */)
+
+		require.Len(t, m.fields, 1)
+		require.Len(t, m.messages, 1)
+		require.Len(t, m.oneofs, 1)
+
+		assert.Equal(t, "msg", m.name)
+		assert.Equal(t, "field", m.fields["1"].name)
+		assert.Equal(t, "nested", m.messages["nested"].name)
+		assert.Equal(t, "oneof", m.oneofs["oneof"].name)
+	})
+}

--- a/internal/compatible/method.go
+++ b/internal/compatible/method.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/method.go
+++ b/internal/compatible/method.go
@@ -1,0 +1,111 @@
+package compatible
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+type methods map[string]*method
+
+var _ descriptorProtoGroup = (methods)(nil)
+
+func (ms methods) Items() map[string]descriptorProto {
+	items := make(map[string]descriptorProto)
+	for i, m := range ms {
+		items[i] = m
+	}
+	return items
+}
+
+// method represents a *descriptor.MethodDescriptorProto.
+type method struct {
+	path            location.Path
+	name            string
+	input           string
+	output          string
+	clientStreaming bool
+	serverStreaming bool
+}
+
+var _ descriptorProto = (*method)(nil)
+
+func (m *method) Name() string        { return m.name }
+func (m *method) Path() location.Path { return m.path }
+func (m *method) Type() string        { return fmt.Sprintf("Method %q", m.name) }
+
+func newMethod(md *descriptor.MethodDescriptorProto, p location.Path) *method {
+	return &method{
+		path:            p,
+		name:            md.GetName(),
+		input:           strings.TrimPrefix(md.GetInputType(), "."),
+		output:          strings.TrimPrefix(md.GetOutputType(), "."),
+		clientStreaming: md.GetClientStreaming(),
+		serverStreaming: md.GetServerStreaming(),
+	}
+}
+
+// checkMethods verifies that,
+//  - None of the methods were removed.
+//  - None of the methods' request types were updated.
+//  - None of the methods' response types were updated.
+//  - None of the methods' client streaming capabilities were updated.
+//  - None of the methods' server streaming capabilities were updated.
+func (c *fileChecker) checkMethods(original, updated methods) {
+	c.checkRemovedItems(original, updated, location.Name)
+	for i, um := range updated {
+		if om, ok := original[i]; ok {
+			c.checkMethod(om, um)
+		}
+	}
+}
+
+func (c *fileChecker) checkMethod(original, updated *method) {
+	c.checkUpdatedAttribute(
+		original,
+		Wire,
+		"request type",
+		original.input,
+		updated.input,
+		location.MethodRequest,
+	)
+	c.checkUpdatedAttribute(
+		original,
+		Wire,
+		"response type",
+		original.output,
+		updated.output,
+		location.MethodResponse,
+	)
+	c.checkUpdatedAttribute(
+		original,
+		getStreamSeverity(original.clientStreaming),
+		"client streaming",
+		strconv.FormatBool(original.clientStreaming),
+		strconv.FormatBool(updated.clientStreaming),
+		location.MethodRequest,
+	)
+	c.checkUpdatedAttribute(
+		original,
+		getStreamSeverity(original.serverStreaming),
+		"server streaming",
+		strconv.FormatBool(original.serverStreaming),
+		strconv.FormatBool(updated.serverStreaming),
+		location.MethodResponse,
+	)
+}
+
+// getStreamSeverity determines the severity of a client/server stream
+// update. A method without client/server streaming can update to
+// enable either (or both) and continue to be wire-compatible.
+// However, an update in the reverse direction, i.e. from streaming to
+// not streaming is NOT wire-compatible.
+func getStreamSeverity(original bool) Severity {
+	if original {
+		return Wire
+	}
+	return Source
+}

--- a/internal/compatible/method_test.go
+++ b/internal/compatible/method_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/method_test.go
+++ b/internal/compatible/method_test.go
@@ -1,0 +1,96 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMethod(t *testing.T) {
+	tests := []struct {
+		desc     string
+		original methods
+		updated  methods
+		err      string
+	}{
+		{
+			desc:     "Valid update",
+			original: methods{"foo": &method{name: "foo"}},
+			updated:  methods{"foo": &method{name: "foo"}, "bar": &method{name: "bar"}},
+		},
+		{
+			desc:     "Removed method",
+			original: methods{"foo": &method{name: "foo"}},
+			updated:  methods{"bar": &method{name: "bar"}},
+			err:      `test.proto:1:1:wire:Method "foo" was removed.`,
+		},
+		{
+			desc:     "Updated input",
+			original: methods{"foo": &method{name: "foo", input: "foo.FooRequest"}},
+			updated:  methods{"foo": &method{name: "foo", input: "foo.AnotherRequest"}},
+			err:      `test.proto:1:1:wire:Method "foo" had its request type updated from "foo.FooRequest" to "foo.AnotherRequest".`,
+		},
+		{
+			desc:     "Updated output",
+			original: methods{"foo": &method{name: "foo", output: "foo.FooResponse"}},
+			updated:  methods{"foo": &method{name: "foo", output: "foo.AnotherResponse"}},
+			err:      `test.proto:1:1:wire:Method "foo" had its response type updated from "foo.FooResponse" to "foo.AnotherResponse".`,
+		},
+		{
+			desc:     "Updated client-streaming (wire-compatible)",
+			original: methods{"foo": &method{name: "foo", clientStreaming: false}},
+			updated:  methods{"foo": &method{name: "foo", clientStreaming: true}},
+			err:      `test.proto:1:1:source:Method "foo" had its client streaming updated from "false" to "true".`,
+		},
+		{
+			desc:     "Updated client-streaming (wire-incompatible)",
+			original: methods{"foo": &method{name: "foo", clientStreaming: true}},
+			updated:  methods{"foo": &method{name: "foo", clientStreaming: false}},
+			err:      `test.proto:1:1:wire:Method "foo" had its client streaming updated from "true" to "false".`,
+		},
+		{
+			desc:     "Updated client-streaming (wire-compatible)",
+			original: methods{"foo": &method{name: "foo", serverStreaming: false}},
+			updated:  methods{"foo": &method{name: "foo", serverStreaming: true}},
+			err:      `test.proto:1:1:source:Method "foo" had its server streaming updated from "false" to "true".`,
+		},
+		{
+			desc:     "Updated client-streaming (wire-incompatible)",
+			original: methods{"foo": &method{name: "foo", serverStreaming: true}},
+			updated:  methods{"foo": &method{name: "foo", serverStreaming: false}},
+			err:      `test.proto:1:1:wire:Method "foo" had its server streaming updated from "true" to "false".`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := newTestChecker(t)
+			fn := func(o, u descriptorProtoGroup) {
+				c.checkMethods(o.(methods), u.(methods))
+			}
+			check(t, c, fn, tt.original, tt.updated, tt.err)
+		})
+	}
+}
+
+func TestNewMethod(t *testing.T) {
+	t.Run("Empty method", func(t *testing.T) {
+		m := newMethod(&descriptor.MethodDescriptorProto{Name: proto.String("method")}, nil /* location.Path */)
+		assert.Equal(t, "method", m.name)
+	})
+	t.Run("Non-empty method", func(t *testing.T) {
+		m := newMethod(&descriptor.MethodDescriptorProto{
+			Name:            proto.String("method"),
+			InputType:       proto.String(".foo.BarRequest"),
+			OutputType:      proto.String(".foo.BarResponse"),
+			ClientStreaming: proto.Bool(true),
+		}, nil /* location.Path */)
+
+		assert.Equal(t, "method", m.name)
+		assert.Equal(t, "foo.BarRequest", m.input)
+		assert.Equal(t, "foo.BarResponse", m.output)
+		assert.True(t, m.clientStreaming)
+		assert.False(t, m.serverStreaming)
+	})
+}

--- a/internal/compatible/oneof.go
+++ b/internal/compatible/oneof.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/oneof.go
+++ b/internal/compatible/oneof.go
@@ -1,0 +1,44 @@
+package compatible
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+type oneofs map[string]*oneof
+
+var _ descriptorProtoGroup = (oneofs)(nil)
+
+func (os oneofs) Items() map[string]descriptorProto {
+	items := make(map[string]descriptorProto)
+	for i, o := range os {
+		items[i] = o
+	}
+	return items
+}
+
+// oneof represents a *descriptor.OneofDescriptorProto.
+type oneof struct {
+	path location.Path
+	name string
+}
+
+var _ descriptorProto = (*oneof)(nil)
+
+func (o *oneof) Name() string        { return o.name }
+func (o *oneof) Path() location.Path { return o.path }
+func (o *oneof) Type() string        { return fmt.Sprintf("Oneof %q", o.name) }
+
+func newOneof(od *descriptor.OneofDescriptorProto, p location.Path) *oneof {
+	return &oneof{
+		path: p,
+		name: od.GetName(),
+	}
+}
+
+// checkOneofs verifies that none of the oneof declarations were removed.
+func (c *fileChecker) checkOneofs(original, updated oneofs) {
+	c.checkRemovedItems(original, updated, location.Name)
+}

--- a/internal/compatible/oneof_test.go
+++ b/internal/compatible/oneof_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/oneof_test.go
+++ b/internal/compatible/oneof_test.go
@@ -1,0 +1,44 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOneof(t *testing.T) {
+	tests := []struct {
+		desc     string
+		original oneofs
+		updated  oneofs
+		err      string
+	}{
+		{
+			desc:     "Valid update",
+			original: oneofs{"foo": &oneof{name: "foo"}},
+			updated:  oneofs{"foo": &oneof{name: "foo"}, "bar": &oneof{name: "bar"}},
+		},
+		{
+			desc:     "Removed oneof",
+			original: oneofs{"foo": &oneof{name: "foo"}},
+			updated:  oneofs{"bar": &oneof{name: "bar"}},
+			err:      `test.proto:1:1:wire:Oneof "foo" was removed.`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := newTestChecker(t)
+			fn := func(o, u descriptorProtoGroup) {
+				c.checkOneofs(o.(oneofs), u.(oneofs))
+			}
+			check(t, c, fn, tt.original, tt.updated, tt.err)
+		})
+	}
+}
+
+func TestNewOneof(t *testing.T) {
+	o := newOneof(&descriptor.OneofDescriptorProto{Name: proto.String("oneof")}, nil /* location.Path */)
+	assert.Equal(t, "oneof", o.name)
+}

--- a/internal/compatible/service.go
+++ b/internal/compatible/service.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/compatible/service.go
+++ b/internal/compatible/service.go
@@ -1,0 +1,57 @@
+package compatible
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/uber/prototool/internal/location"
+)
+
+type services map[string]*service
+
+var _ descriptorProtoGroup = (services)(nil)
+
+func (ss services) Items() map[string]descriptorProto {
+	items := make(map[string]descriptorProto)
+	for i, s := range ss {
+		items[i] = s
+	}
+	return items
+}
+
+// service represents a *descriptor.ServiceDescriptorProto.
+type service struct {
+	path    location.Path
+	name    string
+	methods methods
+}
+
+var _ descriptorProto = (*service)(nil)
+
+func (s *service) Name() string        { return s.name }
+func (s *service) Path() location.Path { return s.path }
+func (s *service) Type() string        { return fmt.Sprintf("Service %q", s.name) }
+
+func newService(sd *descriptor.ServiceDescriptorProto, p location.Path) *service {
+	methods := make(methods, len(sd.GetMethod()))
+	for i, m := range sd.GetMethod() {
+		methods[m.GetName()] = newMethod(m, p.Scope(location.Method, i))
+	}
+	return &service{
+		path:    p,
+		name:    sd.GetName(),
+		methods: methods,
+	}
+}
+
+// checkServices verifies that,
+//   - None of the services were removed.
+//   - None of the services' methods were inappropriately updated.
+func (c *fileChecker) checkServices(original, updated services) {
+	c.checkRemovedItems(original, updated, location.Name)
+	for i, us := range updated {
+		if os, ok := original[i]; ok {
+			c.checkMethods(os.methods, us.methods)
+		}
+	}
+}

--- a/internal/compatible/service_test.go
+++ b/internal/compatible/service_test.go
@@ -1,0 +1,62 @@
+package compatible
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService(t *testing.T) {
+	tests := []struct {
+		desc     string
+		original services
+		updated  services
+		err      string
+	}{
+		{
+			desc:     "Valid update",
+			original: services{"foo": &service{name: "foo"}},
+			updated:  services{"foo": &service{name: "foo"}, "bar": &service{name: "bar"}},
+		},
+		{
+			desc:     "Removed service",
+			original: services{"foo": &service{name: "foo"}},
+			updated:  services{"bar": &service{name: "bar"}},
+			err:      `test.proto:1:1:wire:Service "foo" was removed.`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := newTestChecker(t)
+			fn := func(o, u descriptorProtoGroup) {
+				c.checkServices(o.(services), u.(services))
+			}
+			check(t, c, fn, tt.original, tt.updated, tt.err)
+		})
+	}
+}
+
+func TestNewService(t *testing.T) {
+	t.Run("Empty service", func(t *testing.T) {
+		s := newService(&descriptor.ServiceDescriptorProto{Name: proto.String("service")}, nil /* location.Path */)
+		assert.Equal(t, "service", s.name)
+	})
+	t.Run("Non-empty service", func(t *testing.T) {
+		s := newService(&descriptor.ServiceDescriptorProto{
+			Name: proto.String("service"),
+			Method: []*descriptor.MethodDescriptorProto{
+				{
+					Name: proto.String("method"),
+				},
+			},
+		}, nil /* location.Path */)
+
+		require.Len(t, s.methods, 1)
+
+		assert.Equal(t, "service", s.name)
+		assert.Equal(t, "method", s.methods["method"].name)
+	})
+}

--- a/internal/compatible/service_test.go
+++ b/internal/compatible/service_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package compatible
 
 import (

--- a/internal/location/comments.go
+++ b/internal/location/comments.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 // Comments represents a Proto location's comment details.

--- a/internal/location/comments.go
+++ b/internal/location/comments.go
@@ -1,0 +1,29 @@
+package location
+
+// Comments represents a Proto location's comment details.
+type Comments struct {
+	// Leading is the comment that exists before
+	// a proto type's definition.
+	//
+	//  /* I'm a leading comment. */
+	//  message Foo {}
+	//
+	Leading string
+
+	// Trailing is the comment that exists
+	// immediately after a proto type's definition.
+	//
+	//  message Foo {} /* I'm a trailing comment. */
+	//
+	Trailing string
+
+	// LeadingDetached are comments that exists
+	// before a proto type's definition, separated
+	// by at least one newline.
+	//
+	//  /* I'm a leading detached comment. */
+	//
+	//  message Foo {}
+	//
+	LeadingDetached []string
+}

--- a/internal/location/finder.go
+++ b/internal/location/finder.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 import (

--- a/internal/location/finder.go
+++ b/internal/location/finder.go
@@ -1,0 +1,55 @@
+package location
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+// Finder is used to map location paths to their corresponding
+// locations. The Finder is meant to be used on a per-file basis;
+// each file can access the Finder to determine the span for
+// their individual field types.
+//
+// The locations map is keyed based on a unique representation
+// of location paths.
+type Finder struct {
+	locations map[string]Location
+}
+
+// NewFinder constructs a *Finder for a specific file.
+func NewFinder(src *descriptor.SourceCodeInfo) *Finder {
+	locations := src.GetLocation()
+	m := make(map[string]Location, len(locations))
+	for _, l := range locations {
+		m[getKey(l.GetPath())] = NewLocation(l)
+	}
+	return &Finder{locations: m}
+}
+
+// Find returns the Location for the corresponding Path
+// based on its unique key. If not found, false is
+// returned.
+func (f *Finder) Find(p Path) (Location, bool) {
+	l, ok := f.locations[getKey(p)]
+	return l, ok
+}
+
+// getKey constructs a key from the given proto
+// path representation.
+//
+// A proto path is composed of any number of elements,
+// where each element represents a field type, index
+// or target component (e.g. The first message's name field).
+//
+// The path is uniquely represented by a dot-delimited
+// string containing all of the path's type, index, and
+// target contents.
+func getKey(p []int32) string {
+	parts := make([]string, len(p))
+	for i := range p {
+		parts[i] = strconv.Itoa(int(p[i]))
+	}
+	return strings.Join(parts, ".")
+}

--- a/internal/location/finder_test.go
+++ b/internal/location/finder_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 import (

--- a/internal/location/finder_test.go
+++ b/internal/location/finder_test.go
@@ -1,0 +1,70 @@
+package location
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFinder(t *testing.T) {
+	tests := []struct {
+		desc         string
+		givePath     []int32
+		giveSpan     []int32
+		giveDetached []string
+		giveLeading  string
+		giveTrailing string
+		giveID       ID
+		wantLine     int32
+		wantCol      int32
+		found        bool
+	}{
+		{
+			desc:     "Path not found",
+			givePath: []int32{1},
+			found:    false,
+		},
+		{
+			desc:         "Top-level message",
+			givePath:     []int32{4, 0},
+			giveSpan:     []int32{8, 0},
+			giveDetached: []string{"Leading, detached comment"},
+			giveLeading:  "Leading comment",
+			giveTrailing: "Trailing comment",
+			giveID:       Message,
+			wantLine:     9,
+			wantCol:      1,
+			found:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var basePath Path
+			src := &descriptor.SourceCodeInfo{
+				Location: []*descriptor.SourceCodeInfo_Location{
+					{
+						Path:                    tt.givePath,
+						Span:                    tt.giveSpan,
+						LeadingComments:         &tt.giveLeading,
+						TrailingComments:        &tt.giveTrailing,
+						LeadingDetachedComments: tt.giveDetached,
+					},
+				},
+			}
+			f := NewFinder(src)
+			l, ok := f.Find(basePath.Scope(tt.giveID, 0))
+
+			if !tt.found {
+				assert.False(t, tt.found)
+				return
+			}
+			assert.True(t, ok)
+			assert.Equal(t, tt.wantLine, l.Span.Line())
+			assert.Equal(t, tt.wantCol, l.Span.Col())
+			assert.Equal(t, tt.giveDetached, l.Comments.LeadingDetached)
+			assert.Equal(t, tt.giveLeading, l.Comments.Leading)
+			assert.Equal(t, tt.giveTrailing, l.Comments.Trailing)
+		})
+	}
+}

--- a/internal/location/id.go
+++ b/internal/location/id.go
@@ -1,0 +1,51 @@
+package location
+
+// ID is used to identify a variety of Proto types. These
+// identifiers are not clearly documented, unfortunately.
+// However, they can be found in the FileDescriptorSet found
+// in the protoc-gen-go plugin.
+//
+// The following document should be treated as the source
+// of truth for a variety of different Proto types:
+// https://github.com/golang/protobuf/blob/master/protoc-gen-go/descriptor/descriptor.proto
+//
+// The syntax, for example, is identified by 12, and its
+// corresponding path is [12]. This is determined by the
+// following line:
+// https://github.com/golang/protobuf/blob/master/protoc-gen-go/descriptor/descriptor.proto#L89
+type ID int32
+
+// The following identifiers represent Proto types, options, and/or
+// qualitities of a specific type. All of the available Proto types are
+// documented in in the language specification. For more, see:
+// https://developers.google.com/protocol-buffers/docs/reference/proto3-spec
+const (
+	Syntax         ID = 12
+	Package        ID = 2
+	FileOption     ID = 8
+	Message        ID = 4
+	Field          ID = 2
+	NestedType     ID = 3
+	MessageEnum    ID = 4
+	Oneof          ID = 8
+	Enum           ID = 5
+	EnumValue      ID = 2
+	EnumOption     ID = 3
+	Service        ID = 6
+	Method         ID = 2
+	MethodRequest  ID = 2
+	MethodResponse ID = 3
+
+	Name            ID = 1
+	EnumValueNumber ID = 2
+	FieldLabel      ID = 4
+	FieldNumber     ID = 3
+	FieldType       ID = 5
+	FieldTypeName   ID = 6
+
+	AllowAlias         ID = 2
+	JavaPackage        ID = 1
+	JavaOuterClassname ID = 8
+	JavaMultipleFiles  ID = 10
+	GoPackage          ID = 11
+)

--- a/internal/location/id.go
+++ b/internal/location/id.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 // ID is used to identify a variety of Proto types. These

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 import "github.com/golang/protobuf/protoc-gen-go/descriptor"

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -1,0 +1,23 @@
+package location
+
+import "github.com/golang/protobuf/protoc-gen-go/descriptor"
+
+// Location is a convenience wrapper for working
+// with Proto source locations. It contains a
+// span and its corresponding comments.
+type Location struct {
+	Span     Span
+	Comments Comments
+}
+
+// NewLocation creates a new Location from the Proto source location.
+func NewLocation(l *descriptor.SourceCodeInfo_Location) Location {
+	return Location{
+		Span: NewSpan(l.GetSpan()),
+		Comments: Comments{
+			Leading:         l.GetLeadingComments(),
+			Trailing:        l.GetTrailingComments(),
+			LeadingDetached: l.GetLeadingDetachedComments(),
+		},
+	}
+}

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -1,0 +1,69 @@
+package location
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestSourceCodeLocation(
+	path []int32,
+	span []int32,
+	detached []string,
+	leading string,
+	trailing string,
+) *descriptor.SourceCodeInfo_Location {
+	return &descriptor.SourceCodeInfo_Location{
+		Path:                    path,
+		Span:                    span,
+		LeadingDetachedComments: detached,
+		LeadingComments:         &leading,
+		TrailingComments:        &trailing,
+	}
+}
+
+func TestLocation(t *testing.T) {
+	tests := []struct {
+		desc         string
+		giveSpan     []int32
+		giveDetached []string
+		giveLeading  string
+		giveTrailing string
+		wantLine     int32
+		wantCol      int32
+	}{
+		{
+			desc:     "Default value location",
+			wantLine: 1,
+			wantCol:  1,
+		},
+		{
+			desc:         "Hydrated location",
+			giveSpan:     []int32{1, 2},
+			giveDetached: []string{"Leading, detached comment"},
+			giveLeading:  "Leading comment",
+			giveTrailing: "Trailing comment",
+			wantLine:     2,
+			wantCol:      3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			l := NewLocation(
+				newTestSourceCodeLocation(
+					nil, // Path
+					tt.giveSpan,
+					tt.giveDetached,
+					tt.giveLeading,
+					tt.giveTrailing,
+				),
+			)
+			assert.Equal(t, tt.wantLine, l.Span.Line())
+			assert.Equal(t, tt.wantCol, l.Span.Col())
+			assert.Equal(t, tt.giveDetached, l.Comments.LeadingDetached)
+			assert.Equal(t, tt.giveLeading, l.Comments.Leading)
+			assert.Equal(t, tt.giveTrailing, l.Comments.Trailing)
+		})
+	}
+}

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 import (

--- a/internal/location/path.go
+++ b/internal/location/path.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 // Path represents a Proto location path.

--- a/internal/location/path.go
+++ b/internal/location/path.go
@@ -1,0 +1,49 @@
+package location
+
+// Path represents a Proto location path.
+type Path []int32
+
+// Scope adds field-specific scope to this Path.
+// The path is scoped by adding a specific proto
+// identifier, along with its index.
+//
+// Adding scope to a proto file's first
+// message type, for example, is done by,
+//
+//  p.Scope(Message, 0)
+func (p Path) Scope(typ ID, idx int) Path {
+	return p.copyWith(int32(typ), int32(idx))
+}
+
+// Target adds the given target to this Path.
+// The path receives a target to a specific
+// proto type's component by explicitly
+// specifying the target identifier.
+//
+// Targetting a proto file's package
+// definition, for example, is done by,
+//
+//  p.Target(Package)
+func (p Path) Target(target ID) Path {
+	return p.copyWith(int32(target))
+}
+
+// copyWith creates a new Path, appending the
+// given elements to those already found in p.
+//
+// We purposefully make a copy of the Path
+// so that we don't accidentally truncate
+// previously added elements.
+//
+// For details, read up at:
+// https://blog.golang.org/go-slices-usage-and-internals
+func (p Path) copyWith(elems ...int32) Path {
+	path := make(Path, len(p)+len(elems))
+	for i, e := range p {
+		path[i] = e
+	}
+	for i, e := range elems {
+		path[len(p)+i] = e
+	}
+	return path
+}

--- a/internal/location/path_test.go
+++ b/internal/location/path_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 import (

--- a/internal/location/path_test.go
+++ b/internal/location/path_test.go
@@ -1,0 +1,31 @@
+package location
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPath(t *testing.T) {
+	var base Path
+	t.Run("Scope", func(t *testing.T) {
+		foo := base.Scope(Message, 0)
+		bar := base.Scope(Message, 0)
+		assert.Equal(t, foo, bar)
+
+		// Updating one should not change the other.
+		foo = foo.Scope(Field, 0)
+		assert.Equal(t, Path{4, 0, 2, 0}, foo)
+		assert.NotEqual(t, foo, bar)
+	})
+	t.Run("Target", func(t *testing.T) {
+		foo := base.Target(Name)
+		bar := base.Target(Name)
+		assert.Equal(t, foo, bar)
+
+		// Updating one should not change the other.
+		foo = foo.Target(Name)
+		assert.Equal(t, Path{1, 1}, foo)
+		assert.NotEqual(t, foo, bar)
+	})
+}

--- a/internal/location/span.go
+++ b/internal/location/span.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 import "fmt"

--- a/internal/location/span.go
+++ b/internal/location/span.go
@@ -1,0 +1,38 @@
+package location
+
+import "fmt"
+
+// Span represents a Proto location span.
+// A Span always has exactly three or four elements: start line, start column,
+// end line (optional, otherwise assumed same as start line), end column.
+// These are packed into a single field for efficiency.
+//
+// We only ever need to display the initial line and column, so we ignore
+// the remaining elements, i.e. the end line and end column.
+//
+// Note that line and column numbers are zero-based. We purposefully add 1 to
+// each before displaying to a user.
+type Span [2]int32
+
+// NewSpan constructs a Span from the given slice.
+func NewSpan(s []int32) Span {
+	if len(s) < 2 {
+		return Span{}
+	}
+	return Span{s[0], s[1]}
+}
+
+// Line returns the start line for this Span.
+func (s Span) Line() int32 {
+	return s[0] + 1
+}
+
+// Col returns the start column for this Span.
+func (s Span) Col() int32 {
+	return s[1] + 1
+}
+
+// String displays this Span as a string.
+func (s Span) String() string {
+	return fmt.Sprintf("%d:%d", s.Line(), s.Col())
+}

--- a/internal/location/span_test.go
+++ b/internal/location/span_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package location
 
 import (

--- a/internal/location/span_test.go
+++ b/internal/location/span_test.go
@@ -1,0 +1,46 @@
+package location
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpan(t *testing.T) {
+	tests := []struct {
+		desc       string
+		giveSpan   []int32
+		wantLine   int32
+		wantCol    int32
+		wantString string
+	}{
+		{
+			desc:       "Default value",
+			wantLine:   1,
+			wantCol:    1,
+			wantString: "1:1",
+		},
+		{
+			desc:       "Equal line, col",
+			giveSpan:   []int32{1, 1},
+			wantLine:   2,
+			wantCol:    2,
+			wantString: "2:2",
+		},
+		{
+			desc:       "Unequal line, col",
+			giveSpan:   []int32{1, 2},
+			wantLine:   2,
+			wantCol:    3,
+			wantString: "2:3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			s := NewSpan(tt.giveSpan)
+			assert.Equal(t, tt.wantLine, s.Line())
+			assert.Equal(t, tt.wantCol, s.Col())
+			assert.Equal(t, tt.wantString, s.String())
+		})
+	}
+}


### PR DESCRIPTION
This introduces a new `compatible` package that can be used to compare two `*descriptor.FileDescriptorSets` against one another. The package considers a variety of possible changes that are not backward-compatible, such as removing a message's field.

The `compatible` package also includes the severity of the change (`source` and `wire`), such that it will distinguish between source code compatibility from wire compatibility. For reference, the checks are inspired by what is found in the [Proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3#updating). 

This also adds a `location` package that can be used to map the `*descriptor.SourceCodeInfo` to each of the relevant descriptor types. With this, we can recover what line and column caused each of the backward-incompatible changes.

The expected output is of the following form:
```
foo.proto:8:15:wire:Field "key" (1) was removed.
bar.proto:9:16:source:Field "value" (2) had its type updated from "int32" to "int64".
```

Note that this has been ported from an internal repository. Some of the unit tests are temporarily commented out and will be updated to conform to Prototool's package structure.