### PR TITLE
Delete ldflags binding and fix go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SRCS := $(shell find . -name '*.go' | grep -v ^\.\/vendor\/ | grep -v ^\.\/example\/ | grep -v \/gen\/grpcpb\/)
 PKGS := $(shell go list ./... | grep -v github.com\/uber\/prototool\/example | grep -v \/gen\/grpcpb)
-BINS := github.com/uber/prototool/cmd/prototool
+BINS := ./cmd/prototool
 
 DOCKER_IMAGE := golang:1.11.4
 
@@ -34,9 +34,7 @@ vendor:
 
 .PHONY: install
 install:
-	go install \
-		-ldflags "-X 'github.com/uber/prototool/internal/vars.GitCommit=$(shell git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/vars.BuiltTimestamp=$(shell date -u)'" \
-		$(BINS)
+	go install $(BINS)
 
 .PHONY: license
 license:

--- a/etc/bin/brewgen.sh
+++ b/etc/bin/brewgen.sh
@@ -19,6 +19,5 @@ CGO_ENABLED=0 \
   go build \
   -a \
   -installsuffix cgo \
-  -ldflags "-X 'github.com/uber/prototool/internal/vars.GitCommit=$(git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/vars.BuiltTimestamp=$(date -u)'" \
   -o "${BUILD_DIR}/bin/prototool" \
   cmd/prototool/main.go

--- a/etc/bin/releasegen.sh
+++ b/etc/bin/releasegen.sh
@@ -39,7 +39,6 @@ for os in Darwin Linux; do
       go build \
       -a \
       -installsuffix cgo \
-      -ldflags "-X 'github.com/uber/prototool/internal/vars.GitCommit=$(git rev-list -1 HEAD)' -X 'github.com/uber/prototool/internal/vars.BuiltTimestamp=$(date -u)'" \
       -o "${dir}/bin/prototool" \
       cmd/prototool/main.go
     tar -C "${tar_context_dir}" -cvzf "${BASE_DIR}/prototool-${os}-${arch}.tar.gz" "${tar_dir}"

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -105,16 +105,12 @@ func (r *runner) Version() error {
 		Version              string `json:"version,omitempty"`
 		DefaultProtocVersion string `json:"default_protoc_version,omitempty"`
 		GoVersion            string `json:"go_version,omitempty"`
-		GitCommit            string `json:"git_commit,omitempty"`
-		BuiltTimestamp       string `json:"built_timestamp,omitempty"`
 		GOOS                 string `json:"goos,omitempty"`
 		GOARCH               string `json:"goarch,omitempty"`
 	}{
 		Version:              vars.Version,
 		DefaultProtocVersion: vars.DefaultProtocVersion,
 		GoVersion:            runtime.Version(),
-		GitCommit:            vars.GitCommit,
-		BuiltTimestamp:       vars.BuiltTimestamp,
 		GOOS:                 runtime.GOOS,
 		GOARCH:               runtime.GOARCH,
 	}
@@ -134,16 +130,6 @@ func (r *runner) Version() error {
 	}
 	if _, err := fmt.Fprintf(tabWriter, "Go version:\t%s\n", out.GoVersion); err != nil {
 		return err
-	}
-	if out.GitCommit != "" {
-		if _, err := fmt.Fprintf(tabWriter, "Git commit:\t%s\n", out.GitCommit); err != nil {
-			return err
-		}
-	}
-	if out.BuiltTimestamp != "" {
-		if _, err := fmt.Fprintf(tabWriter, "Built:\t%s\n", out.BuiltTimestamp); err != nil {
-			return err
-		}
 	}
 	if _, err := fmt.Fprintf(tabWriter, "OS/Arch:\t%s/%s\n", out.GOOS, out.GOARCH); err != nil {
 		return err

--- a/internal/vars/vars.go
+++ b/internal/vars/vars.go
@@ -19,8 +19,6 @@
 // THE SOFTWARE.
 
 // Package vars contains static variables used in Prototool.
-//
-// Some variables are populated at build time using ldflags.
 package vars
 
 const (
@@ -32,16 +30,4 @@ const (
 	//
 	// See https://github.com/protocolbuffers/protobuf/releases for the latest release.
 	DefaultProtocVersion = "3.6.1"
-)
-
-var (
-	// GitCommit is the git commit used to build the binary.
-	//
-	// This is populated at build time using ldflags.
-	GitCommit string
-
-	// BuiltTimestamp is the time at which the binary was built.
-	//
-	// This is populated at build time using ldflags.
-	BuiltTimestamp string
 )


### PR DESCRIPTION
After #250, `GitCommit` and `BuiltTimestamp` are no longer binding properly, but these were always extraneous, and these don't get bound if you do `go get github.com/uber/prototool/cmd/prototool` anyways. They should just be removed. This also fixes `make install` to properly install the binary from source, as opposed to fetching it.