### PR TITLE
Handle java JAR generation and descriptor_set output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea
 /.tmp
 /brew
+/example/gen/proto/descriptor
 /example/gen/proto/java
 /cmd/prototool/prototool
 /cover

--- a/README.md
+++ b/README.md
@@ -145,7 +145,15 @@ Compile your Protobuf files, but do not generate stubs. This has the effect of c
 
 ##### `prototool generate`
 
-Compile your Protobuf files and generate stubs according to the rules in your `prototool.yaml` or `prototool.json` file. See [example/idl/uber/prototool.yaml](example/idl/uber/prototool.yaml) for an example.
+Compile your Protobuf files and generate stubs according to the rules in your `prototool.yaml` or `prototool.json` file.
+
+See [etc/config/example/prototool.yaml](etc/config/example/prototool.yaml) for all available options. There are special
+options available for Golang plugins, and plugins that output a single file instead of a set of files. Specifically, you
+can output a single JAR for the built-in `protoc` `java` plugin, and you can output a file with the serialized
+`FileDescriptorSet` using the built-in `protoc` `descriptor_set` plugin, optionally also calling `--include_imports`
+and/or `--include_source_info`.
+
+See [example/idl/uber/prototool.yaml](example/idl/uber/prototool.yaml) for a full example.
 
 ##### `prototool lint`
 

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -114,3 +114,23 @@ generate:
 
     - name: java
       output: ../../.gen/proto/java
+
+      # Optional file suffix for plugins that output a single file as opposed
+      # to writing a set of files to a directory. This is only valid in two
+      # known cases:
+      # - For the java plugin, set this to "jar" to produce jars
+      #   https://developers.google.com/protocol-buffers/docs/reference/java-generated#invocation
+      # - For the descriptor_set plugin, this is required as using descriptor_set
+      #   requires a file to be given instead of a directory.
+      file_suffix: jar
+
+      # descriptor_set is special, and uses the --descriptor_set_out flag on protoc.
+      # file_suffix is required, and the options include_imports and include_source_info
+      # can be optionally set to add the flags --include_imports and --include_source-info.
+      # The include_imports and include_source_info options are not valid for any
+      # other plugin name.
+    - name: descriptor_set
+      output: ../../.gen/proto/descriptor
+      file_suffix: bin
+      include_imports: true
+      include_source_info: true

--- a/example/idl/uber/prototool.yaml
+++ b/example/idl/uber/prototool.yaml
@@ -19,3 +19,9 @@ generate:
       output: ../../gen/proto/go
     - name: java
       output: ../../gen/proto/java
+      file_suffix: jar
+    - name: descriptor_set
+      output: ../../gen/proto/descriptor
+      file_suffix: bin
+      include_imports: true
+      include_source_info: true

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -143,7 +143,27 @@ protoc:
 {{.V}}      output: ../../.gen/proto/go
 
 {{.V}}    - name: java
-{{.V}}      output: ../../.gen/proto/java`))
+{{.V}}      output: ../../.gen/proto/java
+
+      # Optional file suffix for plugins that output a single file as opposed
+      # to writing a set of files to a directory. This is only valid in two
+      # known cases:
+      # - For the java plugin, set this to "jar" to produce jars
+      #   https://developers.google.com/protocol-buffers/docs/reference/java-generated#invocation
+      # - For the descriptor_set plugin, this is required as using descriptor_set
+      #   requires a file to be given instead of a directory.
+{{.V}}      file_suffix: jar
+
+      # descriptor_set is special, and uses the --descriptor_set_out flag on protoc.
+      # file_suffix is required, and the options include_imports and include_source_info
+      # can be optionally set to add the flags --include_imports and --include_source-info.
+      # The include_imports and include_source_info options are not valid for any
+      # other plugin name.
+{{.V}}    - name: descriptor_set
+{{.V}}      output: ../../.gen/proto/descriptor
+{{.V}}      file_suffix: bin
+{{.V}}      include_imports: true
+{{.V}}      include_source_info: true`))
 
 type tmplData struct {
 	V             string

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -188,7 +188,21 @@ func (c *compiler) ProtocCommands(protoSet *file.ProtoSet) ([]string, error) {
 func (c *compiler) makeGenDirs(protoSet *file.ProtoSet) error {
 	genDirs := make(map[string]struct{})
 	for _, genPlugin := range protoSet.Config.Gen.Plugins {
-		genDirs[genPlugin.OutputPath.AbsPath] = struct{}{}
+		baseOutputPath := genPlugin.OutputPath.AbsPath
+		// If there is no single output file, protoc plugins take care of making
+		// sub-directories, so we only need to make the base directory.
+		// Otherwise, we need to make all sub-directories of the output file.
+		if genPlugin.FileSuffix == "" {
+			genDirs[baseOutputPath] = struct{}{}
+		} else {
+			for dirPath := range protoSet.DirPathToFiles {
+				relOutputFilePath, err := getRelOutputFilePath(protoSet, dirPath, genPlugin.FileSuffix)
+				if err != nil {
+					return err
+				}
+				genDirs[filepath.Dir(filepath.Join(baseOutputPath, relOutputFilePath))] = struct{}{}
+			}
+		}
 	}
 	for genDir := range genDirs {
 		// we could choose a different permission set, but this seems reasonable
@@ -431,14 +445,38 @@ func getPluginFlagSet(protoSet *file.ProtoSet, dirPath string, genPlugin setting
 	if err != nil {
 		return nil, err
 	}
-	flagSet := []string{fmt.Sprintf("--%s_out=%s", genPlugin.Name, genPlugin.OutputPath.AbsPath)}
+	outputPath := genPlugin.OutputPath.AbsPath
+	if genPlugin.FileSuffix != "" {
+		relOutputFilePath, err := getRelOutputFilePath(protoSet, dirPath, genPlugin.FileSuffix)
+		if err != nil {
+			return nil, err
+		}
+		outputPath = filepath.Join(outputPath, relOutputFilePath)
+	}
+	flagSet := []string{fmt.Sprintf("--%s_out=%s", genPlugin.Name, outputPath)}
 	if len(protoFlags) > 0 {
-		flagSet = []string{fmt.Sprintf("--%s_out=%s:%s", genPlugin.Name, protoFlags, genPlugin.OutputPath.AbsPath)}
+		flagSet = []string{fmt.Sprintf("--%s_out=%s:%s", genPlugin.Name, protoFlags, outputPath)}
 	}
 	if genPlugin.Path != "" {
 		flagSet = append(flagSet, fmt.Sprintf("--plugin=protoc-gen-%s=%s", genPlugin.Name, genPlugin.Path))
 	}
+	if genPlugin.IncludeImports {
+		flagSet = append(flagSet, "--include_imports")
+	}
+	if genPlugin.IncludeSourceInfo {
+		flagSet = append(flagSet, "--include_source_info")
+	}
 	return flagSet, nil
+}
+
+func getRelOutputFilePath(protoSet *file.ProtoSet, dirPath string, fileSuffix string) (string, error) {
+	relPath, err := filepath.Rel(protoSet.Config.DirPath, dirPath)
+	if err != nil {
+		// if we cannot find the relative path, we have a real problem
+		// this should never happen, but could in a bad case with links
+		return "", fmt.Errorf("could not find relative path for %q to %q, this is a system error, please file a bug at github.com/uber/prototool/issues/new: %v", dirPath, protoSet.Config.DirPath, err)
+	}
+	return filepath.Join(relPath, filepath.Base(relPath)+"."+fileSuffix), nil
 }
 
 // the return value corresponds to CodeGeneratorRequest.Parameter

--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -239,11 +239,25 @@ func externalConfigToConfig(e ExternalConfig, dirPath string) (Config, error) {
 			relPath = plugin.Output
 			absPath = filepath.Clean(filepath.Join(dirPath, relPath))
 		}
+		if plugin.FileSuffix != "" && plugin.FileSuffix[0] == '.' {
+			return Config{}, fmt.Errorf("file_suffix begins with '.' but should not include the '.': %s", plugin.FileSuffix)
+		}
+		if plugin.Name != "descriptor_set" {
+			if plugin.IncludeImports {
+				return Config{}, fmt.Errorf("include_imports is only valid for the descriptor_set plugin but set on %q", plugin.Name)
+			}
+			if plugin.IncludeSourceInfo {
+				return Config{}, fmt.Errorf("include_source_info is only valid for the descriptor_set plugin but set on %q", plugin.Name)
+			}
+		}
 		genPlugins[i] = GenPlugin{
-			Name:  plugin.Name,
-			Path:  plugin.Path,
-			Type:  genPluginType,
-			Flags: plugin.Flags,
+			Name:              plugin.Name,
+			Path:              plugin.Path,
+			Type:              genPluginType,
+			Flags:             plugin.Flags,
+			FileSuffix:        plugin.FileSuffix,
+			IncludeImports:    plugin.IncludeImports,
+			IncludeSourceInfo: plugin.IncludeSourceInfo,
 			OutputPath: OutputPath{
 				RelPath: relPath,
 				AbsPath: absPath,

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -226,6 +226,15 @@ type GenPlugin struct {
 	// The path to output to.
 	// Must be relative in a config file.
 	OutputPath OutputPath
+	// If set, the output path will be set to "$OUTPUT_PATH/$(basename $OUTPUT_PATH).$FILE_SUFFIX"
+	// Used for e.g. JAR generation for java or descriptor_set file name.
+	FileSuffix string
+	// Add the --include_imports flags to protoc.
+	// Only valid if Name is descriptor_set.
+	IncludeImports bool
+	// Add the --include_source_info flags to protoc.
+	// Only valid if Name is descriptor_set.
+	IncludeSourceInfo bool
 }
 
 // OutputPath is an output path.
@@ -272,11 +281,14 @@ type ExternalConfig struct {
 			ExtraModifiers map[string]string `json:"extra_modifiers,omitempty" yaml:"extra_modifiers,omitempty"`
 		} `json:"go_options,omitempty" yaml:"go_options,omitempty"`
 		Plugins []struct {
-			Name   string `json:"name,omitempty" yaml:"name,omitempty"`
-			Type   string `json:"type,omitempty" yaml:"type,omitempty"`
-			Flags  string `json:"flags,omitempty" yaml:"flags,omitempty"`
-			Output string `json:"output,omitempty" yaml:"output,omitempty"`
-			Path   string `json:"path,omitempty" yaml:"path,omitempty"`
+			Name              string `json:"name,omitempty" yaml:"name,omitempty"`
+			Type              string `json:"type,omitempty" yaml:"type,omitempty"`
+			Flags             string `json:"flags,omitempty" yaml:"flags,omitempty"`
+			Output            string `json:"output,omitempty" yaml:"output,omitempty"`
+			Path              string `json:"path,omitempty" yaml:"path,omitempty"`
+			FileSuffix        string `json:"file_suffix,omitempty" yaml:"file_suffix,omitempty"`
+			IncludeImports    bool   `json:"include_imports,omitempty" yaml:"include_imports,omitempty"`
+			IncludeSourceInfo bool   `json:"include_source_info,omitempty" yaml:"include_source_info,omitempty"`
 		} `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 	} `json:"generate,omitempty" yaml:"generate,omitempty"`
 }


### PR DESCRIPTION
This adds the configuration options `file_suffix, include_imports, include_source_info` for generation plugins.

- `file_suffix` says to set the output location to a file named `output_dir/$(basename output_dir).file_suffix`, which is required for `--descriptor_set_out` and for JAR generation with `--java_out`.
- `include_imports, include_source_info` are only valid for `descriptor_set` named plugin, and control whether `--include_imports` and/or `--include_source_info` are set.

Example usage:

```yaml
generate:
  plugins:
    - name: java
      output: ../../gen/proto/java
      file_suffix: jar
    - name: descriptor_set
      output: ../../gen/proto/descriptor
      file_suffix: bin
      include_imports: true
      include_source_info: true
```

See `protoc -h` and https://developers.google.com/protocol-buffers/docs/reference/java-generated for more details.

The code in `internal/protoc` needs some serious refactoring but that is outside the scope of this PR. I've tested this does what is expected manually as we don't have automatic tests per plugin.

Fixes #211.
Fixes #238.