### PR TITLE
Inspect commands

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -114,6 +114,9 @@ func getRootCommand(exitCodeAddr *int, develMode bool, args []string, stdin io.R
 	rootCmd.AddCommand(versionCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
 	inspectCmd := &cobra.Command{Use: "inspect", Short: "Top-level command for inspection commands."}
 	inspectCmd.AddCommand(inspectPackagesCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
+	inspectCmd.AddCommand(inspectPackageCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
+	inspectCmd.AddCommand(inspectPackageDepsCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
+	inspectCmd.AddCommand(inspectPackageImportersCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
 	rootCmd.AddCommand(inspectCmd)
 
 	// flags bound to rootCmd are global flags

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -112,6 +112,9 @@ func getRootCommand(exitCodeAddr *int, develMode bool, args []string, stdin io.R
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(lintCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
 	rootCmd.AddCommand(versionCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
+	inspectCmd := &cobra.Command{Use: "inspect", Short: "Top-level command for inspection commands."}
+	inspectCmd.AddCommand(inspectPackagesCmdTemplate.Build(exitCodeAddr, stdin, stdout, stderr, flags))
+	rootCmd.AddCommand(inspectCmd)
 
 	// flags bound to rootCmd are global flags
 	flags.bindDebug(rootCmd.PersistentFlags())

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -624,6 +624,152 @@ func TestVersionJSON(t *testing.T) {
 	assertRegexp(t, 0, fmt.Sprintf(`(?s){.*"version":.*"%s",.*"default_protoc_version":.*"%s".*}`, vars.Version, vars.DefaultProtocVersion), "version", "--json")
 }
 
+func TestInspectPackages(t *testing.T) {
+	assertExact(
+		t,
+		0,
+		`bar
+foo
+google.protobuf`,
+		"inspect", "packages", "testdata/foo",
+	)
+}
+
+func TestInspectPackagesJSON(t *testing.T) {
+	assertExact(
+		t,
+		0,
+		`{
+  "name": "bar",
+  "importers": [
+    "foo"
+  ]
+}
+{
+  "name": "foo",
+  "deps": [
+    "bar",
+    "google.protobuf"
+  ]
+}
+{
+  "name": "google.protobuf",
+  "importers": [
+    "foo"
+  ]
+}`,
+		"inspect", "packages", "testdata/foo", "--json",
+	)
+}
+
+func TestInspectPackage(t *testing.T) {
+	assertExact(
+		t,
+		0,
+		`Name:  foo
+Deps:
+  - bar
+  - google.protobuf`,
+		"inspect", "package", "testdata/foo", "--name", "foo",
+	)
+	assertExact(
+		t,
+		0,
+		`Name:  bar
+Importers:
+  - foo`,
+		"inspect", "package", "testdata/foo", "--name", "bar",
+	)
+	assertExact(
+		t,
+		0,
+		`Name:  google.protobuf
+Importers:
+  - foo`,
+		"inspect", "package", "testdata/foo", "--name", "google.protobuf",
+	)
+}
+
+func TestInspectPackageJSON(t *testing.T) {
+	assertExact(
+		t,
+		0,
+		`{
+  "name": "foo",
+  "deps": [
+    "bar",
+    "google.protobuf"
+  ]
+}`,
+		"inspect", "package", "testdata/foo", "--name", "foo", "--json",
+	)
+	assertExact(
+		t,
+		0,
+		`{
+  "name": "bar",
+  "importers": [
+    "foo"
+  ]
+}`,
+		"inspect", "package", "testdata/foo", "--name", "bar", "--json",
+	)
+	assertExact(
+		t,
+		0,
+		`{
+  "name": "google.protobuf",
+  "importers": [
+    "foo"
+  ]
+}`,
+		"inspect", "package", "testdata/foo", "--name", "google.protobuf", "--json",
+	)
+}
+
+func TestInspectPackageDeps(t *testing.T) {
+	assertExact(
+		t,
+		0,
+		`bar
+google.protobuf`,
+		"inspect", "package-deps", "testdata/foo", "--name", "foo",
+	)
+	assertExact(
+		t,
+		0,
+		``,
+		"inspect", "package-deps", "testdata/foo", "--name", "bar",
+	)
+	assertExact(
+		t,
+		0,
+		``,
+		"inspect", "package-deps", "testdata/foo", "--name", "google.protobuf",
+	)
+}
+
+func TestInspectPackageImporters(t *testing.T) {
+	assertExact(
+		t,
+		0,
+		``,
+		"inspect", "package-importers", "testdata/foo", "--name", "foo",
+	)
+	assertExact(
+		t,
+		0,
+		`foo`,
+		"inspect", "package-importers", "testdata/foo", "--name", "bar",
+	)
+	assertExact(
+		t,
+		0,
+		`foo`,
+		"inspect", "package-importers", "testdata/foo", "--name", "google.protobuf",
+	)
+}
+
 func TestListAllLintGroups(t *testing.T) {
 	assertExact(t, 0, "all\ndefault", "list-all-lint-groups")
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -678,34 +678,6 @@ func TestInspectPackage(t *testing.T) {
 	assertExact(
 		t,
 		0,
-		`Name:  foo
-Deps:
-  - bar
-  - google.protobuf`,
-		"inspect", "package", "testdata/foo", "--name", "foo",
-	)
-	assertExact(
-		t,
-		0,
-		`Name:  bar
-Importers:
-  - foo`,
-		"inspect", "package", "testdata/foo", "--name", "bar",
-	)
-	assertExact(
-		t,
-		0,
-		`Name:  google.protobuf
-Importers:
-  - foo`,
-		"inspect", "package", "testdata/foo", "--name", "google.protobuf",
-	)
-}
-
-func TestInspectPackageJSON(t *testing.T) {
-	assertExact(
-		t,
-		0,
 		`{
   "name": "foo",
   "deps": [
@@ -713,7 +685,7 @@ func TestInspectPackageJSON(t *testing.T) {
     "google.protobuf"
   ]
 }`,
-		"inspect", "package", "testdata/foo", "--name", "foo", "--json",
+		"inspect", "package", "testdata/foo", "--name", "foo",
 	)
 	assertExact(
 		t,
@@ -724,7 +696,7 @@ func TestInspectPackageJSON(t *testing.T) {
     "foo"
   ]
 }`,
-		"inspect", "package", "testdata/foo", "--name", "bar", "--json",
+		"inspect", "package", "testdata/foo", "--name", "bar",
 	)
 	assertExact(
 		t,
@@ -735,7 +707,7 @@ func TestInspectPackageJSON(t *testing.T) {
     "foo"
   ]
 }`,
-		"inspect", "package", "testdata/foo", "--name", "google.protobuf", "--json",
+		"inspect", "package", "testdata/foo", "--name", "google.protobuf",
 	)
 }
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -44,6 +44,7 @@ type flags struct {
 	listLinters    bool
 	lintMode       bool
 	method         string
+	name           string
 	overwrite      bool
 	pkg            string
 	printFields    string
@@ -124,6 +125,10 @@ func (f *flags) bindListLinters(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindMethod(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.method, "method", "", "The GRPC method to call in the form package.Service/Method. This is required.")
+}
+
+func (f *flags) bindName(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.name, "name", "", "The package name. This is required.")
 }
 
 func (f *flags) bindOverwrite(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -253,7 +253,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 
 	grpcCmdTemplate = &cmdTemplate{
 		Use:   "grpc [dirOrFile]",
-		Short: "Call a gRPC endpoint. Be sure to set required flags address, method, and either data or stdin.",
+		Short: "Call a gRPC endpoint. Be sure to set the required flags address, method, and either data or stdin.",
 		Long: `This command compiles your proto files with "protoc", converts JSON input to binary and converts the result from binary to JSON. All these steps take on the order of milliseconds. For example, the overhead for a file with four dependencies is about 30ms, so there is little overhead for CLI calls to gRPC.
 
 There is a full example for gRPC in the example directory of Prototool. Run "make init example" to make sure everything is installed and generated.
@@ -352,6 +352,55 @@ $ cat input.json | prototool grpc example \
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindConfigData(flagSet)
 			flags.bindJSON(flagSet)
+			flags.bindProtocURL(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
+		},
+	}
+
+	inspectPackageCmdTemplate = &cmdTemplate{
+		Use:   "package [dirOrFile]",
+		Short: "Print the given package. Be sure to set the required flag name.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(runner exec.Runner, args []string, flags *flags) error {
+			return runner.InspectPackage(args, flags.name)
+		},
+		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindConfigData(flagSet)
+			flags.bindJSON(flagSet)
+			flags.bindName(flagSet)
+			flags.bindProtocURL(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
+		},
+	}
+
+	inspectPackageDepsCmdTemplate = &cmdTemplate{
+		Use:   "package-deps [dirOrFile]",
+		Short: "Print the given package dependencies. Be sure to set the required flag name.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(runner exec.Runner, args []string, flags *flags) error {
+			return runner.InspectPackageDeps(args, flags.name)
+		},
+		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindConfigData(flagSet)
+			flags.bindName(flagSet)
+			flags.bindProtocURL(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
+		},
+	}
+
+	inspectPackageImportersCmdTemplate = &cmdTemplate{
+		Use:   "package-importers [dirOrFile]",
+		Short: "Print the given package importers. Be sure to set the required flag name.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(runner exec.Runner, args []string, flags *flags) error {
+			return runner.InspectPackageImporters(args, flags.name)
+		},
+		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindConfigData(flagSet)
+			flags.bindName(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -360,14 +360,13 @@ $ cat input.json | prototool grpc example \
 
 	inspectPackageCmdTemplate = &cmdTemplate{
 		Use:   "package [dirOrFile]",
-		Short: "Print the given package. Be sure to set the required flag name.",
+		Short: "Print the given package in JSON format. Be sure to set the required flag name.",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
 			return runner.InspectPackage(args, flags.name)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindConfigData(flagSet)
-			flags.bindJSON(flagSet)
 			flags.bindName(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -342,6 +342,21 @@ $ cat input.json | prototool grpc example \
 		},
 	}
 
+	inspectPackagesCmdTemplate = &cmdTemplate{
+		Use:   "packages [dirOrFile]",
+		Short: "List all packages.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(runner exec.Runner, args []string, flags *flags) error {
+			return runner.InspectPackages(args)
+		},
+		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindConfigData(flagSet)
+			flags.bindProtocURL(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
+		},
+	}
+
 	configInitCmdTemplate = &cmdTemplate{
 		Use:   "init [dirPath]",
 		Short: "Generate an initial config file in the current or given directory.",

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -351,6 +351,7 @@ $ cat input.json | prototool grpc example \
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindConfigData(flagSet)
+			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -65,6 +65,9 @@ type Runner interface {
 	All(args []string, disableFormat, disableLint, fix bool) error
 	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime string, stdin bool) error
 	InspectPackages(args []string) error
+	InspectPackage(args []string, name string) error
+	InspectPackageDeps(args []string, name string) error
+	InspectPackageImporters(args []string, name string) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -64,6 +64,7 @@ type Runner interface {
 	JSONToBinary(args []string) error
 	All(args []string, disableFormat, disableLint, fix bool) error
 	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime string, stdin bool) error
+	InspectPackages(args []string) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -659,8 +659,8 @@ func (r *runner) InspectPackages(args []string) error {
 		return err
 	}
 	if packages != nil {
-		for fullyQualifiedName := range packages.FullyQualifiedNameToPackage {
-			if err := r.println(fullyQualifiedName); err != nil {
+		for name := range packages.NameToPackage {
+			if err := r.println(name); err != nil {
 				return err
 			}
 		}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -658,9 +658,20 @@ func (r *runner) InspectPackages(args []string) error {
 	if err != nil {
 		return err
 	}
-	if packages != nil {
-		for name := range packages.NameToPackage {
-			if err := r.println(name); err != nil {
+	if packages == nil {
+		return nil
+	}
+	for _, pkg := range packages.SortedPackages() {
+		if r.json {
+			data, err := json.MarshalIndent(pkg, "", "  ")
+			if err != nil {
+				return err
+			}
+			if err := r.println(string(data)); err != nil {
+				return err
+			}
+		} else {
+			if err := r.println(pkg.Name); err != nil {
 				return err
 			}
 		}
@@ -891,7 +902,7 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 		}
 		if shouldPrint {
 			if r.json {
-				data, err := json.Marshal(failure)
+				data, err := json.MarshalIndent(failure, "", "  ")
 				if err != nil {
 					return err
 				}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -1005,7 +1005,7 @@ func (r *runner) printFailures(filename string, meta *meta, failures ...*text.Fa
 		}
 		if shouldPrint {
 			if r.json {
-				data, err := json.MarshalIndent(failure, "", "  ")
+				data, err := json.Marshal(failure)
 				if err != nil {
 					return err
 				}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -688,42 +688,11 @@ func (r *runner) InspectPackage(args []string, name string) error {
 	if !ok {
 		return fmt.Errorf("package not found: %s", name)
 	}
-	if r.json {
-		data, err := json.MarshalIndent(pkg, "", "  ")
-		if err != nil {
-			return err
-		}
-		if err := r.println(string(data)); err != nil {
-			return err
-		}
-	} else {
-		tabWriter := newTabWriter(r.output)
-		if _, err := fmt.Fprintf(tabWriter, "Name:\t%s\n", pkg.Name); err != nil {
-			return err
-		}
-		if len(pkg.Deps) > 0 {
-			if _, err := fmt.Fprintf(tabWriter, "Deps:\n"); err != nil {
-				return err
-			}
-			for _, dep := range pkg.Deps {
-				if _, err := fmt.Fprintf(tabWriter, "\t- %s\n", dep); err != nil {
-					return err
-				}
-			}
-		}
-		if len(pkg.Importers) > 0 {
-			if _, err := fmt.Fprintf(tabWriter, "Importers:\n"); err != nil {
-				return err
-			}
-			for _, importer := range pkg.Importers {
-				if _, err := fmt.Fprintf(tabWriter, "\t- %s\n", importer); err != nil {
-					return err
-				}
-			}
-		}
-		return tabWriter.Flush()
+	data, err := json.MarshalIndent(pkg, "", "  ")
+	if err != nil {
+		return err
 	}
-	return nil
+	return r.println(string(data))
 }
 
 func (r *runner) InspectPackageDeps(args []string, name string) error {

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -169,6 +169,7 @@ func (s sortPackages) Len() int          { return len(s) }
 func (s sortPackages) Swap(i int, j int) { s[i], s[j] = s[j], s[i] }
 func (s sortPackages) Less(i int, j int) bool {
 	if s[i] == nil && s[j] == nil {
+		return false
 	}
 	if s[i] == nil && s[j] != nil {
 		return true

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -32,19 +32,19 @@ import (
 type Packages struct {
 	// Map from fully-qualified name to package.
 	// Fully-qualified name includes prefix '.'.
-	FullyQualifiedNameToPackage map[string]*Package
+	NameToPackage map[string]*Package
 }
 
 // Package is an extracted package.
 type Package struct {
 	// Fully-qualified name includes prefix '.'.
-	FullyQualifiedName string
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// The fully-qualified names of the direct dependencies.
 	// For recursive dependencies, look these names up in the Packages struct.
-	DepFullyQualifiedNames []string
+	Deps []string `json:"deps,omitempty" yaml:"deps,omitempty"`
 	// The fully-qualified names of the importers.
 	// For recursive importers, look these names up in the Packages struct.
-	ImporterFullyQualifiedNames []string
+	Importers []string `json:"importers,omitempty" yaml:"importers,omitempty"`
 }
 
 // Field is an extracted field.

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -28,10 +28,30 @@ import (
 	"go.uber.org/zap"
 )
 
+// Packages is a set of extracted packages.
+type Packages struct {
+	// Map from fully-qualified name to package.
+	// Fully-qualified name includes prefix '.'.
+	FullyQualifiedNameToPackage map[string]*Package
+}
+
+// Package is an extracted package.
+type Package struct {
+	// Fully-qualified name includes prefix '.'.
+	FullyQualifiedName string
+	// The fully-qualified names of the direct dependencies.
+	// For recursive dependencies, look these names up in the Packages struct.
+	DepFullyQualifiedNames []string
+	// The fully-qualified names of the importers.
+	// For recursive importers, look these names up in the Packages struct.
+	ImporterFullyQualifiedNames []string
+}
+
 // Field is an extracted field.
 type Field struct {
 	*descriptor.FieldDescriptorProto
 
+	// Fully-qualified path includes prefix '.'.
 	FullyQualifiedPath  string
 	DescriptorProto     *descriptor.DescriptorProto
 	FileDescriptorProto *descriptor.FileDescriptorProto
@@ -42,6 +62,7 @@ type Field struct {
 type Message struct {
 	*descriptor.DescriptorProto
 
+	// Fully-qualified path includes prefix '.'.
 	FullyQualifiedPath  string
 	FileDescriptorProto *descriptor.FileDescriptorProto
 	FileDescriptorSet   *descriptor.FileDescriptorSet
@@ -51,6 +72,7 @@ type Message struct {
 type Service struct {
 	*descriptor.ServiceDescriptorProto
 
+	// Fully-qualified path includes prefix '.'.
 	FullyQualifiedPath  string
 	FileDescriptorProto *descriptor.FileDescriptorProto
 	FileDescriptorSet   *descriptor.FileDescriptorSet
@@ -61,6 +83,8 @@ type Service struct {
 // Paths can begin with ".".
 // The first FileDescriptorSet with a match will be returned.
 type Getter interface {
+	// Get the packages.
+	GetPackages(fileDescriptorSets []*descriptor.FileDescriptorSet) (*Packages, error)
 	// Get the field that matches the path.
 	// Return non-nil value, or error otherwise including if nothing found.
 	GetField(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Field, error)

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -24,6 +24,8 @@
 package extract
 
 import (
+	"sort"
+
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"go.uber.org/zap"
 )
@@ -33,6 +35,16 @@ type Packages struct {
 	// Map from fully-qualified name to package.
 	// Fully-qualified name includes prefix '.'.
 	NameToPackage map[string]*Package
+}
+
+// SortedPackages returns the list of packages sorted by name.
+func (p *Packages) SortedPackages() []*Package {
+	packages := make([]*Package, 0, len(p.NameToPackage))
+	for _, pkg := range p.NameToPackage {
+		packages = append(packages, pkg)
+	}
+	sort.Stable(sortPackages(packages))
+	return packages
 }
 
 // Package is an extracted package.
@@ -111,4 +123,20 @@ func GetterWithLogger(logger *zap.Logger) GetterOption {
 // NewGetter returns a new Getter.
 func NewGetter(options ...GetterOption) Getter {
 	return newGetter(options...)
+}
+
+type sortPackages []*Package
+
+func (s sortPackages) Len() int          { return len(s) }
+func (s sortPackages) Swap(i int, j int) { s[i], s[j] = s[j], s[i] }
+func (s sortPackages) Less(i int, j int) bool {
+	if s[i] == nil && s[j] == nil {
+	}
+	if s[i] == nil && s[j] != nil {
+		return true
+	}
+	if s[i] != nil && s[j] == nil {
+		return false
+	}
+	return s[i].Name < s[j].Name
 }

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -63,7 +63,6 @@ type Package struct {
 type Field struct {
 	*descriptor.FieldDescriptorProto
 
-	// Fully-qualified path includes prefix '.'.
 	FullyQualifiedPath  string
 	DescriptorProto     *descriptor.DescriptorProto
 	FileDescriptorProto *descriptor.FileDescriptorProto
@@ -74,7 +73,6 @@ type Field struct {
 type Message struct {
 	*descriptor.DescriptorProto
 
-	// Fully-qualified path includes prefix '.'.
 	FullyQualifiedPath  string
 	FileDescriptorProto *descriptor.FileDescriptorProto
 	FileDescriptorSet   *descriptor.FileDescriptorSet
@@ -84,7 +82,6 @@ type Message struct {
 type Service struct {
 	*descriptor.ServiceDescriptorProto
 
-	// Fully-qualified path includes prefix '.'.
 	FullyQualifiedPath  string
 	FileDescriptorProto *descriptor.FileDescriptorProto
 	FileDescriptorSet   *descriptor.FileDescriptorSet

--- a/internal/extract/getter.go
+++ b/internal/extract/getter.go
@@ -42,6 +42,10 @@ func newGetter(options ...GetterOption) *getter {
 	return getter
 }
 
+func (g *getter) GetPackages(fileDescriptorSets []*descriptor.FileDescriptorSet) (*Packages, error) {
+	return nil, nil
+}
+
 func (g *getter) GetField(fileDescriptorSets []*descriptor.FileDescriptorSet, path string) (*Field, error) {
 	if len(path) == 0 {
 		return nil, fmt.Errorf("empty path")

--- a/internal/extract/getter.go
+++ b/internal/extract/getter.go
@@ -191,8 +191,8 @@ func getPackageNameToFileDescriptorProtos(fileDescriptorSets []*descriptor.FileD
 			if pkg == "" {
 				return nil, fmt.Errorf("no package on FileDescriptorProto")
 			}
-			if pkg[0] != '.' {
-				return nil, fmt.Errorf("malformed package fully-qualified name: %s", pkg)
+			if pkg[0] == '.' {
+				return nil, fmt.Errorf("malformed package fully-qualified name %s on FileDescriptorProto %+v", pkg, fileDescriptorProto)
 			}
 			existingMap, ok := packageNameToFileNameToFileDescriptorProto[pkg]
 			if !ok {


### PR DESCRIPTION
This adds a bunch of inspection commands to print out data about packages. We can extend this in the future to include other items (messages within packages, files, etc).  We need most of this functionality anyways for the breaking change detector and there was an ask for it, so we might as well expose it.

Tldr:

```
$ cd example

$ prototool inspect packages
foo
google.protobuf
sub

$ prototool inspect packages --json
{
  "name": "foo",
  "deps": [
    "google.protobuf",
    "sub"
  ]
}
{
  "name": "google.protobuf",
  "importers": [
    "foo"
  ]
}
{
  "name": "sub",
  "importers": [
    "foo"
  ]
}

$ prototool inspect package --name foo
{
  "name": "foo",
  "deps": [
    "google.protobuf",
    "sub"
  ]
}

$ prototool inspect package-deps --name foo
google.protobuf
sub

$ prototool inspect package-importers --name sub
foo
```