### PR TITLE
Re-add staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,6 @@ staticcheck:
 	@go install honnef.co/go/tools/cmd/staticcheck
 	staticcheck --tests=false $(PKGS)
 
-.PHONY: unused
-unused:
-	@go install honnef.co/go/tools/cmd/unused
-	unused --tests=false $(PKGS)
-
 .PHONY: checklicense
 checklicense: install
 	@go install go.uber.org/tools/update-license
@@ -130,9 +125,9 @@ checklicense: install
 	fi
 
 .PHONY: lint
-# TODO: re-add errcheck staticcheck unused when they are fixed for Golang modules
-#lint: checknodiffgenerated golint vet errcheck staticcheck unused checklicense
-lint: checknodiffgenerated golint vet checklicense
+# TODO: re-add errcheck when it fixed for Golang modules
+#lint: checknodiffgenerated golint vet errcheck staticcheck checklicense
+lint: checknodiffgenerated golint vet staticcheck checklicense
 
 .PHONY: test
 test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/uber/prototool
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/proto v1.6.7
@@ -30,5 +31,5 @@ require (
 	golang.org/x/tools v0.0.0-20181218204010-d4971274fe38
 	google.golang.org/grpc v1.17.0
 	gopkg.in/yaml.v2 v2.2.2
-	honnef.co/go/tools v0.0.0-20180728063816-88497007e858
+	honnef.co/go/tools v0.0.0-20190103051756-51b3beccf3bd
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cpuguy83/go-md2man v1.0.8 h1:DwoNytLphI8hzS2Af4D0dfaEaiSq2bN05mEm4R6vf8M=
 github.com/cpuguy83/go-md2man v1.0.8/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=
@@ -14,7 +16,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekf
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/lint v0.0.0-20171212024629-883fe33ffc43 h1:XmYUUcBam5XYcf8KaEKd4qGLxA4e91Com//IsgwknNk=
 github.com/golang/lint v0.0.0-20171212024629-883fe33ffc43/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
-github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
@@ -85,3 +86,5 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858 h1:wN+eVZ7U+gqdqkec6C6VXR1OFf9a5Ul9ETzeYsYv20g=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.0-20190103051756-51b3beccf3bd h1:XpdBGqRaN/jumov7ZMaVkd9GDhalYgiWF7C8GNyE7Qc=
+honnef.co/go/tools v0.0.0-20190103051756-51b3beccf3bd/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -37,7 +37,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/uber/prototool/internal/cfginit"
 	"github.com/uber/prototool/internal/create"
@@ -54,8 +53,6 @@ import (
 	"github.com/uber/prototool/internal/vars"
 	"go.uber.org/zap"
 )
-
-var jsonMarshaler = &jsonpb.Marshaler{Indent: "  "}
 
 type runner struct {
 	configProvider   settings.ConfigProvider
@@ -836,13 +833,6 @@ func (r *runner) println(s string) error {
 	}
 	_, err := fmt.Fprintln(r.output, s)
 	return err
-}
-
-func (r *runner) getInputData(arg string) ([]byte, error) {
-	if arg == "-" {
-		return ioutil.ReadAll(r.input)
-	}
-	return []byte(arg), nil
 }
 
 func (r *runner) getInputReader(data string, stdin bool) io.Reader {

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -56,7 +56,7 @@ var (
 	// protoc outputs both this line and fileNotFound, so we end up ignoring this one
 	// TODO figure out what the error is for errors in the import
 	importNotFoundRegexp              = regexp.MustCompile("^(.*): Import (.*) was not found or had errors.$")
-	noSyntaxSpecifiedRegexp           = regexp.MustCompile("No syntax specified for the proto file: (.*)\\. Please use")
+	noSyntaxSpecifiedRegexp           = regexp.MustCompile(`No syntax specified for the proto file: (.*)\. Please use`)
 	jsonCamelCaseRegexp               = regexp.MustCompile("^(.*): (The JSON camel-case name of field.*)$")
 	isNotDefinedRegexp                = regexp.MustCompile("^(.*): (.*) is not defined.$")
 	seemsToBeDefinedRegexp            = regexp.MustCompile(`^(.*): (".*" seems to be defined in ".*", which is not imported by ".*". To use it here, please add the necessary import.)$`)


### PR DESCRIPTION
Now that https://github.com/dominikh/go-tools/issues/328 is resolved, we can use staticcheck again. This updates the version of staticcheck that is downloaded, and re-adds it to the lint target. unused has been merged into staticcheck and is deprecated. This also fixes three issues that got introduced that staticcheck now returns.