### PR TITLE
@suppresswarnings for linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Lint rules can be set using the configuration file. See the configuration at [et
 
 - `google`: This lint group follows the Style Guide at https://developers.google.com/protocol-buffers/docs/style. This is a small group of rules meant to enforce basic naming, and is widely followed. The style guide is copied to [etc/style/google/google.proto](etc/style/google/google.proto).
 - `uber`: This lint group follows the Style Guide at [etc/style/uber/uber.proto](etc/style/uber/uber.proto). This is a very strict rule group and is meant to enforce consistent development patterns.
+- `uber2`: This lint group is the v2 of the `uber` lint group, and makes some modifcations to more closely follow the Google Cloud APIs file
+  structure, as well as adding even more rules to enforce more consistent development patterns. This lint group is under development.
 
 Configuration of your group can be done by setting the `lint.group` option in your `prototool.yaml` file:
 
@@ -185,6 +187,24 @@ See the `prototool.yaml` files at [etc/style/google/prototool.yaml](etc/style/go
 [etc/style/uber/prototool.yaml](etc/style/uber/prototool.yaml) for examples.
 
 The `uber` lint group represents the default lint group, and will be used if no lint group is configured.
+
+While Prototool takes the stance that linting should be a pass/fail exercise, some lint rules are linting for usages that should not be
+commonly used, but still have validity within the lint group construct. These rules can be suppressed by adding `@suppresswarnings ANNOTATION`
+to the element comment. The following lint rules can be suppressed:
+
+
+| Lint Rule                   | Containing Lint Groups   | Suppressing Annotation   |
+|-----------------------------|--------------------------|--------------------------|
+| `MESSAGE_FIELDS_NOT_FLOATS` | `uber2`                  | `floats`                 |
+
+As an example:
+
+```
+// Hello is a field where we understand the concerns with using doubles but require them.
+//
+// @suppresswarnings floats
+double hello = 1;
+```
 
 See [internal/cmd/testdata/lint](internal/cmd/testdata/lint) for additional examples of configurations, and run `prototool lint internal/cmd/testdata/lint/DIR` from a checkout of this repository to see example failures.
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -430,6 +430,14 @@ func TestLint(t *testing.T) {
 	assertDoLintFile(
 		t,
 		false,
+		`17:3:MESSAGE_FIELDS_NOT_FLOATS
+		18:3:MESSAGE_FIELDS_NOT_FLOATS`,
+		"testdata/lint/floats/foo/v1/foo.proto",
+	)
+
+	assertDoLintFile(
+		t,
+		false,
 		`16:3:ENUM_FIELD_PREFIXES_EXCEPT_MESSAGE
 		16:3:ENUM_ZERO_VALUES_INVALID_EXCEPT_MESSAGE
 		17:3:ENUM_FIELD_PREFIXES_EXCEPT_MESSAGE

--- a/internal/cmd/testdata/lint/floats/foo/v1/foo.proto
+++ b/internal/cmd/testdata/lint/floats/foo/v1/foo.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package foo.v1;
+
+option go_package = "foov1";
+option java_multiple_files = true;
+option java_outer_classname = "FooProto";
+option java_package = "com.foo.v1";
+
+message One {
+  // This is a field we are ok with having floats.
+  //
+  // @suppresswarnings floats
+  double one = 1;
+  // @suppresswarnings floats
+  float two = 2;
+  double three = 3;
+  double four = 4;
+}

--- a/internal/cmd/testdata/lint/floats/prototool.yaml
+++ b/internal/cmd/testdata/lint/floats/prototool.yaml
@@ -1,0 +1,2 @@
+lint:
+  group: uber2

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/file"
@@ -173,6 +174,7 @@ var (
 		importsNotWeakLinter,
 		messageFieldNamesLowerSnakeCaseLinter,
 		messageFieldsNoJSONNameLinter,
+		messageFieldsNotFloatsLinter,
 		messageNamesCamelCaseLinter,
 		messageNamesCapitalizedLinter,
 		oneofNamesLowerSnakeCaseLinter,
@@ -389,4 +391,17 @@ func shouldIgnore(linter Linter, descriptor *proto.Proto, ignoreIDToFilePaths ma
 		}
 	}
 	return false, nil
+}
+
+func isSuppressed(comment *proto.Comment, annotation string) bool {
+	if comment == nil {
+		return false
+	}
+	annotation = "@suppresswarnings " + annotation
+	for _, line := range comment.Lines {
+		if strings.Contains(line, annotation) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This adds the concept of `@suppresswarnings` for key linters. See the documentation. The only linter this is enabled for is `MESSAGE_FIELDS_NOT_FLOATS`, which is only part of our new `uber2` lint group.