### PR TITLE
Fix prototool create when empty file exists

### DIFF
--- a/internal/create/handler.go
+++ b/internal/create/handler.go
@@ -98,7 +98,13 @@ func (h *handler) checkFilePath(filePath string) error {
 		return fmt.Errorf("%q is not a directory somehow", dirPath)
 	}
 	if _, err := os.Stat(filePath); err == nil {
-		return fmt.Errorf("%q already exists", filePath)
+		data, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		if len(data) > 0 {
+			return fmt.Errorf("%q already exists", filePath)
+		}
 	}
 	return nil
 }

--- a/vim/prototool/plugin/prototool.vim
+++ b/vim/prototool/plugin/prototool.vim
@@ -65,6 +65,15 @@ function! PrototoolCreate() abort
     endif
 endfunction
 
+function! PrototoolCreateReadPost() abort
+    if exists('g:prototool_create_enable')
+      if line('$') == 1 && getline(1) == ''
+        silent! execute '!prototool create %'
+        silent! edit
+      endif
+    endif
+endfunction
+
 " default functionality below
 
 call PrototoolFormatDisable()
@@ -72,3 +81,4 @@ call PrototoolCreateEnable()
 
 autocmd BufEnter,BufWritePost *.proto :call PrototoolFormat()
 autocmd BufNewFile *.proto :call PrototoolCreate()
+autocmd BufReadPost *.proto :call PrototoolCreateReadPost()


### PR DESCRIPTION
This prevented a file created with NERDTree to be populated.