### PR TITLE
Allow relative paths for generate.plugins.path

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -126,7 +126,9 @@ generate:
       # Optional override for the plugin path. For example, if you set set path to
       # /usr/local/bin/gogo_plugin", prototool will add the
       # "--plugin=protoc-gen-gogo=/usr/local/bin/gogo_plugin" flag to protoc calls.
-      path: /usr/local/bin/gogo
+      # If set to "gogo_plugin", prototool will search your path for "gogo_plugin",.
+      # and fail if "gogo_plugin" cannot be found.
+      path: gogo_plugin
 
     - name: yarpc-go
       type: gogo

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -156,7 +156,9 @@ protoc:
       # Optional override for the plugin path. For example, if you set set path to
       # /usr/local/bin/gogo_plugin", prototool will add the
       # "--plugin=protoc-gen-gogo=/usr/local/bin/gogo_plugin" flag to protoc calls.
-{{.V}}      path: /usr/local/bin/gogo
+      # If set to "gogo_plugin", prototool will search your path for "gogo_plugin",.
+      # and fail if "gogo_plugin" cannot be found.
+{{.V}}      path: gogo_plugin
 
 {{.V}}    - name: yarpc-go
 {{.V}}      type: gogo


### PR DESCRIPTION
This is a fix I've been meaning to do for a while. Instead of only allowing:

```
generate:
  plugins:
    - name: grpc-java
      path: /usr/local/bin/protoc-gen-grpc-java
```

This allows you to specify just `protoc-gen-grpc-java`, which will result in prototool executing `command -v` (the POSIX equivalent of `which`) on this value. This allows for `prototool.yaml`s to be shared with this value in a machine-independent manner.

Manually tested to make sure this works.