### PR TITLE
Only work on files underneath specified directory and deprecate --protoc-wkt-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Usage:
 
 `dirOrFile` can take two forms:
 
-- You can specify exactly one directory. If this is done, Prototool goes up until it finds a `prototool.yaml` or `prototool.json` file (or uses the current directory if none is found), and then walks starting at this location for all `.proto` files, and these are used, except for files in the `excludes` lists in `prototool.yaml` or `prototool.json` files.
+- You can specify exactly one directory. If this is done, Prototool goes up until it finds a `prototool.yaml` or `prototool.json` file (or uses the current directory if none is found), and then uses this config for all `.proto` files under the given directory recursively, except for files in the `excludes` lists in `prototool.yaml` or `prototool.json` files.
 - You can specify exactly one file. This has the effect as if you specified the directory of this file (using the logic above), but errors are only printed for that file. This is useful for e.g. Vim integration.
 - You can specify nothing. This has the effect as if you specified the current directory as the directory.
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -183,11 +183,11 @@ func (f *flags) bindProtocURL(flagSet *pflag.FlagSet) {
 }
 
 func (f *flags) bindProtocBinPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-wkt-path and must not be used with the protoc-url flag.")
+	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must not be used with the protoc-url flag.")
 }
 
 func (f *flags) bindProtocWKTPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocWKTPath, "protoc-wkt-path", "", "The path to the well-known types. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-bin-path and must not be used with the protoc-url flag.")
+	flagSet.StringVar(&f.protocWKTPath, "protoc-wkt-path", "", "Deprecated: has no effect.")
 }
 
 func (f *flags) bindStdin(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -595,12 +595,6 @@ func getRunner(develMode bool, stdin io.Reader, stdout io.Writer, stderr io.Writ
 			exec.RunnerWithProtocBinPath(flags.protocBinPath),
 		)
 	}
-	if flags.protocWKTPath != "" {
-		runnerOptions = append(
-			runnerOptions,
-			exec.RunnerWithProtocWKTPath(flags.protocWKTPath),
-		)
-	}
 	if flags.errorFormat != "" {
 		runnerOptions = append(
 			runnerOptions,

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -118,13 +118,6 @@ func RunnerWithProtocBinPath(protocBinPath string) RunnerOption {
 	}
 }
 
-// RunnerWithProtocWKTPath returns a RunnerOption that uses the given path to include the well-known types.
-func RunnerWithProtocWKTPath(protocWKTPath string) RunnerOption {
-	return func(runner *runner) {
-		runner.protocWKTPath = protocWKTPath
-	}
-}
-
 // RunnerWithProtocURL returns a RunnerOption that uses the given protoc zip file URL.
 func RunnerWithProtocURL(protocURL string) RunnerOption {
 	return func(runner *runner) {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -69,7 +69,6 @@ type runner struct {
 	cachePath     string
 	configData    string
 	protocBinPath string
-	protocWKTPath string
 	protocURL     string
 	errorFormat   string
 	json          bool
@@ -124,7 +123,6 @@ func (r *runner) cloneForWorkDirPath(workDirPath string) *runner {
 		cachePath:        r.cachePath,
 		configData:       r.configData,
 		protocBinPath:    r.protocBinPath,
-		protocWKTPath:    r.protocWKTPath,
 		protocURL:        r.protocURL,
 		errorFormat:      r.errorFormat,
 		json:             r.json,
@@ -759,12 +757,6 @@ func (r *runner) newDownloader(config settings.Config) (protoc.Downloader, error
 			protoc.DownloaderWithProtocBinPath(r.protocBinPath),
 		)
 	}
-	if r.protocWKTPath != "" {
-		downloaderOptions = append(
-			downloaderOptions,
-			protoc.DownloaderWithProtocWKTPath(r.protocWKTPath),
-		)
-	}
 	if r.protocURL != "" {
 		downloaderOptions = append(
 			downloaderOptions,
@@ -788,12 +780,6 @@ func (r *runner) newCompiler(doGen bool, doFileDescriptorSet bool) protoc.Compil
 		compilerOptions = append(
 			compilerOptions,
 			protoc.CompilerWithProtocBinPath(r.protocBinPath),
-		)
-	}
-	if r.protocWKTPath != "" {
-		compilerOptions = append(
-			compilerOptions,
-			protoc.CompilerWithProtocWKTPath(r.protocWKTPath),
 		)
 	}
 	if r.protocURL != "" {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -226,7 +226,11 @@ func (r *runner) Files(args []string) error {
 	if err != nil {
 		return err
 	}
-	for _, files := range meta.ProtoSet.DirPathToFiles {
+	for dirPath, files := range meta.ProtoSet.DirPathToFiles {
+		// skip those files not under the directory
+		if !strings.HasPrefix(dirPath, meta.ProtoSet.DirPath) {
+			continue
+		}
 		for _, file := range files {
 			if err := r.println(file.DisplayPath); err != nil {
 				return err
@@ -404,7 +408,11 @@ func (r *runner) Format(args []string, overwrite, diffMode, lintMode, fixFlag bo
 
 func (r *runner) format(overwrite, diffMode, lintMode bool, fix int, fileHeader string, meta *meta) error {
 	success := true
-	for _, protoFiles := range meta.ProtoSet.DirPathToFiles {
+	for dirPath, protoFiles := range meta.ProtoSet.DirPathToFiles {
+		// skip those files not under the directory
+		if !strings.HasPrefix(dirPath, meta.ProtoSet.DirPath) {
+			continue
+		}
 		for _, protoFile := range protoFiles {
 			fileSuccess, err := r.formatFile(overwrite, diffMode, lintMode, fix, fileHeader, meta, protoFile)
 			if err != nil {
@@ -975,7 +983,11 @@ func (r *runner) printLinters(config settings.LintConfig, linters []lint.Linter)
 }
 
 func (r *runner) printAffectedFiles(meta *meta) {
-	for _, files := range meta.ProtoSet.DirPathToFiles {
+	for dirPath, files := range meta.ProtoSet.DirPathToFiles {
+		// skip those files not under the directory
+		if !strings.HasPrefix(dirPath, meta.ProtoSet.DirPath) {
+			continue
+		}
 		for _, file := range files {
 			r.logger.Debug("using file", zap.String("file", file.DisplayPath))
 		}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -70,41 +70,18 @@ type ProtoFile struct {
 
 // ProtoSetProvider provides ProtoSets.
 type ProtoSetProvider interface {
-	// GetMultipleForDir gets the ProtoSets for the given dirPath.
-	// Each ProtoSet will have the config assocated with all files associated with
+	// GetForDir gets the ProtoSet for the given dirPath.
+	// The ProtoSet will have the config assocated with all files associated with
 	// the ProtoSet.
 	//
 	// This will return all .proto files in the directory of the associated config file
 	// and all it's subdirectories, or the given directory and its subdirectories
 	// if there is no config file.
 	//
-	// Configs will be searched for starting at the directory of each .proto file
+	// Config will be searched for starting at the directory of each .proto file
 	// and going up a directory until hitting root.
-	GetMultipleForDir(workDirPath string, dirPath string) ([]*ProtoSet, error)
-
-	// GetMultipleForFiles gets the ProtoSets for the given filePaths.
-	// Each ProtoSet will have the config assocated with all files associated with
-	// the ProtoSet.
-	//
-	// Configs will be searched for starting at the directory of each .proto file
-	// and going up a directory until hitting root.
-	//
-	// This ignores excludes, all files given will be included.
-	GetMultipleForFiles(workDirPath string, filePaths ...string) ([]*ProtoSet, error)
-
-	// GetForDir does the same logic as GetMultipleForDir, but returns an error if there
-	// is not exactly one ProtoSet. We keep the original logic and testing for multiple
-	// ProtoSets around as we are still discussing this pre-v1.0.
-	// https://github.com/uber/prototool/issues/10
-	// https://github.com/uber/prototool/issues/93
+	// Returns an error if there is not exactly one ProtoSet.
 	GetForDir(workDirPath string, dirPath string) (*ProtoSet, error)
-
-	// GetForFiles does the same logic as GetMultipleForFiles, but returns an error if there
-	// is not exactly one ProtoSet. We keep the original logic and testing for multiple
-	// ProtoSets around as we are still discussing this pre-v1.0.
-	// https://github.com/uber/prototool/issues/10
-	// https://github.com/uber/prototool/issues/93
-	GetForFiles(workDirPath string, filePaths ...string) (*ProtoSet, error)
 }
 
 // ProtoSetProviderOption is an option for a new ProtoSetProvider.

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -273,21 +273,6 @@ func getDirPathToProtoFiles(protoFiles []*ProtoFile) map[string][]*ProtoFile {
 	return dirPathToProtoFiles
 }
 
-func getProtoFiles(filePaths []string) ([]*ProtoFile, error) {
-	protoFiles := make([]*ProtoFile, 0, len(filePaths))
-	for _, filePath := range filePaths {
-		absFilePath, err := AbsClean(filePath)
-		if err != nil {
-			return nil, err
-		}
-		protoFiles = append(protoFiles, &ProtoFile{
-			Path:        absFilePath,
-			DisplayPath: filePath,
-		})
-	}
-	return protoFiles, nil
-}
-
 // isExcluded determines whether the given filePath should be excluded.
 // Note that all excludes are assumed to be cleaned absolute paths at
 // this point.

--- a/internal/file/proto_set_provider_test.go
+++ b/internal/file/proto_set_provider_test.go
@@ -31,269 +31,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestProtoSetProviderGetMultipleForFilesAll(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetMultipleForFiles(
-		cwd,
-		"testdata/valid/base/a/file.proto",
-		"testdata/valid/base/b/file.proto",
-		"testdata/valid/base/c/file.proto",
-		"testdata/valid/base/a/d/file.proto",
-		"testdata/valid/base/a/d/file2.proto",
-		"testdata/valid/base/a/d/file3.proto",
-		"testdata/valid/base/a/e/file.proto",
-		"testdata/valid/base/a/f/file.proto",
-		"testdata/valid/base/b/g/h/file.proto",
-	)
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		[]*ProtoSet{
-			&ProtoSet{
-				WorkDirPath: cwd,
-				DirPath:     cwd,
-				DirPathToFiles: map[string][]*ProtoFile{
-					cwd + "/testdata/valid/base/a": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/file.proto",
-							DisplayPath: "testdata/valid/base/a/file.proto",
-						},
-					},
-					cwd + "/testdata/valid/base/c": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/c/file.proto",
-							DisplayPath: "testdata/valid/base/c/file.proto",
-						},
-					},
-					cwd + "/testdata/valid/base/a/e": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/e/file.proto",
-							DisplayPath: "testdata/valid/base/a/e/file.proto",
-						},
-					},
-					cwd + "/testdata/valid/base/a/f": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/f/file.proto",
-							DisplayPath: "testdata/valid/base/a/f/file.proto",
-						},
-					},
-				},
-				Config: settings.Config{
-					DirPath: cwd + "/testdata/valid/base",
-					ExcludePrefixes: []string{
-						cwd + "/testdata/valid/base/c/i",
-						cwd + "/testdata/valid/base/d",
-					},
-					Compile: settings.CompileConfig{
-						ProtobufVersion:       "3.4.0",
-						IncludePaths:          []string{},
-						IncludeWellKnownTypes: true,
-					},
-					Lint: settings.LintConfig{
-						IncludeIDs:          []string{},
-						ExcludeIDs:          []string{},
-						IgnoreIDToFilePaths: map[string][]string{},
-					},
-					Gen: settings.GenConfig{
-						GoPluginOptions: settings.GenGoPluginOptions{},
-						Plugins:         []settings.GenPlugin{},
-					},
-				},
-			},
-			&ProtoSet{
-				WorkDirPath: cwd,
-				DirPath:     cwd,
-				DirPathToFiles: map[string][]*ProtoFile{
-					cwd + "/testdata/valid/base/a/d": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/d/file.proto",
-							DisplayPath: "testdata/valid/base/a/d/file.proto",
-						},
-						{
-							Path:        cwd + "/testdata/valid/base/a/d/file2.proto",
-							DisplayPath: "testdata/valid/base/a/d/file2.proto",
-						},
-						{
-							Path:        cwd + "/testdata/valid/base/a/d/file3.proto",
-							DisplayPath: "testdata/valid/base/a/d/file3.proto",
-						},
-					},
-				},
-				Config: settings.Config{
-					DirPath: cwd + "/testdata/valid/base/a/d",
-					ExcludePrefixes: []string{
-						cwd + "/testdata/valid/base/a/d/file3.proto",
-					},
-					Compile: settings.CompileConfig{
-						ProtobufVersion:       "3.2.0",
-						IncludePaths:          []string{},
-						IncludeWellKnownTypes: true,
-					},
-					Lint: settings.LintConfig{
-						IncludeIDs:          []string{},
-						ExcludeIDs:          []string{},
-						IgnoreIDToFilePaths: map[string][]string{},
-					},
-					Gen: settings.GenConfig{
-						GoPluginOptions: settings.GenGoPluginOptions{},
-						Plugins:         []settings.GenPlugin{},
-					},
-				},
-			},
-			&ProtoSet{
-				WorkDirPath: cwd,
-				DirPath:     cwd,
-				DirPathToFiles: map[string][]*ProtoFile{
-					cwd + "/testdata/valid/base/b": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/b/file.proto",
-							DisplayPath: "testdata/valid/base/b/file.proto",
-						},
-					},
-					cwd + "/testdata/valid/base/b/g/h": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/b/g/h/file.proto",
-							DisplayPath: "testdata/valid/base/b/g/h/file.proto",
-						},
-					},
-				},
-				Config: settings.Config{
-					DirPath: cwd + "/testdata/valid/base/b",
-					ExcludePrefixes: []string{
-						cwd + "/testdata/valid/base/b/g/h",
-					},
-					Compile: settings.CompileConfig{
-						ProtobufVersion:       "3.3.0",
-						IncludePaths:          []string{},
-						IncludeWellKnownTypes: true,
-					},
-					Lint: settings.LintConfig{
-						IncludeIDs:          []string{},
-						ExcludeIDs:          []string{},
-						IgnoreIDToFilePaths: map[string][]string{},
-					},
-					Gen: settings.GenConfig{
-						GoPluginOptions: settings.GenGoPluginOptions{},
-						Plugins:         []settings.GenPlugin{},
-					},
-				},
-			},
-		},
-		protoSets,
-	)
-}
-
-func TestProtoSetProviderGetMultipleForFilesSomeMissing(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetMultipleForFiles(
-		cwd,
-		"testdata/valid/base/a/file.proto",
-		"testdata/valid/base/c/file.proto",
-		"testdata/valid/base/a/d/file.proto",
-		"testdata/valid/base/a/d/file3.proto",
-		"testdata/valid/base/a/e/file.proto",
-		"testdata/valid/base/a/f/file.proto",
-	)
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		[]*ProtoSet{
-			&ProtoSet{
-				WorkDirPath: cwd,
-				DirPath:     cwd,
-				DirPathToFiles: map[string][]*ProtoFile{
-					cwd + "/testdata/valid/base/a": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/file.proto",
-							DisplayPath: "testdata/valid/base/a/file.proto",
-						},
-					},
-					cwd + "/testdata/valid/base/c": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/c/file.proto",
-							DisplayPath: "testdata/valid/base/c/file.proto",
-						},
-					},
-					cwd + "/testdata/valid/base/a/e": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/e/file.proto",
-							DisplayPath: "testdata/valid/base/a/e/file.proto",
-						},
-					},
-					cwd + "/testdata/valid/base/a/f": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/f/file.proto",
-							DisplayPath: "testdata/valid/base/a/f/file.proto",
-						},
-					},
-				},
-				Config: settings.Config{
-					DirPath: cwd + "/testdata/valid/base",
-					ExcludePrefixes: []string{
-						cwd + "/testdata/valid/base/c/i",
-						cwd + "/testdata/valid/base/d",
-					},
-					Compile: settings.CompileConfig{
-						ProtobufVersion:       "3.4.0",
-						IncludePaths:          []string{},
-						IncludeWellKnownTypes: true,
-					},
-					Lint: settings.LintConfig{
-						IncludeIDs:          []string{},
-						ExcludeIDs:          []string{},
-						IgnoreIDToFilePaths: map[string][]string{},
-					},
-					Gen: settings.GenConfig{
-						GoPluginOptions: settings.GenGoPluginOptions{},
-						Plugins:         []settings.GenPlugin{},
-					},
-				},
-			},
-			&ProtoSet{
-				WorkDirPath: cwd,
-				DirPath:     cwd,
-				DirPathToFiles: map[string][]*ProtoFile{
-					cwd + "/testdata/valid/base/a/d": []*ProtoFile{
-						{
-							Path:        cwd + "/testdata/valid/base/a/d/file.proto",
-							DisplayPath: "testdata/valid/base/a/d/file.proto",
-						},
-						{
-							Path:        cwd + "/testdata/valid/base/a/d/file3.proto",
-							DisplayPath: "testdata/valid/base/a/d/file3.proto",
-						},
-					},
-				},
-				Config: settings.Config{
-					DirPath: cwd + "/testdata/valid/base/a/d",
-					ExcludePrefixes: []string{
-						cwd + "/testdata/valid/base/a/d/file3.proto",
-					},
-					Compile: settings.CompileConfig{
-						ProtobufVersion:       "3.2.0",
-						IncludePaths:          []string{},
-						IncludeWellKnownTypes: true,
-					},
-					Lint: settings.LintConfig{
-						IncludeIDs:          []string{},
-						ExcludeIDs:          []string{},
-						IgnoreIDToFilePaths: map[string][]string{},
-					},
-					Gen: settings.GenConfig{
-						GoPluginOptions: settings.GenGoPluginOptions{},
-						Plugins:         []settings.GenPlugin{},
-					},
-				},
-			},
-		},
-		protoSets,
-	)
-}
-
 // We need to use valid as a representation of "cwd" so we verify
 // that we do the recursive search properly. We used to use actual cwd,
 // however since we added testdata/invalid, this will not work anymore.
@@ -303,7 +40,7 @@ func TestProtoSetProviderGetMultipleForDirCwdAsValidRel(t *testing.T) {
 	require.NoError(t, err)
 	validDirPath := filepath.Join(cwd, "testdata", "valid")
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetMultipleForDir(cwd, filepath.Join(".", "testdata", "valid"))
+	protoSets, err := protoSetProvider.getMultipleForDir(cwd, filepath.Join(".", "testdata", "valid"))
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -441,7 +178,7 @@ func TestProtoSetProviderGetMultipleForDirCwdAbs(t *testing.T) {
 	require.NoError(t, err)
 	validDirPath := filepath.Join(cwd, "testdata", "valid")
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetMultipleForDir(cwd, validDirPath)
+	protoSets, err := protoSetProvider.getMultipleForDir(cwd, validDirPath)
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -574,7 +311,7 @@ func TestProtoSetProviderGetMultipleForDirCwdSubRel(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	protoSetProvider := newTestProtoSetProvider(t)
-	protoSets, err := protoSetProvider.GetMultipleForDir(cwd, "testdata/valid/base/d/g")
+	protoSets, err := protoSetProvider.getMultipleForDir(cwd, "testdata/valid/base/d/g")
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -624,7 +361,7 @@ func TestProtoSetProviderGetMultipleForDirTwoConfigFiles(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	protoSetProvider := newTestProtoSetProvider(t)
-	_, err = protoSetProvider.GetMultipleForDir(cwd, "testdata/invalid")
+	_, err = protoSetProvider.getMultipleForDir(cwd, "testdata/invalid")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "multiple configuration files")
 }
@@ -680,8 +417,8 @@ func TestIsExcluded(t *testing.T) {
 	}
 }
 
-func newTestProtoSetProvider(t *testing.T) ProtoSetProvider {
+func newTestProtoSetProvider(t *testing.T) *protoSetProvider {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
-	return NewProtoSetProvider(ProtoSetProviderWithLogger(logger))
+	return newProtoSetProvider(ProtoSetProviderWithLogger(logger))
 }

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -309,7 +309,7 @@ type Linter interface {
 	ID() string
 	// Return the purpose of this Linter. This should be a human-readable string.
 	Purpose(config settings.LintConfig) string
-	// Check the file data for the descriptors in a common directgory.
+	// Check the file data for the descriptors in a common directory.
 	// If there is a lint failure, this returns it in the
 	// slice and does not return an error. An error is returned if something
 	// unexpected happens. Callers should verify the files are compilable
@@ -403,6 +403,10 @@ func GetLinters(config settings.LintConfig) ([]Linter, error) {
 func GetDirPathToDescriptors(protoSet *file.ProtoSet) (map[string][]*FileDescriptor, error) {
 	dirPathToDescriptors := make(map[string][]*FileDescriptor, len(protoSet.DirPathToFiles))
 	for dirPath, protoFiles := range protoSet.DirPathToFiles {
+		// skip those files not under the directory
+		if !strings.HasPrefix(dirPath, protoSet.DirPath) {
+			continue
+		}
 		descriptors := make([]*FileDescriptor, len(protoFiles))
 		for i, protoFile := range protoFiles {
 			file, err := os.Open(protoFile.Path)

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -70,7 +70,6 @@ type compiler struct {
 	logger              *zap.Logger
 	cachePath           string
 	protocBinPath       string
-	protocWKTPath       string
 	protocURL           string
 	doGen               bool
 	doFileDescriptorSet bool
@@ -398,12 +397,6 @@ func (c *compiler) newDownloader(config settings.Config) (Downloader, error) {
 			DownloaderWithProtocBinPath(c.protocBinPath),
 		)
 	}
-	if c.protocWKTPath != "" {
-		downloaderOptions = append(
-			downloaderOptions,
-			DownloaderWithProtocWKTPath(c.protocWKTPath),
-		)
-	}
 	if c.protocURL != "" {
 		downloaderOptions = append(
 			downloaderOptions,
@@ -557,17 +550,6 @@ func getIncludes(downloader Downloader, config settings.Config, dirPath string, 
 		}
 		if includePath == configDirPath {
 			includedConfigDirPath = true
-		}
-	}
-	if config.Compile.IncludeWellKnownTypes {
-		wellKnownTypesIncludePath, err := downloader.WellKnownTypesIncludePath()
-		if err != nil {
-			return nil, err
-		}
-		includes = append(includes, wellKnownTypesIncludePath)
-		// TODO: not exactly platform independent
-		if strings.HasPrefix(dirPath, wellKnownTypesIncludePath) {
-			fileInIncludePath = true
 		}
 	}
 	// you want your proto files to be in at least one of the -I directories

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -197,6 +197,9 @@ func (c *compiler) makeGenDirs(protoSet *file.ProtoSet) error {
 			genDirs[baseOutputPath] = struct{}{}
 		} else {
 			for dirPath := range protoSet.DirPathToFiles {
+				if !strings.HasPrefix(dirPath, protoSet.DirPath) {
+					continue
+				}
 				relOutputFilePath, err := getRelOutputFilePath(protoSet, dirPath, genPlugin.FileSuffix)
 				if err != nil {
 					return err
@@ -293,6 +296,9 @@ func (c *compiler) getCmdMetas(protoSet *file.ProtoSet) (cmdMetas []*cmdMeta, re
 		return cmdMetas, err
 	}
 	for dirPath, protoFiles := range protoSet.DirPathToFiles {
+		if !strings.HasPrefix(dirPath, protoSet.DirPath) {
+			continue
+		}
 		// you want your proto files to be in at least one of the -I directories
 		// or otherwise things can get weird
 		// we make best effort to make sure we have the a parent directory of the file

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -197,6 +197,7 @@ func (c *compiler) makeGenDirs(protoSet *file.ProtoSet) error {
 			genDirs[baseOutputPath] = struct{}{}
 		} else {
 			for dirPath := range protoSet.DirPathToFiles {
+				// skip those files not under the directory
 				if !strings.HasPrefix(dirPath, protoSet.DirPath) {
 					continue
 				}
@@ -296,6 +297,7 @@ func (c *compiler) getCmdMetas(protoSet *file.ProtoSet) (cmdMetas []*cmdMeta, re
 		return cmdMetas, err
 	}
 	for dirPath, protoFiles := range protoSet.DirPathToFiles {
+		// skip those files not under the directory
 		if !strings.HasPrefix(dirPath, protoSet.DirPath) {
 			continue
 		}
@@ -508,6 +510,8 @@ func getPluginFlagSetProtoFlags(protoSet *file.ProtoSet, dirPath string, genPlug
 		// you cannot include the files in the same package in the Mfile=package map
 		// or otherwise protoc-gen-go, protoc-gen-gogo, etc freak out and put
 		// these packages in as imports
+		// but, unlike other usages of DirPathToFiles, you MUST include all directories
+		// under control of the prototool.yaml to make sure all modifiers are added
 		if subDirPath != dirPath {
 			for _, protoFile := range protoFiles {
 				path, err := filepath.Rel(protoSet.Config.DirPath, protoFile.Path)

--- a/internal/protoc/downloader_test.go
+++ b/internal/protoc/downloader_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -104,9 +103,7 @@ func TestNewDownloaderProtocValidation(t *testing.T) {
 		desc          string
 		url           string
 		binPath       string
-		wktPath       string
 		createBinPath bool
-		createWKTPath bool
 		err           error
 	}{
 		{
@@ -117,36 +114,20 @@ func TestNewDownloaderProtocValidation(t *testing.T) {
 			url:  "http://example.com",
 		},
 		{
-			desc:          "protocBinPath with protocWKTPath",
+			desc:          "protocBinPath",
 			binPath:       "protoc",
-			wktPath:       "include",
 			createBinPath: true,
-			createWKTPath: true,
 		},
 		{
-			desc:    "protocURL set with protocBinPath and protocWKTPath",
+			desc:    "protocURL set with protocBinPath",
 			url:     "http://example.com",
 			binPath: "protoc",
-			wktPath: "include",
-			err:     fmt.Errorf("cannot use protoc-url in combination with either protoc-bin-path or protoc-wkt-path"),
-		},
-		{
-			desc:    "protocBinPath set without protocWKTPath",
-			binPath: "protoc",
-			err:     fmt.Errorf("both protoc-bin-path and protoc-wkt-path must be set"),
+			err:     fmt.Errorf("cannot use protoc-url in combination with protoc-bin-path"),
 		},
 		{
 			desc:    "protocBinPath does not exist",
 			binPath: "protoc",
-			wktPath: "include",
 			err:     fmt.Errorf("stat protoc: no such file or directory"),
-		},
-		{
-			desc:          "protocWKTPath does not exist",
-			binPath:       "protoc",
-			wktPath:       "include",
-			createBinPath: true,
-			err:           fmt.Errorf("stat include: no such file or directory"),
 		},
 	}
 	for _, tt := range tests {
@@ -162,20 +143,10 @@ func TestNewDownloaderProtocValidation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if tt.createWKTPath {
-				tt.wktPath, err = ioutil.TempDir(tmpRoot, tt.wktPath)
-				require.NoError(t, err)
-			}
-
-			if tt.createBinPath && tt.createWKTPath {
-				require.NoError(t, os.MkdirAll(filepath.Join(tt.wktPath, "google", "protobuf"), 0755))
-			}
-
 			_, err = newDownloader(
 				settings.Config{},
 				DownloaderWithProtocURL(tt.url),
 				DownloaderWithProtocBinPath(tt.binPath),
-				DownloaderWithProtocWKTPath(tt.wktPath),
 			)
 
 			if tt.err != nil {

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -41,20 +41,13 @@ type Downloader interface {
 	//
 	// Returns the path to the downloaded protobuf artifacts.
 	//
-	// ProtocPath and WellKnownTypesIncludePath implicitly call this.
+	// ProtocPath implicitly calls this.
 	Download() (string, error)
 
 	// Get the path to protoc.
 	//
 	// If not downloaded, this downloads and caches protobuf. This is thread-safe.
 	ProtocPath() (string, error)
-
-	// Get the path to include for the well-known types.
-	//
-	// Inside this directory will be the subdirectories google/protobuf.
-	//
-	// If not downloaded, this downloads and caches protobuf. This is thread-safe.
-	WellKnownTypesIncludePath() (string, error)
 
 	// Delete any downloaded artifacts.
 	//
@@ -88,14 +81,6 @@ func DownloaderWithCachePath(cachePath string) DownloaderOption {
 func DownloaderWithProtocBinPath(protocBinPath string) DownloaderOption {
 	return func(downloader *downloader) {
 		downloader.protocBinPath = protocBinPath
-	}
-}
-
-// DownloaderWithProtocWKTPath returns a DownloaderOption that uses the given path to include
-// the well-known types.
-func DownloaderWithProtocWKTPath(protocWKTPath string) DownloaderOption {
-	return func(downloader *downloader) {
-		downloader.protocWKTPath = protocWKTPath
 	}
 }
 
@@ -166,14 +151,6 @@ func CompilerWithCachePath(cachePath string) CompilerOption {
 func CompilerWithProtocBinPath(protocBinPath string) CompilerOption {
 	return func(compiler *compiler) {
 		compiler.protocBinPath = protocBinPath
-	}
-}
-
-// CompilerWithProtocWKTPath returns a CompilerOption that uses the given path to include the
-// well-known types.
-func CompilerWithProtocWKTPath(protocWKTPath string) CompilerOption {
-	return func(compiler *compiler) {
-		compiler.protocWKTPath = protocWKTPath
 	}
 }
 


### PR DESCRIPTION
The previous behavior was to take the input directory, walk up until a prototool.yaml is found, and then compile everything under the prototool.yaml. The behavior now is to take the input directory, walk up until a prototool.yaml is found, and then only compile everything under the input directory. All commands will function the same in practice, this just makes it so that when you specify a given directory, not everything is compiled. Previously, this behavior was needed because we allowed multiple files to be specified on the command line, not just a single directory, but since we never exposed that functionality, we can reason about Prototool better and make this (very helpful) update. 

The helper code (not exposed publically in any way) to search files instead of directories is also deleted, as it is not used. This also deprecates `--protoc-wkt-path` as the Well-Known Types are automatically included with `protoc`.