### PR TITLE
Revert #304 deprecation of --protoc-wkt-path flag

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -183,11 +183,11 @@ func (f *flags) bindProtocURL(flagSet *pflag.FlagSet) {
 }
 
 func (f *flags) bindProtocBinPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must not be used with the protoc-url flag.")
+	flagSet.StringVar(&f.protocBinPath, "protoc-bin-path", "", "The path to the protoc binary. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-wkt-path and must not be used with the protoc-url flag.")
 }
 
 func (f *flags) bindProtocWKTPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.protocWKTPath, "protoc-wkt-path", "", "Deprecated: has no effect.")
+	flagSet.StringVar(&f.protocWKTPath, "protoc-wkt-path", "", "The path to the well-known types. Setting this option will ignore the config protoc.version setting. This flag must be used with protoc-bin-path and must not be used with the protoc-url flag.")
 }
 
 func (f *flags) bindStdin(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -595,6 +595,12 @@ func getRunner(develMode bool, stdin io.Reader, stdout io.Writer, stderr io.Writ
 			exec.RunnerWithProtocBinPath(flags.protocBinPath),
 		)
 	}
+	if flags.protocWKTPath != "" {
+		runnerOptions = append(
+			runnerOptions,
+			exec.RunnerWithProtocWKTPath(flags.protocWKTPath),
+		)
+	}
 	if flags.errorFormat != "" {
 		runnerOptions = append(
 			runnerOptions,

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -118,6 +118,13 @@ func RunnerWithProtocBinPath(protocBinPath string) RunnerOption {
 	}
 }
 
+// RunnerWithProtocWKTPath returns a RunnerOption that uses the given path to include the well-known types.
+func RunnerWithProtocWKTPath(protocWKTPath string) RunnerOption {
+	return func(runner *runner) {
+		runner.protocWKTPath = protocWKTPath
+	}
+}
+
 // RunnerWithProtocURL returns a RunnerOption that uses the given protoc zip file URL.
 func RunnerWithProtocURL(protocURL string) RunnerOption {
 	return func(runner *runner) {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -69,6 +69,7 @@ type runner struct {
 	cachePath     string
 	configData    string
 	protocBinPath string
+	protocWKTPath string
 	protocURL     string
 	errorFormat   string
 	json          bool
@@ -123,6 +124,7 @@ func (r *runner) cloneForWorkDirPath(workDirPath string) *runner {
 		cachePath:        r.cachePath,
 		configData:       r.configData,
 		protocBinPath:    r.protocBinPath,
+		protocWKTPath:    r.protocWKTPath,
 		protocURL:        r.protocURL,
 		errorFormat:      r.errorFormat,
 		json:             r.json,
@@ -757,6 +759,12 @@ func (r *runner) newDownloader(config settings.Config) (protoc.Downloader, error
 			protoc.DownloaderWithProtocBinPath(r.protocBinPath),
 		)
 	}
+	if r.protocWKTPath != "" {
+		downloaderOptions = append(
+			downloaderOptions,
+			protoc.DownloaderWithProtocWKTPath(r.protocWKTPath),
+		)
+	}
 	if r.protocURL != "" {
 		downloaderOptions = append(
 			downloaderOptions,
@@ -780,6 +788,12 @@ func (r *runner) newCompiler(doGen bool, doFileDescriptorSet bool) protoc.Compil
 		compilerOptions = append(
 			compilerOptions,
 			protoc.CompilerWithProtocBinPath(r.protocBinPath),
+		)
+	}
+	if r.protocWKTPath != "" {
+		compilerOptions = append(
+			compilerOptions,
+			protoc.CompilerWithProtocWKTPath(r.protocWKTPath),
 		)
 	}
 	if r.protocURL != "" {

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -70,6 +70,7 @@ type compiler struct {
 	logger              *zap.Logger
 	cachePath           string
 	protocBinPath       string
+	protocWKTPath       string
 	protocURL           string
 	doGen               bool
 	doFileDescriptorSet bool
@@ -397,6 +398,12 @@ func (c *compiler) newDownloader(config settings.Config) (Downloader, error) {
 			DownloaderWithProtocBinPath(c.protocBinPath),
 		)
 	}
+	if c.protocWKTPath != "" {
+		downloaderOptions = append(
+			downloaderOptions,
+			DownloaderWithProtocWKTPath(c.protocWKTPath),
+		)
+	}
 	if c.protocURL != "" {
 		downloaderOptions = append(
 			downloaderOptions,
@@ -550,6 +557,17 @@ func getIncludes(downloader Downloader, config settings.Config, dirPath string, 
 		}
 		if includePath == configDirPath {
 			includedConfigDirPath = true
+		}
+	}
+	if config.Compile.IncludeWellKnownTypes {
+		wellKnownTypesIncludePath, err := downloader.WellKnownTypesIncludePath()
+		if err != nil {
+			return nil, err
+		}
+		includes = append(includes, wellKnownTypesIncludePath)
+		// TODO: not exactly platform independent
+		if strings.HasPrefix(dirPath, wellKnownTypesIncludePath) {
+			fileInIncludePath = true
 		}
 	}
 	// you want your proto files to be in at least one of the -I directories

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -61,8 +61,11 @@ type downloader struct {
 	// the looked-up and verified to exist base path
 	cachedBasePath string
 
-	// If set, Prototool will invoke protoc from the configured binPath
+	// If set, Prototool will invoke protoc and include
+	// the well-known-types, from the configured binPath
+	// and wktPath.
 	protocBinPath string
+	protocWKTPath string
 }
 
 func newDownloader(config settings.Config, options ...DownloaderOption) (*downloader, error) {
@@ -76,15 +79,31 @@ func newDownloader(config settings.Config, options ...DownloaderOption) (*downlo
 	if downloader.config.Compile.ProtobufVersion == "" {
 		downloader.config.Compile.ProtobufVersion = vars.DefaultProtocVersion
 	}
-	if downloader.protocBinPath != "" {
+	if downloader.protocBinPath != "" || downloader.protocWKTPath != "" {
 		if downloader.protocURL != "" {
-			return nil, fmt.Errorf("cannot use protoc-url in combination with protoc-bin-path")
+			return nil, fmt.Errorf("cannot use protoc-url in combination with either protoc-bin-path or protoc-wkt-path")
+		}
+		if downloader.protocBinPath == "" || downloader.protocWKTPath == "" {
+			return nil, fmt.Errorf("both protoc-bin-path and protoc-wkt-path must be set")
 		}
 		cleanBinPath := filepath.Clean(downloader.protocBinPath)
 		if _, err := os.Stat(cleanBinPath); os.IsNotExist(err) {
 			return nil, err
 		}
+		cleanWKTPath := filepath.Clean(downloader.protocWKTPath)
+		if _, err := os.Stat(cleanWKTPath); os.IsNotExist(err) {
+			return nil, err
+		}
+		protobufPath := filepath.Join(cleanWKTPath, "google", "protobuf")
+		info, err := os.Stat(protobufPath)
+		if os.IsNotExist(err) {
+			return nil, err
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("%q is not a valid well-known types directory", protobufPath)
+		}
 		downloader.protocBinPath = cleanBinPath
+		downloader.protocWKTPath = cleanWKTPath
 	}
 	return downloader, nil
 }
@@ -108,6 +127,17 @@ func (d *downloader) ProtocPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(basePath, "bin", "protoc"), nil
+}
+
+func (d *downloader) WellKnownTypesIncludePath() (string, error) {
+	if d.protocWKTPath != "" {
+		return d.protocWKTPath, nil
+	}
+	basePath, err := d.Download()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(basePath, "include"), nil
 }
 
 func (d *downloader) Delete() error {

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -41,13 +41,20 @@ type Downloader interface {
 	//
 	// Returns the path to the downloaded protobuf artifacts.
 	//
-	// ProtocPath implicitly calls this.
+	// ProtocPath and WellKnownTypesIncludePath implicitly call this.
 	Download() (string, error)
 
 	// Get the path to protoc.
 	//
 	// If not downloaded, this downloads and caches protobuf. This is thread-safe.
 	ProtocPath() (string, error)
+
+	// Get the path to include for the well-known types.
+	//
+	// Inside this directory will be the subdirectories google/protobuf.
+	//
+	// If not downloaded, this downloads and caches protobuf. This is thread-safe.
+	WellKnownTypesIncludePath() (string, error)
 
 	// Delete any downloaded artifacts.
 	//
@@ -81,6 +88,14 @@ func DownloaderWithCachePath(cachePath string) DownloaderOption {
 func DownloaderWithProtocBinPath(protocBinPath string) DownloaderOption {
 	return func(downloader *downloader) {
 		downloader.protocBinPath = protocBinPath
+	}
+}
+
+// DownloaderWithProtocWKTPath returns a DownloaderOption that uses the given path to include
+// the well-known types.
+func DownloaderWithProtocWKTPath(protocWKTPath string) DownloaderOption {
+	return func(downloader *downloader) {
+		downloader.protocWKTPath = protocWKTPath
 	}
 }
 
@@ -151,6 +166,14 @@ func CompilerWithCachePath(cachePath string) CompilerOption {
 func CompilerWithProtocBinPath(protocBinPath string) CompilerOption {
 	return func(compiler *compiler) {
 		compiler.protocBinPath = protocBinPath
+	}
+}
+
+// CompilerWithProtocWKTPath returns a CompilerOption that uses the given path to include the
+// well-known types.
+func CompilerWithProtocWKTPath(protocWKTPath string) CompilerOption {
+	return func(compiler *compiler) {
+		compiler.protocWKTPath = protocWKTPath
 	}
 }
 


### PR DESCRIPTION
It turns out this should not have been removed - the WKT being available was a function of local environment, not protoc being upgraded.