### PR TITLE
 Fix prototool commands to work when no Protobuf files are found

### DIFF
--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -66,6 +66,15 @@ func HandlerWithPackage(pkg string) HandlerOption {
 	}
 }
 
+// HandlerWithConfigData returns a HandlerOption that uses the given configuration
+// data instead of using configuration files that are found. This acts as if there is only one
+// configuration file at the current working directory. All found configuration files are ignored.
+func HandlerWithConfigData(configData string) HandlerOption {
+	return func(handler *handler) {
+		handler.configData = configData
+	}
+}
+
 // NewHandler returns a new Handler.
 func NewHandler(options ...HandlerOption) Handler {
 	return newHandler(options...)

--- a/internal/create/handler.go
+++ b/internal/create/handler.go
@@ -74,6 +74,7 @@ type handler struct {
 	develMode      bool
 	configProvider settings.ConfigProvider
 	pkg            string
+	configData     string
 }
 
 func newHandler(options ...HandlerOption) *handler {
@@ -195,7 +196,7 @@ func (h *handler) isV2(filePath string) (bool, error) {
 		return false, err
 	}
 	absDirPath := filepath.Dir(absFilePath)
-	config, err := h.configProvider.GetForDir(absDirPath)
+	config, err := h.getConfig(absDirPath)
 	if err != nil {
 		return false, err
 	}
@@ -212,7 +213,7 @@ func (h *handler) getFileHeader(filePath string) (string, error) {
 		return "", err
 	}
 	absDirPath := filepath.Dir(absFilePath)
-	config, err := h.configProvider.GetForDir(absDirPath)
+	config, err := h.getConfig(absDirPath)
 	if err != nil {
 		return "", err
 	}
@@ -232,7 +233,7 @@ func (h *handler) getPkg(filePath string, defaultPackage string) (string, error)
 		return "", err
 	}
 	absDirPath := filepath.Dir(absFilePath)
-	config, err := h.configProvider.GetForDir(absDirPath)
+	config, err := h.getConfig(absDirPath)
 	if err != nil {
 		return "", err
 	}
@@ -277,6 +278,13 @@ func (h *handler) getPkg(filePath string, defaultPackage string) (string, error)
 		return "", err
 	}
 	return getPkgFromRel(rel, "", defaultPackage), nil
+}
+
+func (h *handler) getConfig(absDirPath string) (settings.Config, error) {
+	if h.configData != "" {
+		return h.configProvider.GetForData(absDirPath, h.configData)
+	}
+	return h.configProvider.GetForDir(absDirPath)
 }
 
 func getPkgFromRel(rel string, basePkg string, defaultPackage string) string {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -57,7 +57,6 @@ import (
 )
 
 type runner struct {
-	configProvider   settings.ConfigProvider
 	protoSetProvider file.ProtoSetProvider
 
 	workDirPath string
@@ -84,16 +83,6 @@ func newRunner(workDirPath string, input io.Reader, output io.Writer, options ..
 	for _, option := range options {
 		option(runner)
 	}
-	configProviderOptions := []settings.ConfigProviderOption{
-		settings.ConfigProviderWithLogger(runner.logger),
-	}
-	if runner.develMode {
-		configProviderOptions = append(
-			configProviderOptions,
-			settings.ConfigProviderWithDevelMode(),
-		)
-	}
-	runner.configProvider = settings.NewConfigProvider(configProviderOptions...)
 	protoSetProviderOptions := []file.ProtoSetProviderOption{
 		file.ProtoSetProviderWithLogger(runner.logger),
 	}
@@ -115,7 +104,6 @@ func newRunner(workDirPath string, input io.Reader, output io.Writer, options ..
 
 func (r *runner) cloneForWorkDirPath(workDirPath string) *runner {
 	return &runner{
-		configProvider:   r.configProvider,
 		protoSetProvider: r.protoSetProvider,
 		workDirPath:      workDirPath,
 		input:            r.input,
@@ -841,6 +829,12 @@ func (r *runner) newCreateHandler(pkg string) create.Handler {
 	}
 	if r.develMode {
 		handlerOptions = append(handlerOptions, create.HandlerWithDevelMode())
+	}
+	if r.configData != "" {
+		handlerOptions = append(
+			handlerOptions,
+			create.HandlerWithConfigData(r.configData),
+		)
 	}
 	return create.NewHandler(handlerOptions...)
 }

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -665,9 +665,6 @@ func (r *runner) getPackageSet(args []string) (*extract.PackageSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(fileDescriptorSets) == 0 {
-		return nil, fmt.Errorf("no FileDescriptorSets returned")
-	}
 	reflectPackageSet, err := reflect.NewPackageSet(fileDescriptorSets...)
 	if err != nil {
 		return nil, err

--- a/internal/reflect/reflect.go
+++ b/internal/reflect/reflect.go
@@ -37,6 +37,9 @@ import (
 // The FileDescriptorSets can have FileDescriptorProtos with the same name, but
 // they must be equal.
 func NewPackageSet(fileDescriptorSets ...*descriptor.FileDescriptorSet) (*reflectv1.PackageSet, error) {
+	if len(fileDescriptorSets) == 0 {
+		return &reflectv1.PackageSet{}, nil
+	}
 	packageNameToFileNameToFileDescriptorProto, err := getPackageNameToFileNameToFileDescriptorProto(fileDescriptorSets)
 	if err != nil {
 		return nil, err

--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -58,7 +58,7 @@ func (c *configProvider) GetForDir(dirPath string) (Config, error) {
 		return Config{}, err
 	}
 	if filePath == "" {
-		return Config{}, nil
+		return getDefaultConfig(c.develMode, dirPath)
 	}
 	return c.Get(filePath)
 }
@@ -164,6 +164,10 @@ func get(develMode bool, filePath string) (Config, error) {
 		return Config{}, err
 	}
 	return externalConfigToConfig(develMode, externalConfig, filepath.Dir(filePath))
+}
+
+func getDefaultConfig(develMode bool, dirPath string) (Config, error) {
+	return externalConfigToConfig(develMode, ExternalConfig{}, dirPath)
 }
 
 func getExternalConfig(filePath string) (ExternalConfig, error) {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -323,7 +323,7 @@ type ConfigProvider interface {
 	// The directory must be an absolute path.
 	//
 	// If such a file is found, it is read as an ExternalConfig and converted to a Config.
-	// If no such file is found, Config{} is returned.
+	// If no such file is found, the default config is returned.
 	// If multiple files named by one of the ConfigFilenames are found in the same
 	// directory, error is returned.
 	GetForDir(dirPath string) (Config, error)
@@ -333,7 +333,7 @@ type ConfigProvider interface {
 	// The file must have either the extension .yaml or .json.
 	//
 	// If such a file is found, it is read as an ExternalConfig and converted to a Config.
-	// If no such file is found, Config{} is returned.
+	// If no such file is found, error is returned.
 	Get(filePath string) (Config, error)
 	// GetFilePathForDir tries to find a file named by one of the ConfigFilenames starting in the
 	// given directory, and going up a directory until hitting root.


### PR DESCRIPTION
This performs a pretty wide-ranging number of fixes to let `prototool` work when no Protobuf files are found. This was inspired by getting `prototool cache update` to work within a Docker build. Other fixes are performed as well.

Fixes:

- Always return a default configuration from `settings.ConfigProvider#GetForDir`. For backwards compatibility reasons, we need to have `IncludeWellKnownTypes` always set in a `settings.Config` object, so `settings.Config{}` is not sufficient. The updates below make sure we always have a valid config, falling back to making a default config in the current directory if none is found.
- Have `file.ProtoSetProvider.GetForDir` return a default `ProtoSet` with no files and a valid config if no Protobuf files are found.
- Handle no `descriptor.FileDescriptorSets` in the `extract` and `reflect` packages, and allow this to be passed from the `exec` package.
- Have `prototool create` handle the `--config-data` flag properly. This flag was installed but not properly handled due to `create` using the `settings` package in a way that no other package does.
- Delete the instantiation of a `settings.ConfigProvider` in `exec.Runner` as it was not used anymore.

There's a bigger refactor of the `settings` and `file` package we should do at some point, these packages have grown organically all the way back to the pre-0.1 inception of Prototool, but this is out of scope for what we need right now.

Added basic tests, and also verified that `prototool cache update, prototool compile, prototool lint, prototool format, prototool generate, prototool all, prototool inspect packages` work when there are no Protobuf files.