### PR TITLE
Test that message fields were not moved from outside oneof to inside oneof

### DIFF
--- a/internal/breaking/BUILD.bazel
+++ b/internal/breaking/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "check_message_fields_not_deleted.go",
         "check_message_fields_same_label.go",
         "check_message_fields_same_name.go",
+        "check_message_fields_same_oneof.go",
         "check_message_fields_same_type.go",
         "check_message_oneofs_fields_not_removed.go",
         "check_message_oneofs_not_deleted.go",

--- a/internal/breaking/breaking.go
+++ b/internal/breaking/breaking.go
@@ -70,7 +70,7 @@ var (
 		Checker{
 			ID:      "MESSAGE_FIELDS_SAME_ONEOF",
 			Purpose: "Checks that message fields that were not in a oneof are not now in a oneof.",
-			Check:   checkMessageFieldsSameName,
+			Check:   checkMessageFieldsSameOneof,
 		},
 		Checker{
 			ID:      "MESSAGE_FIELDS_SAME_TYPE",

--- a/internal/breaking/breaking.go
+++ b/internal/breaking/breaking.go
@@ -68,6 +68,11 @@ var (
 			Check:   checkMessageFieldsSameName,
 		},
 		Checker{
+			ID:      "MESSAGE_FIELDS_SAME_ONEOF",
+			Purpose: "Checks that message fields that were not in a oneof are not now in a oneof.",
+			Check:   checkMessageFieldsSameName,
+		},
+		Checker{
 			ID:      "MESSAGE_FIELDS_SAME_TYPE",
 			Purpose: "Checks that message fields have the same type.",
 			Check:   checkMessageFieldsSameType,

--- a/internal/breaking/breaking_test.go
+++ b/internal/breaking/breaking_test.go
@@ -105,6 +105,9 @@ func TestRunOne(t *testing.T) {
 		newServiceMethodsSameClientStreamingFailure("foo.v1.ThreeAPI", "ThreeThree", false),
 		newServiceMethodsSameServerStreamingFailure("foo.v1.ThreeAPI", "ThreeFour", true),
 		newServiceMethodsSameServerStreamingFailure("foo.v1.ThreeAPI", "ThreeFive", false),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven", 1, "test"),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven.NestedEleven", 1, "test"),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven.NestedEleven.NestedNestedEleven", 1, "test"),
 	)
 }
 
@@ -183,6 +186,9 @@ func TestRunOneIncludeBeta(t *testing.T) {
 		newServiceMethodsSameClientStreamingFailure("foo.v1.ThreeAPI", "ThreeThree", false),
 		newServiceMethodsSameServerStreamingFailure("foo.v1.ThreeAPI", "ThreeFour", true),
 		newServiceMethodsSameServerStreamingFailure("foo.v1.ThreeAPI", "ThreeFive", false),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven", 1, "test"),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven.NestedEleven", 1, "test"),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven.NestedEleven.NestedNestedEleven", 1, "test"),
 		newMessagesNotDeletedFailure("foo.v1beta1.One.NestedOne.NestedNestedTwo"),
 		newMessagesNotDeletedFailure("foo.v1beta1.One.NestedTwo"),
 		newMessagesNotDeletedFailure("foo.v1beta1.Two"),
@@ -327,6 +333,9 @@ func TestRunOneAllowBetaDeps(t *testing.T) {
 		newServiceMethodsSameClientStreamingFailure("foo.v1.ThreeAPI", "ThreeThree", false),
 		newServiceMethodsSameServerStreamingFailure("foo.v1.ThreeAPI", "ThreeFour", true),
 		newServiceMethodsSameServerStreamingFailure("foo.v1.ThreeAPI", "ThreeFive", false),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven", 1, "test"),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven.NestedEleven", 1, "test"),
+		newMessageFieldsSameOneofFailure("foo.v1.Eleven.NestedEleven.NestedNestedEleven", 1, "test"),
 	)
 }
 

--- a/internal/breaking/check_message_fields_same_oneof.go
+++ b/internal/breaking/check_message_fields_same_oneof.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package breaking
+
+import (
+	"github.com/uber/prototool/internal/extract"
+	"github.com/uber/prototool/internal/text"
+)
+
+func checkMessageFieldsSameOneof(addFailure func(*text.Failure), from *extract.PackageSet, to *extract.PackageSet) error {
+	return forEachMessageFieldPair(addFailure, from, to, checkMessageFieldsSameOneofMessageField)
+}
+
+func checkMessageFieldsSameOneofMessageField(addFailure func(*text.Failure), from *extract.MessageField, to *extract.MessageField) error {
+	fromOneof := from.MessageOneof()
+	toOneof := to.MessageOneof()
+	// checkMessageOneofsFieldsNotRemoved will check the reverse
+	if fromOneof == nil && toOneof != nil {
+		addFailure(newMessageFieldsSameOneofFailure(from.Message().FullyQualifiedName(), from.ProtoMessage().Number, toOneof.ProtoMessage().Name))
+	}
+	return nil
+}
+
+func newMessageFieldsSameOneofFailure(messageName string, fieldNumber int32, oneofName string) *text.Failure {
+	return newTextFailuref(`Message field "%d" on message %q moved from not in oneof to in oneof %q.`, fieldNumber, messageName, oneofName)
+}

--- a/internal/breaking/check_message_fields_same_oneof.go
+++ b/internal/breaking/check_message_fields_same_oneof.go
@@ -40,5 +40,5 @@ func checkMessageFieldsSameOneofMessageField(addFailure func(*text.Failure), fro
 }
 
 func newMessageFieldsSameOneofFailure(messageName string, fieldNumber int32, oneofName string) *text.Failure {
-	return newTextFailuref(`Message field "%d" on message %q moved from not in oneof to in oneof %q.`, fieldNumber, messageName, oneofName)
+	return newTextFailuref(`Message field "%d" on message %q moved from outside any oneof to inside the oneof %q.`, fieldNumber, messageName, oneofName)
 }

--- a/internal/breaking/testdata/one/from/foo/v1/foo.proto
+++ b/internal/breaking/testdata/one/from/foo/v1/foo.proto
@@ -232,3 +232,13 @@ message ThreeFourResponse {}
 message ThreeFiveRequest {}
 
 message ThreeFiveResponse {}
+
+message Eleven {
+  message NestedEleven {
+    message NestedNestedEleven {
+      int64 hello = 1;
+    }
+    int64 hello = 1;
+  }
+  int64 hello = 1;
+}

--- a/internal/breaking/testdata/one/to/foo/v1/foo.proto
+++ b/internal/breaking/testdata/one/to/foo/v1/foo.proto
@@ -198,3 +198,19 @@ message ThreeFourResponse {}
 message ThreeFiveRequest {}
 
 message ThreeFiveResponse {}
+
+message Eleven {
+  message NestedEleven {
+    message NestedNestedEleven {
+      oneof test {
+        int64 hello = 1;
+      }
+    }
+    oneof test {
+      int64 hello = 1;
+    }
+  }
+  oneof test {
+    int64 hello = 1;
+  }
+}


### PR DESCRIPTION
Re: #301.

Moving a message field from outside a oneof to inside a oneof is a source code breaking change, which we consider to be a breaking change.