### PR TITLE
fix docker readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ provided by `protoc` out of the box, however.
 
 If you want to have a consistent build environment for external plugins, we recommend creating a Docker image. We provide
 a basic Docker image at [hub.docker.com/r/uber/prototool](https://hub.docker.com/r/uber/prototool), defined in the [docker](docker)
-directory within this repository. See the [README.md][docker/README.md] for more details.
+directory within this repository. See the [docker/README.md](docker/README.md) for more details.
 
 ##### Lint/Format Choices
 


### PR DESCRIPTION
Super quick and easy, use () instead of [] in markdown link syntax