### PR TITLE
Install curl and git on Docker image

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -38,7 +38,7 @@ a GitHub issue and we will evaluate it.
 | [twirp] | 5.5.1 | protoc-gen-twirp<br>protoc-gen-twirp_python |
 | [yarpc] | 1.36.1 | protoc-gen-yarpc-go |
 
-The Well-Known Types are copied to `/usr/include`.
+The Well-Known Types are copied to `/usr/include`. The packages `bash`, `curl`, and `git` are also installed.
 
 ## Versioning
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ ENV PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc
 ENV PROTOTOOL_PROTOC_WKT_PATH=/usr/include
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
-RUN apk add --update --no-cache bash grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX}
+RUN apk add --update --no-cache bash curl git grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX}
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/include /usr/include
 


### PR DESCRIPTION
`git` is needed for `prototool break check`, and `curl` is needed on occasion and takes almost no space.