### PR TITLE
Allow google.protobuf.Timestamp field to be named time

### DIFF
--- a/internal/cmd/testdata/lint/wktsuffix/foo/foo.proto
+++ b/internal/cmd/testdata/lint/wktsuffix/foo/foo.proto
@@ -17,4 +17,6 @@ message Bar {
     google.protobuf.Timestamp three = 3;
     google.protobuf.Duration four = 4;
   }
+  // Make sure this is allowed.
+  google.protobuf.Timestamp time = 5;
 }

--- a/internal/lint/check_wkt_timestamp_suffix.go
+++ b/internal/lint/check_wkt_timestamp_suffix.go
@@ -62,7 +62,7 @@ func (v wktTimestampSuffixVisitor) VisitOneofField(field *proto.OneOfField) {
 }
 
 func (v wktTimestampSuffixVisitor) visitField(field *proto.Field) {
-	if field.Type == "google.protobuf.Timestamp" && !strings.HasSuffix(field.Name, "_time") {
-		v.AddFailuref(field.Position, `Field %q of type "google.protobuf.Timestamp" must end in "_time".`, field.Name)
+	if field.Type == "google.protobuf.Timestamp" && !(field.Name == "time" || strings.HasSuffix(field.Name, "_time")) {
+		v.AddFailuref(field.Position, `Field %q of type "google.protobuf.Timestamp" must be "time" or end in "_time".`, field.Name)
 	}
 }


### PR DESCRIPTION
This was an oversight - we meant to do this, but didn't actually adjust the code. This was already being done for `google.Protobuf.Duration`.