### PR TITLE
Glob matching for lint ignore files

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -7,6 +7,11 @@ def prototool_deps(**kwargs):
         importpath = "honnef.co/go/tools",
     )
     go_repository(
+        name = "com_github_bmatcuk_doublestar",
+        importpath = "github.com/bmatcuk/doublestar",
+        tag = "v1.1.1",
+    )
+    go_repository(
         name = "com_github_burntsushi_toml",
         importpath = "github.com/BurntSushi/toml",
         tag = "v0.3.1",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/uber/prototool
 
 require (
+	github.com/bmatcuk/doublestar v1.1.1
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/emicklei/proto v1.6.7
 	github.com/fullstorydev/grpcurl v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/bmatcuk/doublestar v1.1.1 h1:YroD6BJCZBYx06yYFEWvUuKVWQn3vLLQAVmDmvTSaiQ=
+github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=

--- a/internal/lint/BUILD.bazel
+++ b/internal/lint/BUILD.bazel
@@ -84,6 +84,7 @@ go_library(
         "//internal/strs:go_default_library",
         "//internal/text:go_default_library",
         "//internal/wkt:go_default_library",
+        "@com_github_bmatcuk_doublestar//:go_default_library",
         "@com_github_emicklei_proto//:go_default_library",
         "@com_github_gobuffalo_flect//:go_default_library",
         "@org_uber_go_zap//:go_default_library",

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/bmatcuk/doublestar"
 	"github.com/emicklei/proto"
 	"github.com/uber/prototool/internal/file"
 	"github.com/uber/prototool/internal/settings"
@@ -510,7 +511,12 @@ func shouldIgnore(linter Linter, descriptor *FileDescriptor, ignoreIDToFilePaths
 		return false, nil
 	}
 	for _, ignoreFilePath := range ignoreFilePaths {
-		if filePath == ignoreFilePath {
+		match, err := doublestar.PathMatch(ignoreFilePath, filePath)
+		if err != nil {
+			return false, err
+		}
+
+		if match {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Adds support for glob matching lint ignore files. The prototool config file becomes overly verbose when needing to explicitly list all files.

- Adds dep on https://github.com/bmatcuk/doublestar 
In our use case, pattern matching is most useful when you can recursively exclude directories. Go has a long standing issue for support https://github.com/golang/go/issues/11862, but it appears to be dragging.