### PR TITLE
 Add lint.file_header.content option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,24 @@ lint:
     is_commented: true
 ```
 
-The `path` option specifies the path to the file that contains the header data.
-The `is_commented` option specifies whether the header data is already commented, and if not, `// ` will be added before all non-empty lines,
-and `//` will be added before all empty lines. `is_commented` is optional and generally will not be set if the file is not commented, for
-example if `path` points to a text LICENSE file.
+Alternatively, directly specify the content:
 
-If `lint.file_header.path` is set, `prototool create`, `prototool format --fix`, and `prototool lint` will all take the file header into account.
+```yaml
+lint:
+  file_header:
+    content: |
+      //
+      // Acme, Inc. (c) 2019
+      //
+    is_commented: true
+```
+
+The `path` option specifies the path to the file that contains the header data. The `content` option specifies the content directly.
+Only one of these can be specified. The `is_commented` option specifies whether the header data is already commented, and if not,
+`// ` will be added before all non-empty lines, and `//` will be added before all empty lines. `is_commented` is optional and
+generally will not be set if the file is not commented, for example if `path` points to a text LICENSE file.
+
+If `lint.file_header.path` or `lint.file_header.content` is set, `prototool create`, `prototool format --fix`, and `prototool lint` will all take the file header into account.
 
 See [internal/cmd/testdata/lint](internal/cmd/testdata/lint) for additional examples of configurations, and run `prototool lint internal/cmd/testdata/lint/DIR` from a checkout of this repository to see example failures.
 

--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -71,18 +71,27 @@ lint:
     remove:
       - ENUM_NAMES_CAMEL_CASE
 
-  # The path to the file header for all Protobuf files.
-  # If this is set and the FILE_HEADER linter is turned on, files will
-  # be checked to begin with the contents of this file, and format --fix
+  # The path to the file header or the file header content for all Protobuf files.
+  # If either path or content is set and the FILE_HEADER linter is turned on,
+  # files will be checked to begin with the given header, and format --fix
   # will place this header before the syntax declaration. Note that
   # format --fix will delete anything before the syntax declaration
   # if this is set.
+  #
+  # Set path to use a file's contents for the header. Path must be relative.
+  # Set content to directly specify the header.
+  # **Both path and content cannot be set at the same time. They are only done
+  # so here for example purposes.**
   #
   # If is_commented is set, this file is assumed to already have comments
   # and will be added directly. If is_commented is not set, "// " will be
   # added before every line.
   file_header:
     path: path/to/protobuf_file_header.txt
+    content: |
+      //
+      // Acme, Inc. (c) 2019
+      //
     is_commented: true
 
 # Code generation directives.

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -101,18 +101,27 @@ protoc:
 {{.V}}    remove:
 {{.V}}      - ENUM_NAMES_CAMEL_CASE
 
-  # The path to the file header for all Protobuf files.
-  # If this is set and the FILE_HEADER linter is turned on, files will
-  # be checked to begin with the contents of this file, and format --fix
+  # The path to the file header or the file header content for all Protobuf files.
+  # If either path or content is set and the FILE_HEADER linter is turned on,
+  # files will be checked to begin with the given header, and format --fix
   # will place this header before the syntax declaration. Note that
   # format --fix will delete anything before the syntax declaration
   # if this is set.
+  #
+  # Set path to use a file's contents for the header. Path must be relative.
+  # Set content to directly specify the header.
+  # **Both path and content cannot be set at the same time. They are only done
+  # so here for example purposes.**
   #
   # If is_commented is set, this file is assumed to already have comments
   # and will be added directly. If is_commented is not set, "// " will be
   # added before every line.
 {{.V}}  file_header:
 {{.V}}    path: path/to/protobuf_file_header.txt
+{{.V}}    content: |
+{{.V}}      //
+{{.V}}      // Acme, Inc. (c) 2019
+{{.V}}      //
 {{.V}}    is_commented: true
 
 # Code generation directives.

--- a/internal/cmd/testdata/create/version2two/protobuf_file_header.txt
+++ b/internal/cmd/testdata/create/version2two/protobuf_file_header.txt
@@ -1,3 +1,0 @@
-// this
-  // is a
-    // header

--- a/internal/cmd/testdata/create/version2two/prototool.yaml
+++ b/internal/cmd/testdata/create/version2two/prototool.yaml
@@ -1,7 +1,10 @@
 lint:
   group: uber2
   file_header:
-    path: protobuf_file_header.txt
+    content: |
+      // this
+        // is a
+          // header
     is_commented: true
 create:
   packages:

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -299,6 +299,7 @@ type ExternalConfig struct {
 		}
 		FileHeader struct {
 			Path        string `json:"path,omitempty" yaml:"path,omitempty"`
+			Content     string `json:"content,omitempty" yaml:"content,omitempty"`
 			IsCommented bool   `json:"is_commented,omitempty" yaml:"is_commented,omitempty"`
 		} `json:"file_header,omitempty" yaml:"file_header,omitempty"`
 		// devel-mode only


### PR DESCRIPTION
This is a quick addition - this has been on my mind for a while. Instead of needing a separate file for the file header, this allows one to specify it directly in the configuration file.