### PR TITLE
Add concept of protoc.FileDescriptorSet with extra information and validation

### DIFF
--- a/internal/breaking/breaking_test.go
+++ b/internal/breaking/breaking_test.go
@@ -364,7 +364,7 @@ func getPackageSets(subDirPath string) (*extract.PackageSet, *extract.PackageSet
 	if err != nil {
 		return nil, nil, err
 	}
-	fromReflectPackageSet, err := reflect.NewPackageSet(fromFileDescriptorSets...)
+	fromReflectPackageSet, err := reflect.NewPackageSet(fromFileDescriptorSets.Unwrap()...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -376,7 +376,7 @@ func getPackageSets(subDirPath string) (*extract.PackageSet, *extract.PackageSet
 	if err != nil {
 		return nil, nil, err
 	}
-	toReflectPackageSet, err := reflect.NewPackageSet(toFileDescriptorSets...)
+	toReflectPackageSet, err := reflect.NewPackageSet(toFileDescriptorSets.Unwrap()...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/exec/BUILD.bazel
+++ b/internal/exec/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//internal/settings:go_default_library",
         "//internal/text:go_default_library",
         "//internal/vars:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -37,7 +37,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/uber/prototool/internal/breaking"
 	"github.com/uber/prototool/internal/cfginit"
 	"github.com/uber/prototool/internal/create"
@@ -248,7 +247,7 @@ func (r *runner) Gen(args []string, dryRun bool) error {
 	return err
 }
 
-func (r *runner) compile(doGen, doFileDescriptorSet, dryRun bool, meta *meta) ([]*descriptor.FileDescriptorSet, error) {
+func (r *runner) compile(doGen, doFileDescriptorSet, dryRun bool, meta *meta) (protoc.FileDescriptorSets, error) {
 	if dryRun {
 		return nil, r.printCommands(doGen, meta.ProtoSet)
 	}
@@ -562,7 +561,7 @@ func (r *runner) GRPC(args, headers []string, address, method, data, callTimeout
 		parsedCallTimeout,
 		parsedConnectTimeout,
 		parsedKeepaliveTime,
-	).Invoke(fileDescriptorSets, address, method, reader, r.output)
+	).Invoke(fileDescriptorSets.Unwrap(), address, method, reader, r.output)
 }
 
 func (r *runner) InspectPackages(args []string) error {
@@ -665,7 +664,7 @@ func (r *runner) getPackageSet(args []string) (*extract.PackageSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	reflectPackageSet, err := reflect.NewPackageSet(fileDescriptorSets...)
+	reflectPackageSet, err := reflect.NewPackageSet(fileDescriptorSets.Unwrap()...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extract/extract_test.go
+++ b/internal/extract/extract_test.go
@@ -48,7 +48,7 @@ func getPackageSet(subDirPath string) (*PackageSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	reflectPackageSet, err := reflect.NewPackageSet(fileDescriptorSets...)
+	reflectPackageSet, err := reflect.NewPackageSet(fileDescriptorSets.Unwrap()...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -41,13 +41,17 @@ type ProtoSet struct {
 	// Must be cleaned.
 	WorkDirPath string
 	// The given directory path.
-	// This will be the same as WorkDirPath if files were given.
 	// Must be absolute.
 	// Must be cleaned.
 	DirPath string
 	// The directory path to slice of .proto files.
 	// All paths must be absolute.
+	// All paths must reside within DirPath.
 	// Must be cleaned.
+	// The directory paths will always reside within DirPath,
+	// that is filepath.Rel(ProtoSetDirPath, DirPath) will never return
+	// error and always return a non-empty string. Note the string could be ".".
+	// The ProtoFiles will always be in the directory specified by the key.
 	DirPathToFiles map[string][]*ProtoFile
 	// The associated Config.
 	// Must be valid.

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -119,10 +119,8 @@ func NewDownloader(config settings.Config, options ...DownloaderOption) (Downloa
 type FileDescriptorSet struct {
 	*descriptor.FileDescriptorSet
 	// The containing ProtoSet.
-	// Absolute.
 	ProtoSet *file.ProtoSet
-	// The directory path for the built files in this FileDescriptorSet.
-	// Absolute.
+	// The absolute directory path for the built files in this FileDescriptorSet.
 	// This directory path will always reside within the ProtoSetDirPath,
 	// that is filepath.Rel(ProtoSetDirPath, DirPath) will never return
 	// error and always return a non-empty string. Note the string could be ".".

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -113,6 +113,43 @@ func NewDownloader(config settings.Config, options ...DownloaderOption) (Downloa
 	return newDownloader(config, options...)
 }
 
+// FileDescriptorSet is a wrapper for descriptor.FileDescriptorSet.
+//
+// This will contain both the files specified by ProtoFiles and all imports.
+type FileDescriptorSet struct {
+	*descriptor.FileDescriptorSet
+	// The containing ProtoSet.
+	// Absolute.
+	ProtoSet *file.ProtoSet
+	// The directory path for the built files in this FileDescriptorSet.
+	// Absolute.
+	// This directory path will always reside within the ProtoSetDirPath,
+	// that is filepath.Rel(ProtoSetDirPath, DirPath) will never return
+	// error and always return a non-empty string. Note the string could be ".".
+	DirPath string
+	// The ProtoFiles for the built files in this FileDescriptorSet.
+	// The directory of Path will always be equal to DirPath.
+	ProtoFiles []*file.ProtoFile
+}
+
+// FileDescriptorSets are a slice of FileDescriptorSet objects.
+type FileDescriptorSets []*FileDescriptorSet
+
+// Unwrap converts f to []*descriptor.FileDescriptorSet.
+//
+// Used for backwards compatibility with existing code that is based on
+// descriptor.FileDescriptorSets.
+func (f FileDescriptorSets) Unwrap() []*descriptor.FileDescriptorSet {
+	if f == nil {
+		return nil
+	}
+	d := make([]*descriptor.FileDescriptorSet, len(f))
+	for i, e := range f {
+		d[i] = e.FileDescriptorSet
+	}
+	return d
+}
+
 // CompileResult is the result of a compile
 type CompileResult struct {
 	// The failures from all calls.
@@ -121,7 +158,7 @@ type CompileResult struct {
 	//
 	// Will only be set if the CompilerWithFileDescriptorSet
 	// option is used.
-	FileDescriptorSets []*descriptor.FileDescriptorSet
+	FileDescriptorSets []*FileDescriptorSet
 }
 
 // Compiler compiles protobuf files.

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -158,7 +158,7 @@ type CompileResult struct {
 	//
 	// Will only be set if the CompilerWithFileDescriptorSet
 	// option is used.
-	FileDescriptorSets []*FileDescriptorSet
+	FileDescriptorSets FileDescriptorSets
 }
 
 // Compiler compiles protobuf files.

--- a/internal/reflect/reflect_test.go
+++ b/internal/reflect/reflect_test.go
@@ -505,7 +505,7 @@ func TestOne(t *testing.T) {
 
 func testNewPackageSet(t *testing.T, subDirPath string, packageSetJSON string) {
 	fileDescriptorSets := ptesting.RequireGetFileDescriptorSets(t, ".", "testdata/"+subDirPath)
-	packageSet, err := NewPackageSet(fileDescriptorSets...)
+	packageSet, err := NewPackageSet(fileDescriptorSets.Unwrap()...)
 	require.NoError(t, err)
 	// It's much easier to edit JSON than the actual Golang structs all the type
 	expectedPackageSet := requireUnmarshalPackageSet(t, packageSetJSON)

--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -37,7 +37,7 @@ import (
 var jsonMarshaler = &jsonpb.Marshaler{Indent: "  "}
 
 // RequireGetFileDescriptorSets calls GetDescriptorFileSets with require calls.
-func RequireGetFileDescriptorSets(t *testing.T, workDirPath string, dirPath string) []*descriptor.FileDescriptorSet {
+func RequireGetFileDescriptorSets(t *testing.T, workDirPath string, dirPath string) protoc.FileDescriptorSets {
 	fileDescriptorSets, err := GetFileDescriptorSets(workDirPath, dirPath)
 	require.NoError(t, err)
 	require.NotEmpty(t, fileDescriptorSets)
@@ -45,7 +45,7 @@ func RequireGetFileDescriptorSets(t *testing.T, workDirPath string, dirPath stri
 }
 
 // GetFileDescriptorSets gets the FileDescriptorSets that result from compiling the given dirPath.
-func GetFileDescriptorSets(workDirPath string, dirPath string) ([]*descriptor.FileDescriptorSet, error) {
+func GetFileDescriptorSets(workDirPath string, dirPath string) (protoc.FileDescriptorSets, error) {
 	protoSet, err := file.NewProtoSetProvider().GetForDir(workDirPath, dirPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds the concept of `protoc.FileDescriptorSet`, which wraps a `descriptor.FileDescriptorSet` with information on what was used to create the `FileDescriptorSet`. This also does some validation on directory paths from `file.ProtoSetProvider`. This is going to be required for some upcoming work.

This diff attempts to make as few changes as possible to the rest of the code by providing unwrapping functionality back to `[]*descriptor.FileDescriptorSet`.