### PR TITLE
 Split format.printer out to separate package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,12 @@ golden: install
 	for file in $(shell find internal/cmd/testdata/format-fix -name '*.proto'); do \
 		prototool format --fix $${file} > $${file}.golden || true; \
 	done
+	for file in $(shell find internal/cmd/testdata/format-fix-v2 -name '*.proto.golden'); do \
+		rm -f $${file}; \
+	done
+	for file in $(shell find internal/cmd/testdata/format-fix-v2 -name '*.proto'); do \
+		prototool format --fix $${file} > $${file}.golden || true; \
+	done
 
 .PHONY: example
 example: install

--- a/internal/buf/BUILD.bazel
+++ b/internal/buf/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["buf.go"],
+    importpath = "github.com/uber/prototool/internal/buf",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["buf_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+)

--- a/internal/buf/buf_test.go
+++ b/internal/buf/buf_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package buf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasic(t *testing.T) {
+	testPrinter(
+		t,
+		"onetwothree",
+		func(p *Printer) {
+			p.P(`one`, `two`, `three`)
+		},
+	)
+	testPrinter(
+		t,
+		"one two three",
+		func(p *Printer) {
+			p.P(`one `, `two `, `three`)
+		},
+	)
+	testPrinter(
+		t,
+		"one\n  twothree\n   four\n\nfive",
+		func(p *Printer) {
+			// purposefully adding space
+			p.P(`one `)
+			p.In()
+			p.P(`two`, `three`)
+			// purposefully adding space
+			p.P(` four`)
+			p.Out()
+			p.P()
+			p.P(`five`)
+			p.P()
+		},
+	)
+}
+
+func testPrinter(t *testing.T, expected string, f func(*Printer)) {
+	printer := NewPrinter("  ")
+	f(printer)
+	assert.Equal(t, expected, printer.String())
+}

--- a/internal/buf/buf_test.go
+++ b/internal/buf/buf_test.go
@@ -29,21 +29,21 @@ import (
 func TestBasic(t *testing.T) {
 	testPrinter(
 		t,
-		"onetwothree",
+		"onetwothree\n",
 		func(p *Printer) {
 			p.P(`one`, `two`, `three`)
 		},
 	)
 	testPrinter(
 		t,
-		"one two three",
+		"one two three\n",
 		func(p *Printer) {
 			p.P(`one `, `two `, `three`)
 		},
 	)
 	testPrinter(
 		t,
-		"one\n  twothree\n   four\n\nfive",
+		"one\n  twothree\n   four\n\nfive\n\n",
 		func(p *Printer) {
 			// purposefully adding space
 			p.P(`one `)

--- a/internal/cmd/testdata/format-fix-v2/foo.proto.golden
+++ b/internal/cmd/testdata/format-fix-v2/foo.proto.golden
@@ -32,7 +32,7 @@ message Baz {
 
   // another unassociated comment
 
-  google.protobuf.Timestamp timestamp = 3; // inline c-style comment 
+  google.protobuf.Timestamp timestamp = 3; // inline c-style comment
   map<string, int64> m = 11;
   oneof test_oneof {
     int64 foo1 = 8;

--- a/internal/cmd/testdata/format-fix/foo.proto.golden
+++ b/internal/cmd/testdata/format-fix/foo.proto.golden
@@ -29,7 +29,7 @@ message Baz {
 
   // another unassociated comment
 
-  google.protobuf.Timestamp timestamp = 3; // inline c-style comment 
+  google.protobuf.Timestamp timestamp = 3; // inline c-style comment
   map<string, int64> m = 11;
   oneof test_oneof {
     int64 foo1 = 8;

--- a/internal/cmd/testdata/format/proto3/foo/foo.proto.golden
+++ b/internal/cmd/testdata/format/proto3/foo/foo.proto.golden
@@ -48,7 +48,7 @@ message Baz {
 
   // dep comment
   bar.Dep dep = 2;
-  google.protobuf.Timestamp timestamp = 3; // inline c-style comment 
+  google.protobuf.Timestamp timestamp = 3; // inline c-style comment
   int64 woot = 5 [(bar.field_option) = true];
   // comment17
   int64 woot2 = 6 [

--- a/internal/format/BUILD.bazel
+++ b/internal/format/BUILD.bazel
@@ -7,12 +7,12 @@ go_library(
         "first_pass_visitor.go",
         "format.go",
         "main_visitor.go",
-        "printer.go",
         "transformer.go",
     ],
     importpath = "github.com/uber/prototool/internal/format",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/buf:go_default_library",
         "//internal/protostrs:go_default_library",
         "//internal/text:go_default_library",
         "@com_github_emicklei_proto//:go_default_library",

--- a/internal/format/base_visitor.go
+++ b/internal/format/base_visitor.go
@@ -27,17 +27,18 @@ import (
 	"text/scanner"
 
 	"github.com/emicklei/proto"
+	"github.com/uber/prototool/internal/buf"
 	"github.com/uber/prototool/internal/text"
 )
 
 type baseVisitor struct {
-	*printer
+	*buf.Printer
 
 	Failures []*text.Failure
 }
 
 func newBaseVisitor() *baseVisitor {
-	return &baseVisitor{printer: newPrinter()}
+	return &baseVisitor{Printer: buf.NewPrinter("  ")}
 }
 
 func (v *baseVisitor) AddFailure(position scanner.Position, format string, args ...interface{}) {


### PR DESCRIPTION
This makes it separately tested and usable by other packages. This also makes the `Printer` trim extra whitespace, which results in a small (cleanup) diff to format behavior.