### PR TITLE
Allow lint.ignores.files to specify directories as well as files

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -1,4 +1,6 @@
 # Paths to exclude when searching for Protobuf files.
+# These can either be file or directory names.
+# If there is a directory name, that directory and all sub-directories will be excluded.
 excludes:
   - path/to/a
   - path/to/b/file.proto
@@ -44,6 +46,8 @@ lint:
   group: uber2
 
   # Linter files to ignore.
+  # These can either be file or directory names.
+  # If there is a directory name, that directory and all sub-directories will be ignored.
   ignores:
     - id: RPC_NAMES_CAMEL_CASE
       files:
@@ -51,7 +55,7 @@ lint:
         - path/to/bar.proto
     - id: SYNTAX_PROTO3
       files:
-        - path/to/foo.proto
+        - path/to/dir
 
   # Linter rules.
   # Run prototool lint --list-all-linters to see all available linters.

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -29,6 +29,8 @@ import (
 )
 
 var tmpl = template.Must(template.New("tmpl").Parse(`# Paths to exclude when searching for Protobuf files.
+# These can either be file or directory names.
+# If there is a directory name, that directory and all sub-directories will be excluded.
 {{.V}}excludes:
 {{.V}}  - path/to/a
 {{.V}}  - path/to/b/file.proto
@@ -74,6 +76,8 @@ protoc:
 {{.V}}  group: uber2
 
   # Linter files to ignore.
+  # These can either be file or directory names.
+  # If there is a directory name, that directory and all sub-directories will be ignored.
 {{.V}}  ignores:
 {{.V}}    - id: RPC_NAMES_CAMEL_CASE
 {{.V}}      files:
@@ -81,7 +85,7 @@ protoc:
 {{.V}}        - path/to/bar.proto
 {{.V}}    - id: SYNTAX_PROTO3
 {{.V}}      files:
-{{.V}}        - path/to/foo.proto
+{{.V}}        - path/to/dir
 
   # Linter rules.
   # Run prototool lint --list-all-linters to see all available linters.

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -581,6 +581,19 @@ func TestLint(t *testing.T) {
 	assertDoLintFile(
 		t,
 		false,
+		`14:3:MESSAGE_FIELDS_NOT_FLOATS`,
+		"testdata/lint/ignoredir/foo/v1/foo.proto",
+	)
+	assertDoLintFile(
+		t,
+		true,
+		``,
+		"testdata/lint/ignoredir/bar/v1/bar.proto",
+	)
+
+	assertDoLintFile(
+		t,
+		false,
 		`23:1:REQUEST_RESPONSE_TYPES_ONLY_IN_FILE
 		30:1:REQUEST_RESPONSE_TYPES_ONLY_IN_FILE`,
 		"testdata/lint/onlyinfile/foo/v1/hello_api.proto",

--- a/internal/cmd/testdata/lint/ignoredir/bar/v1/bar.proto
+++ b/internal/cmd/testdata/lint/ignoredir/bar/v1/bar.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package bar.v1;
+
+option csharp_namespace = "Bar.V1";
+option go_package = "barv1";
+option java_multiple_files = true;
+option java_outer_classname = "BarProto";
+option java_package = "com.bar.v1";
+option objc_class_prefix = "BXX";
+option php_namespace = "Bar\\V1";
+
+message Bar {
+  float one = 1;
+}

--- a/internal/cmd/testdata/lint/ignoredir/foo/v1/foo.proto
+++ b/internal/cmd/testdata/lint/ignoredir/foo/v1/foo.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package foo.v1;
+
+option csharp_namespace = "Foo.V1";
+option go_package = "foov1";
+option java_multiple_files = true;
+option java_outer_classname = "FooProto";
+option java_package = "com.foo.v1";
+option objc_class_prefix = "FXX";
+option php_namespace = "Foo\\V1";
+
+message One {
+  float one = 1;
+}

--- a/internal/cmd/testdata/lint/ignoredir/prototool.yaml
+++ b/internal/cmd/testdata/lint/ignoredir/prototool.yaml
@@ -1,0 +1,14 @@
+lint:
+  group: uber2
+  rules:
+    remove:
+      - ENUMS_HAVE_SENTENCE_COMMENTS
+      - MESSAGES_HAVE_SENTENCE_COMMENTS_EXCEPT_REQUEST_RESPONSE_TYPES
+      - RPCS_HAVE_SENTENCE_COMMENTS
+      - SERVICES_HAVE_SENTENCE_COMMENTS
+  ignores:
+    - id: MESSAGE_FIELDS_NOT_FLOATS
+      files:
+        - bar/v1
+        - foo/v11
+

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -32,6 +32,8 @@ import (
 // DefaultWalkTimeout is the default walk timeout.
 const DefaultWalkTimeout time.Duration = 3 * time.Second
 
+var rootDirPath = filepath.Dir(string(filepath.Separator))
+
 // ProtoSet represents a set of .proto files and an associated config.
 //
 // ProtoSets will be validated if returned from this package.
@@ -150,4 +152,20 @@ func CheckAbs(path string) error {
 		return fmt.Errorf("expected absolute path but was %s", path)
 	}
 	return nil
+}
+
+// IsExcluded determines whether the given filePath should be excluded.
+//
+// absConfigDirPath represents the absolute path to the configuration file.
+// This is used to determine when we should stop checking for excludes.
+func IsExcluded(absFilePath string, absConfigDirPath string, absExcludePaths ...string) bool {
+	for _, absExcludePath := range absExcludePaths {
+		for curFilePath := absFilePath; curFilePath != absConfigDirPath && curFilePath != rootDirPath; curFilePath = filepath.Dir(curFilePath) {
+			if curFilePath == absExcludePath {
+				return true
+			}
+		}
+	}
+	return false
+
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -84,3 +84,20 @@ func TestCheckAbs(t *testing.T) {
 		assert.EqualError(t, CheckAbs("path/to/foo"), "expected absolute path but was path/to/foo")
 	})
 }
+
+func TestIsExcluded(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	testIsExcluded(t, true, "/foo/bar", "/", "/foo")
+	testIsExcluded(t, true, "/foo", "/", "/foo")
+	testIsExcluded(t, false, filepath.Join(wd, "foo"), wd, filepath.Join(wd, "fooo"))
+	testIsExcluded(t, true, filepath.Join(wd, "foo/bar"), wd, filepath.Join(wd, "foo"))
+	testIsExcluded(t, false, filepath.Join(wd, "foo/bar"), wd, filepath.Join(wd, "bar"))
+	testIsExcluded(t, true, filepath.Join(wd, "foo.proto"), wd, filepath.Join(wd, "foo.proto"))
+	testIsExcluded(t, false, filepath.Join(wd, "bar"), wd, filepath.Join(wd, "bar/foo.proto"))
+	testIsExcluded(t, true, filepath.Join(wd, "bar/baz/foo.proto"), wd, filepath.Join(wd, "bar"))
+}
+
+func testIsExcluded(t *testing.T, expected bool, absFilePath string, absConfigDirPath string, absExcludePaths ...string) {
+	assert.Equal(t, expected, IsExcluded(absFilePath, absConfigDirPath, absExcludePaths...))
+}

--- a/internal/file/proto_set_provider_test.go
+++ b/internal/file/proto_set_provider_test.go
@@ -442,57 +442,6 @@ func TestProtoSetProviderGetForDirConfigData(t *testing.T) {
 	)
 }
 
-func TestIsExcluded(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-
-	tests := []struct {
-		desc     string
-		filePath string
-		stopPath string
-		excludes map[string]struct{}
-		excluded bool
-	}{
-		{
-			desc:     "Nothing excluded",
-			filePath: cwd,
-			excluded: false,
-		},
-		{
-			desc:     "String prefix of excluded dir is not excluded",
-			filePath: filepath.Join(cwd, "foo"),
-			stopPath: cwd,
-			excludes: map[string]struct{}{filepath.Join(cwd, "fooo"): struct{}{}},
-			excluded: false,
-		},
-		{
-			desc:     "Not excluded, terminates without stopPath",
-			filePath: filepath.Join(cwd, "foo"),
-			excludes: map[string]struct{}{filepath.Join(cwd, "bar"): struct{}{}},
-			excluded: false,
-		},
-		{
-			desc:     "Directory is exluded",
-			filePath: filepath.Join(cwd, "foo/bar"),
-			stopPath: cwd,
-			excludes: map[string]struct{}{filepath.Join(cwd, "foo"): struct{}{}},
-			excluded: true,
-		},
-		{
-			desc:     "File is exluded",
-			filePath: filepath.Join(cwd, "foo.proto"),
-			stopPath: cwd,
-			excludes: map[string]struct{}{filepath.Join(cwd, "foo.proto"): struct{}{}},
-			excluded: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			assert.Equal(t, tt.excluded, isExcluded(tt.filePath, tt.stopPath, tt.excludes))
-		})
-	}
-}
-
 func newTestProtoSetProvider(t *testing.T) *protoSetProvider {
 	return newProtoSetProvider(ProtoSetProviderWithLogger(newTestLogger(t)))
 }

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -509,12 +509,7 @@ func shouldIgnore(linter Linter, descriptor *FileDescriptor, ignoreIDToFilePaths
 	if !ok {
 		return false, nil
 	}
-	for _, ignoreFilePath := range ignoreFilePaths {
-		if filePath == ignoreFilePath {
-			return true, nil
-		}
-	}
-	return false, nil
+	return file.IsExcluded(filePath, descriptor.ProtoSet.Config.DirPath, ignoreFilePaths...), nil
 }
 
 func checkLintID(lintID string) error {


### PR DESCRIPTION
Fixes #340.

I decided against adding a new field `dirs` as it adds confusion IMO, and the below just matches `excludes`, which makes just as much sense. This allows you to specify either a file or directory for `lint.ignores.files`, which was a feature request.