### PR TITLE
Added 'regexp' plugin option

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -134,6 +134,12 @@ generate:
       # The Mfile=package flags are automatically set.
       # ** Otherwise, generally do not set this unless you know what you are doing. **
       flags: plugins=grpc
+      # Regular expression pattern.
+      # If specified, .proto absolute path should match the pattern,
+      # otherwise plugin is not applied.
+      # Multiple plugins with the same name and different match patterns
+      # and configurations can be specified.
+      regexp: .
 
       # The path to output generated files to.
       # If the directory does not exist, it will be created when running generation.

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -164,6 +164,12 @@ protoc:
       # The Mfile=package flags are automatically set.
       # ** Otherwise, generally do not set this unless you know what you are doing. **
 {{.V}}      flags: plugins=grpc
+      # Regular expression pattern.
+      # If specified, .proto absolute path should match the pattern,
+      # otherwise plugin is not applied.
+      # Multiple plugins with the same name and different match patterns
+      # and configurations can be specified.
+{{.V}}      regexp: .
 
       # The path to output generated files to.
       # If the directory does not exist, it will be created when running generation.

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -444,6 +444,9 @@ func (c *compiler) getPluginFlagSets(protoSet *file.ProtoSet, dirPath string) ([
 	}
 	pluginFlagSets := make([][]string, 0, len(protoSet.Config.Gen.Plugins))
 	for _, genPlugin := range protoSet.Config.Gen.Plugins {
+		if genPlugin.Regexp != nil && !genPlugin.Regexp.MatchString(dirPath) {
+			continue
+		}
 		pluginFlagSet, err := getPluginFlagSet(protoSet, dirPath, genPlugin)
 		if err != nil {
 			return nil, err

--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -256,6 +257,13 @@ func externalConfigToConfig(develMode bool, e ExternalConfig, dirPath string) (C
 				return Config{}, fmt.Errorf("include_source_info is only valid for the descriptor_set plugin but set on %q", plugin.Name)
 			}
 		}
+		var re *regexp.Regexp
+		if plugin.Regexp != "" {
+			re, err = regexp.Compile(plugin.Regexp)
+			if err != nil {
+				return Config{}, fmt.Errorf("failed to compile regexp for plugin %q: %v", plugin.Name, err)
+			}
+		}
 		genPlugins[i] = GenPlugin{
 			Name:              plugin.Name,
 			GetPath:           getPluginPathFunc(plugin.Path),
@@ -264,6 +272,7 @@ func externalConfigToConfig(develMode bool, e ExternalConfig, dirPath string) (C
 			FileSuffix:        plugin.FileSuffix,
 			IncludeImports:    plugin.IncludeImports,
 			IncludeSourceInfo: plugin.IncludeSourceInfo,
+			Regexp:            re,
 			OutputPath: OutputPath{
 				RelPath: relPath,
 				AbsPath: absPath,

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -22,6 +22,7 @@ package settings
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -254,6 +255,9 @@ type GenPlugin struct {
 	// The path to output to.
 	// Must be relative in a config file.
 	OutputPath OutputPath
+	// Input path regular expression pattern.
+	// Limits plugin use to paths matching specified pattern.
+	Regexp *regexp.Regexp
 	// If set, the output path will be set to "$OUTPUT_PATH/$(basename $OUTPUT_PATH).$FILE_SUFFIX"
 	// Used for e.g. JAR generation for java or descriptor_set file name.
 	FileSuffix string
@@ -324,6 +328,7 @@ type ExternalConfig struct {
 			Output            string `json:"output,omitempty" yaml:"output,omitempty"`
 			Path              string `json:"path,omitempty" yaml:"path,omitempty"`
 			FileSuffix        string `json:"file_suffix,omitempty" yaml:"file_suffix,omitempty"`
+			Regexp            string `json:"regexp,omitempty" yaml:"regexp,omitempty"`
 			IncludeImports    bool   `json:"include_imports,omitempty" yaml:"include_imports,omitempty"`
 			IncludeSourceInfo bool   `json:"include_source_info,omitempty" yaml:"include_source_info,omitempty"`
 		} `json:"plugins,omitempty" yaml:"plugins,omitempty"`


### PR DESCRIPTION
Hi there! First of all, thanks for immensely useful tool, really simplifies protobuf workflow. The only thing I missed is an ability to selectively apply different plugins to different directories with .proto's. E.g. I'd like to generate swagger files for a small portion of services, not all of them. So here we are: new option for a plugin, "regexp". If specified, only protosets whose paths are matched are processed by the plugin. As an added bonus, it is possible to have different records in plugins' section with the same name that match different portions of source tree.

Best regards,
A.