### PR TITLE
Add TLS support for `prototool grpc` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,31 @@ $ cat input.json | prototool grpc example \
 }
 ```
 
+### SSL/TLS Connections
+
+To enable SSL/TLS connections to the server, use the `--tls` command line flag. 
+If not specified all the following flags will be ignored.
+
+By default host validation is enabled. To disable, pass the `--insecure` command line flag.
+
+To use a custom certificate authority, pass the `--cacert` command line flag to the path of the file in pem format.
+
+To use a custom key and certificate, pass the `--key` and `--cert` command line flag to the path of the files in pem format.
+
+To use a custom server name for validation, pass `--server-name` command line flag.
+
+```bash
+$ prototool grpc example \  
+  --data '{"value":"hello"}'
+  --address foo.bar.com:443
+  --method foo.ExcitedService/ExclamationBidiStream
+  --tls
+  --cacert /path/to/cacert/file.pem
+  --cert /path/to/cert/file.pem
+  --key /path/to/key/file.pem
+  --server-name foo.bar.com
+```
+
 ## Tips and Tricks
 
 Prototool is meant to help enforce a consistent development style for Protobuf, and as such you should follow some basic rules:

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,12 @@ import (
 
 type flags struct {
 	address        string
+	tls            bool
+	insecure       bool
+	cacert         string
+	cert           string
+	key            string
+	serverName     string
 	cachePath      string
 	callTimeout    string
 	configData     string
@@ -161,3 +167,28 @@ func (f *flags) bindUncomment(flagSet *pflag.FlagSet) {
 func (f *flags) bindFix(flagSet *pflag.FlagSet) {
 	flagSet.BoolVarP(&f.fix, "fix", "f", false, "Fix the file according to the Style Guide.")
 }
+
+func (f *flags) bindTLS(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.tls, "tls", false, "Enable SSL/TLS connection to remote host")
+}
+
+func (f *flags) bindInsecure(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.insecure, "insecure", false, "Disable host certificate validation for TLS connections. Ignored if --tls is not specified.")
+}
+
+func (f *flags) bindCacert(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.cacert, "cacert", "", "File containing trusted root certificates for verifying the server. Ignored if --tls is not specified.")
+}
+
+func (f *flags) bindCert(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.cert, "cert", "", "File containing client certificate (public key), to present to the server. Ignored if --tls is not specified. Must also provide the --key.")
+}
+
+func (f *flags) bindKey(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.key, "key", "", "File containing client private key, to present to the server. Ignored if --tls is not specified. Must also provide the --cert option.")
+}
+
+func (f *flags) bindSeverName(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.serverName, "server-name", "", "Override server name when validating TLS certificate. Ignored if --tls is not specified.")
+}
+

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -188,7 +188,7 @@ func (f *flags) bindKey(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.key, "key", "", "File containing client private key, to present to the server. Ignored if --tls is not specified. Must also provide the --cert option.")
 }
 
-func (f *flags) bindSeverName(flagSet *pflag.FlagSet) {
+func (f *flags) bindServerName(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.serverName, "server-name", "", "Override server name when validating TLS certificate. Ignored if --tls is not specified.")
 }
 

--- a/internal/cmd/gen-prototool-bash-completion/main.go
+++ b/internal/cmd/gen-prototool-bash-completion/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/cmd/gen-prototool-manpages/main.go
+++ b/internal/cmd/gen-prototool-manpages/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/cmd/gen-prototool-zsh-completion/main.go
+++ b/internal/cmd/gen-prototool-zsh-completion/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/cmd/prototool/main.go
+++ b/internal/cmd/prototool/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -324,7 +324,7 @@ $ cat input.json | prototool grpc example \
 }`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.GRPC(args, flags.headers, flags.address, flags.method, flags.data, flags.callTimeout, flags.connectTimeout, flags.keepaliveTime, flags.stdin)
+			return runner.GRPC(args, flags.headers, flags.address, flags.method, flags.data, flags.callTimeout, flags.connectTimeout, flags.keepaliveTime, flags.stdin, flags.tls, flags.insecure, flags.cacert, flags.cert, flags.key, flags.serverName)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindConfigData(flagSet)
@@ -339,6 +339,12 @@ $ cat input.json | prototool grpc example \
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindTLS(flagSet)
+			flags.bindInsecure(flagSet)
+			flags.bindCacert(flagSet)
+			flags.bindCert(flagSet)
+			flags.bindKey(flagSet)
+			flags.bindSeverName(flagSet)
 		},
 	}
 

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -344,7 +344,7 @@ $ cat input.json | prototool grpc example \
 			flags.bindCacert(flagSet)
 			flags.bindCert(flagSet)
 			flags.bindKey(flagSet)
-			flags.bindSeverName(flagSet)
+			flags.bindServerName(flagSet)
 		},
 	}
 

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/create/handler.go
+++ b/internal/create/handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/desc/desc.go
+++ b/internal/desc/desc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -63,7 +63,7 @@ type Runner interface {
 	BinaryToJSON(args []string) error
 	JSONToBinary(args []string) error
 	All(args []string, disableFormat, disableLint, fix bool) error
-	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime string, stdin bool) error
+	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime string, stdin bool, tls bool, insecure bool, cacert string, cert string, key string, serverName string) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/extract/getter.go
+++ b/internal/extract/getter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/file/proto_set_provider_test.go
+++ b/internal/file/proto_set_provider_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/format/base_visitor.go
+++ b/internal/format/base_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/format/first_pass_visitor.go
+++ b/internal/format/first_pass_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/format/main_visitor.go
+++ b/internal/format/main_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/format/printer.go
+++ b/internal/format/printer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/format/transformer.go
+++ b/internal/format/transformer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -89,6 +89,18 @@ func HandlerWithHeader(key string, value string) HandlerOption {
 		// it takes care of validation
 		// if we switch out grpcurl we will probably change to a metadata.MD object
 		handler.headers = append(handler.headers, fmt.Sprintf("%s:%s", key, value))
+	}
+}
+
+// HandlerWithTLS returns a HandlerOption that enables TLS connections to the remote host with the given configuration attributes.
+func HandlerWithTLS(insecure bool, cacert string, cert string, key string, serverName string) HandlerOption {
+	return func(handler *handler) {
+		handler.tls = true
+		handler.insecure = insecure
+		handler.cacert = cacert
+		handler.cert = cert
+		handler.key = key
+		handler.serverName = serverName
 	}
 }
 

--- a/internal/grpc/invocation_event_handler.go
+++ b/internal/grpc/invocation_event_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/base_linter.go
+++ b/internal/lint/base_linter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/base_visitor.go
+++ b/internal/lint/base_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_comments_no_c_style.go
+++ b/internal/lint/check_comments_no_c_style.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enum_field_names_upper_snake_case.go
+++ b/internal/lint/check_enum_field_names_upper_snake_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enum_field_names_uppercase.go
+++ b/internal/lint/check_enum_field_names_uppercase.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enum_field_prefixes.go
+++ b/internal/lint/check_enum_field_prefixes.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enum_names_camel_case.go
+++ b/internal/lint/check_enum_names_camel_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enum_names_capitalized.go
+++ b/internal/lint/check_enum_names_capitalized.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enum_zero_values_invalid.go
+++ b/internal/lint/check_enum_zero_values_invalid.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enums_have_comments.go
+++ b/internal/lint/check_enums_have_comments.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_enums_no_allow_alias.go
+++ b/internal/lint/check_enums_no_allow_alias.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_file_options_equal.go
+++ b/internal/lint/check_file_options_equal.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_file_options_required.go
+++ b/internal/lint/check_file_options_required.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_file_options_same_in_dir.go
+++ b/internal/lint/check_file_options_same_in_dir.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_file_options_unset.go
+++ b/internal/lint/check_file_options_unset.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_go_package_not_long_form.go
+++ b/internal/lint/check_go_package_not_long_form.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_message_field_names_lower_snake_case.go
+++ b/internal/lint/check_message_field_names_lower_snake_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_message_field_names_lowercase.go
+++ b/internal/lint/check_message_field_names_lowercase.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_message_fields_not_floats.go
+++ b/internal/lint/check_message_fields_not_floats.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_message_names_camel_case.go
+++ b/internal/lint/check_message_names_camel_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_message_names_capitalized.go
+++ b/internal/lint/check_message_names_capitalized.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_messages_have_comments.go
+++ b/internal/lint/check_messages_have_comments.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_messages_have_comments_except_request_response_types.go
+++ b/internal/lint/check_messages_have_comments_except_request_response_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_oneof_names_lower_snake_case.go
+++ b/internal/lint/check_oneof_names_lower_snake_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_package_is_declared.go
+++ b/internal/lint/check_package_is_declared.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_package_lower_snake_case.go
+++ b/internal/lint/check_package_lower_snake_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_packages_same_in_dir.go
+++ b/internal/lint/check_packages_same_in_dir.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_request_response_names_match_rpc.go
+++ b/internal/lint/check_request_response_names_match_rpc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_request_response_types_in_same_file.go
+++ b/internal/lint/check_request_response_types_in_same_file.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_request_response_types_unique.go
+++ b/internal/lint/check_request_response_types_unique.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_rpc_names_camel_case.go
+++ b/internal/lint/check_rpc_names_camel_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_rpc_names_capitalized.go
+++ b/internal/lint/check_rpc_names_capitalized.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_rpcs_have_comments.go
+++ b/internal/lint/check_rpcs_have_comments.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_service_names_camel_case.go
+++ b/internal/lint/check_service_names_camel_case.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_service_names_capitalized.go
+++ b/internal/lint/check_service_names_capitalized.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_services_have_comments.go
+++ b/internal/lint/check_services_have_comments.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_syntax_proto3.go
+++ b/internal/lint/check_syntax_proto3.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/check_wkt_directly_imported.go
+++ b/internal/lint/check_wkt_directly_imported.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/protoc/compiler.go
+++ b/internal/protoc/compiler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/protoc/downloader_test.go
+++ b/internal/protoc/downloader_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/protostrs/protostrs.go
+++ b/internal/protostrs/protostrs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/protostrs/protostrs_test.go
+++ b/internal/protostrs/protostrs_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/reflect/handler.go
+++ b/internal/reflect/handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/reflect/reflect.go
+++ b/internal/reflect/reflect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/strs/strs.go
+++ b/internal/strs/strs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/strs/strs_test.go
+++ b/internal/strs/strs_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/vars/vars.go
+++ b/internal/vars/vars.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/wkt/wkt.go
+++ b/internal/wkt/wkt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
As the "prototool grpc" command is just a passthrough to the grpcurl library, there was no way to pass the attributes to the tool for TLS related connections.  By default the current use of the library would be with the '-plaintext' flag (as it does not pass a TLS creds object to "BlockingDial" call).  

This PR adds new command line flags to the "grpc" command to support TLS connections.  These flags mirror the same flags from the grpcurl cli.  The only difference relates to the "--tls" flag itself (which doesn't exist on the grpcurl library).  Since "prototool grpc" by default implies the "-plaintext" flag from grpcurl, a new "--tls" flag will exist that enables TLS (the reverse of --plaintext).