### PR TITLE
Remove comments from prototool.yaml generated by config init by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ When specifying a directory or set of files for Prototool to operate on, Prototo
 
 If multiple `prototool.yaml` or `prototool.json` files are found that match the input directory or files, an error will be returned.
 
+See [etc/config/example/prototool.yaml](etc/config/example/prototool.yaml) all available options.
+
 ## File Discovery
 
 In most Prototool commands, you will see help along the following lines:

--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ Recommended base config file:
 ```yaml
 protoc:
   version: 3.7.0
+lint:
+  group: uber2
 ```
 
-The command `prototool config init` will generate a config file in the current directory with all available configuration options commented out except `protoc.version`. See [etc/config/example/prototool.yaml](etc/config/example/prototool.yaml) for the config file that `prototool config init --uncomment` generates.
+The command `prototool config init` will generate a config file in the current directory with the currently recommended options set.
 
 When specifying a directory or set of files for Prototool to operate on, Prototool will search for config files for each directory starting at the given path, and going up a directory until hitting root. If no config file is found, Prototool will use default values and operate as if there was a config file in the current directory, including the current directory with `-I` to `protoc`.
 
@@ -117,7 +119,13 @@ Let's go over some of the basic commands.
 
 ##### `prototool config init`
 
-Create a `prototool.yaml` file in the current directory, with all options except `protoc.version` commented out.
+Create a `prototool.yaml` file in the current directory with the currently recommended options set.
+
+Pass the `--document` flag to generate a `prototool.yaml` file with all other options documented and commented out.
+
+Pass the `--uncomment` flag to generate `prototool.yaml` file with all options documented but uncommented.
+
+See [etc/config/example/prototool.yaml](etc/config/example/prototool.yaml) for the config file that `prototool config init --uncomment` generates.
 
 ##### `prototool compile`
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -37,6 +37,7 @@ type flags struct {
 	diffMode          bool
 	disableFormat     bool
 	disableLint       bool
+	document          bool
 	dryRun            bool
 	errorFormat       string
 	fix               bool
@@ -112,6 +113,10 @@ func (f *flags) bindDisableLint(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindDryRun(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.dryRun, "dry-run", false, "Print the protoc commands that would have been run without actually running them.")
+}
+
+func (f *flags) bindDocument(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.document, "document", false, "Document all available options. Automatically set if --uncomment is set.")
 }
 
 func (f *flags) bindErrorFormat(flagSet *pflag.FlagSet) {
@@ -195,7 +200,7 @@ func (f *flags) bindStdin(flagSet *pflag.FlagSet) {
 }
 
 func (f *flags) bindUncomment(flagSet *pflag.FlagSet) {
-	flagSet.BoolVar(&f.uncomment, "uncomment", false, "Uncomment the example config settings.")
+	flagSet.BoolVar(&f.uncomment, "uncomment", false, "Uncomment the example config settings. Automatically sets --document.")
 }
 
 func (f *flags) bindFix(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -418,12 +418,13 @@ $ cat input.json | prototool grpc example \
 	configInitCmdTemplate = &cmdTemplate{
 		Use:   "init [dirPath]",
 		Short: "Generate an initial config file in the current or given directory.",
-		Long:  `All available options will be generated and commented out except for "protoc.version". Pass the "--uncomment" flag to uncomment all options.`,
+		Long:  `The currently recommended options will be set.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.Init(args, flags.uncomment)
+			return runner.Init(args, flags.uncomment, flags.document)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindDocument(flagSet)
 			flags.bindUncomment(flagSet)
 		},
 	}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -45,7 +45,7 @@ func (e *ExitError) Error() string {
 // The args given are the args from the command line.
 // Each additional parameter generally refers to a command-specific flag.
 type Runner interface {
-	Init(args []string, uncomment bool) error
+	Init(args []string, uncomment bool, document bool) error
 	Create(args []string, pkg string) error
 	Version() error
 	CacheUpdate(args []string) error

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -155,7 +155,7 @@ func (r *runner) Version() error {
 	return tabWriter.Flush()
 }
 
-func (r *runner) Init(args []string, uncomment bool) error {
+func (r *runner) Init(args []string, uncomment bool, document bool) error {
 	if len(args) > 1 {
 		return errors.New("must provide one arg dirPath")
 	}
@@ -171,7 +171,7 @@ func (r *runner) Init(args []string, uncomment bool) error {
 	if _, err := os.Stat(filePath); err == nil {
 		return fmt.Errorf("%s already exists", filePath)
 	}
-	data, err := cfginit.Generate(vars.DefaultProtocVersion, uncomment)
+	data, err := cfginit.Generate(vars.DefaultProtocVersion, uncomment, document)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This makes it so that `prototool config init` generates only this by default:

```yaml
protoc:
  version: 3.7.0
lint:
  group: uber2
```

If you want all the comments, you can do `prototool config init --document`. The behavior of `prototool config init --uncomment` is unchanged.