### PR TITLE
Remove the --git-tag flag on break check

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -43,7 +43,6 @@ type flags struct {
 	errorFormat       string
 	fix               bool
 	gitBranch         string
-	gitTag            string
 	headers           []string
 	includeBeta       bool
 	keepaliveTime     string
@@ -129,11 +128,7 @@ func (f *flags) bindErrorFormat(flagSet *pflag.FlagSet) {
 }
 
 func (f *flags) bindGitBranch(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.gitBranch, "git-branch", "", "The git branch to check against. The default is the default branch.")
-}
-
-func (f *flags) bindGitTag(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.gitTag, "git-tag", "", "The git tag to check against. The default is to not use tags and use the default branch.")
+	flagSet.StringVar(&f.gitBranch, "git-branch", "", "The git branch or tag to check against. The default is the default branch.")
 }
 
 func (f *flags) bindHeaders(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -66,14 +66,13 @@ var (
 The input directory must be relative.`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.BreakCheck(args, flags.gitBranch, flags.gitTag, flags.includeBeta, flags.allowBetaDeps)
+			return runner.BreakCheck(args, flags.gitBranch, flags.includeBeta, flags.allowBetaDeps)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindAllowBetaDeps(flagSet)
 			flags.bindCachePath(flagSet)
 			flags.bindConfigData(flagSet)
 			flags.bindGitBranch(flagSet)
-			flags.bindGitTag(flagSet)
 			flags.bindJSON(flagSet)
 			flags.bindIncludeBeta(flagSet)
 			flags.bindProtocURL(flagSet)

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -60,7 +60,7 @@ type Runner interface {
 	InspectPackages(args []string) error
 	InspectPackageDeps(args []string, name string) error
 	InspectPackageImporters(args []string, name string) error
-	BreakCheck(args []string, gitBranch string, gitTag string, includeBeta bool, allowBetaDeps bool) error
+	BreakCheck(args []string, gitBranch string, includeBeta bool, allowBetaDeps bool) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -592,15 +592,7 @@ func (r *runner) InspectPackageImporters(args []string, name string) error {
 	return r.printPackageNames(pkg.ImporterNameToImporter())
 }
 
-func (r *runner) BreakCheck(args []string, gitBranch string, gitTag string, includeBeta bool, allowBetaDeps bool) error {
-	if moreThanOneSet(gitBranch != "", gitTag != "") {
-		return newExitErrorf(255, "can only set one of git-branch, git-tag")
-	}
-	branchOrTag := gitBranch
-	if branchOrTag == "" {
-		branchOrTag = gitTag
-	}
-
+func (r *runner) BreakCheck(args []string, gitBranch string, includeBeta bool, allowBetaDeps bool) error {
 	relDirPath := "."
 	// we check length 0 or 1 in cmd, similar to other commands
 	if len(args) == 1 {
@@ -628,7 +620,7 @@ func (r *runner) BreakCheck(args []string, gitBranch string, gitTag string, incl
 	}
 
 	// this will purposefully fail if we are not at a git repository
-	cloneDirPath, err := git.TemporaryClone(r.logger, r.workDirPath, branchOrTag)
+	cloneDirPath, err := git.TemporaryClone(r.logger, r.workDirPath, gitBranch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
From `man git-clone`:

```
--branch <name>
-b <name>
Instead of pointing the newly created HEAD to the branch pointed to by the cloned repository’s HEAD, point to <name> branch instead. In a non-bare repository, this is the branch that will be checked out. --branch can also take tags and detaches the HEAD at that commit in the resulting repository.
```

`git` documents the `--branch` flag to take either branches or tags, so it would make sense that we do this as well. We were not doing anything else with the flags, in fact if anything the split added confusion (and we did the exact same behavior).

Fixes #373.