### PR TITLE
Move --include-beta and --allow-beta-deps into configuration

### DIFF
--- a/etc/config/example/prototool.yaml
+++ b/etc/config/example/prototool.yaml
@@ -102,6 +102,18 @@ lint:
   # this prefix instead of "com".
   java_package_prefix: au.com
 
+# Breaking change detector directives.
+break:
+  # Include beta packages in breaking change detection.
+  # Beta packages have the form "foo.bar.vMAJORbetaBETA" where MAJOR > 0 and BETA > 0.
+  # By default, beta packages are ignored.
+  include_beta: true
+  # Allow stable packages to depend on beta packages.
+  # By default, the breaking change detector will error if a stable package
+  # depends on a breaking package.
+  # If include_beta is true, this is implicitly set.
+  allow_beta_deps: true
+
 # Code generation directives.
 generate:
   # Options that will apply to all plugins of type go and gogo.

--- a/internal/breaking/BUILD.bazel
+++ b/internal/breaking/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//internal/extract:go_default_library",
         "//internal/protostrs:go_default_library",
         "//internal/reflect/gen/uber/proto/reflect/v1:go_default_library",
+        "//internal/settings:go_default_library",
         "//internal/text:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
@@ -45,6 +46,7 @@ go_test(
     deps = [
         "//internal/extract:go_default_library",
         "//internal/reflect:go_default_library",
+        "//internal/settings:go_default_library",
         "//internal/testing:go_default_library",
         "//internal/text:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/internal/breaking/breaking.go
+++ b/internal/breaking/breaking.go
@@ -22,6 +22,7 @@ package breaking
 
 import (
 	"github.com/uber/prototool/internal/extract"
+	"github.com/uber/prototool/internal/settings"
 	"github.com/uber/prototool/internal/text"
 	"go.uber.org/zap"
 )
@@ -151,7 +152,7 @@ type Runner interface {
 	//
 	// Returns Failures if there are incompatibilities, or error if there is
 	// a system error
-	Run(from *extract.PackageSet, to *extract.PackageSet) ([]*text.Failure, error)
+	Run(config settings.BreakConfig, from *extract.PackageSet, to *extract.PackageSet) ([]*text.Failure, error)
 }
 
 // RunnerOption is an option for a new Runner.
@@ -163,27 +164,6 @@ type RunnerOption func(*runner)
 func RunnerWithLogger(logger *zap.Logger) RunnerOption {
 	return func(runner *runner) {
 		runner.logger = logger
-	}
-}
-
-// RunnerWithIncludeBeta returns a RunnerOption that includes beta packages.
-//
-// The default is to ignore beta packages.
-func RunnerWithIncludeBeta() RunnerOption {
-	return func(runner *runner) {
-		runner.includeBeta = true
-	}
-}
-
-// RunnerWithAllowBetaDeps returns a RunnerOption that allows beta dependencies
-// in stable packages.
-//
-// Setting RunnerWithIncludeBeta will cause this to be true.
-//
-// The default is to not allow beta dependencies in stable packages.
-func RunnerWithAllowBetaDeps() RunnerOption {
-	return func(runner *runner) {
-		runner.allowBetaDeps = true
 	}
 }
 

--- a/internal/breaking/breaking_test.go
+++ b/internal/breaking/breaking_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/prototool/internal/extract"
 	"github.com/uber/prototool/internal/reflect"
+	"github.com/uber/prototool/internal/settings"
 	ptesting "github.com/uber/prototool/internal/testing"
 	"github.com/uber/prototool/internal/text"
 )
@@ -343,13 +344,11 @@ func testRun(t *testing.T, subDirPath string, includeBeta bool, allowBetaDeps bo
 	fromPackageSet, toPackageSet, err := getPackageSets(subDirPath)
 	require.NoError(t, err)
 	runner := NewRunner()
-	if includeBeta {
-		runner = NewRunner(RunnerWithIncludeBeta())
+	config := settings.BreakConfig{
+		IncludeBeta:   includeBeta,
+		AllowBetaDeps: allowBetaDeps,
 	}
-	if allowBetaDeps {
-		runner = NewRunner(RunnerWithAllowBetaDeps())
-	}
-	failures, err := runner.Run(fromPackageSet, toPackageSet)
+	failures, err := runner.Run(config, fromPackageSet, toPackageSet)
 	require.NoError(t, err)
 	for _, failure := range failures {
 		failure.LintID = ""

--- a/internal/breaking/runner.go
+++ b/internal/breaking/runner.go
@@ -22,15 +22,14 @@ package breaking
 
 import (
 	"github.com/uber/prototool/internal/extract"
+	"github.com/uber/prototool/internal/settings"
 	"github.com/uber/prototool/internal/text"
 	"go.uber.org/zap"
 )
 
 type runner struct {
-	logger        *zap.Logger
-	includeBeta   bool
-	allowBetaDeps bool
-	checkers      []Checker
+	logger   *zap.Logger
+	checkers []Checker
 }
 
 func newRunner(options ...RunnerOption) *runner {
@@ -44,9 +43,9 @@ func newRunner(options ...RunnerOption) *runner {
 	return runner
 }
 
-func (r *runner) Run(from *extract.PackageSet, to *extract.PackageSet) ([]*text.Failure, error) {
+func (r *runner) Run(config settings.BreakConfig, from *extract.PackageSet, to *extract.PackageSet) ([]*text.Failure, error) {
 	var err error
-	if !r.includeBeta {
+	if !config.IncludeBeta {
 		from, err = from.WithoutBeta()
 		if err != nil {
 			return nil, err
@@ -59,7 +58,7 @@ func (r *runner) Run(from *extract.PackageSet, to *extract.PackageSet) ([]*text.
 	checkers := r.checkers
 	// if includeBeta, do not do the check
 	// else if not including beta, unless allow beta deps, do not do the check
-	if !r.includeBeta && !r.allowBetaDeps {
+	if !config.IncludeBeta && !config.AllowBetaDeps {
 		checkers = append(checkers, PackagesNoBetaDepsChecker)
 	}
 	var failures []*text.Failure

--- a/internal/cfginit/cfginit.go
+++ b/internal/cfginit/cfginit.go
@@ -139,6 +139,18 @@ protoc:
   # this prefix instead of "com".
 {{.V}}  java_package_prefix: au.com
 
+# Breaking change detector directives.
+{{.V}}break:
+  # Include beta packages in breaking change detection.
+  # Beta packages have the form "foo.bar.vMAJORbetaBETA" where MAJOR > 0 and BETA > 0.
+  # By default, beta packages are ignored.
+  {{.V}}include_beta: true
+  # Allow stable packages to depend on beta packages.
+  # By default, the breaking change detector will error if a stable package
+  # depends on a breaking package.
+  # If include_beta is true, this is implicitly set.
+  {{.V}}allow_beta_deps: true
+
 # Code generation directives.
 {{.V}}generate:
   # Options that will apply to all plugins of type go and gogo.

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -25,7 +25,6 @@ import (
 )
 
 type flags struct {
-	allowBetaDeps     bool
 	address           string
 	cachePath         string
 	callTimeout       string
@@ -44,7 +43,6 @@ type flags struct {
 	fix               bool
 	gitBranch         string
 	headers           []string
-	includeBeta       bool
 	keepaliveTime     string
 	json              bool
 	listAllLinters    bool
@@ -61,10 +59,6 @@ type flags struct {
 	protocURL         string
 	stdin             bool
 	uncomment         bool
-}
-
-func (f *flags) bindAllowBetaDeps(flagSet *pflag.FlagSet) {
-	flagSet.BoolVar(&f.allowBetaDeps, "allow-beta-deps", false, "Allow stable packages to depend on beta packages. This is implicitly set if --include-beta is set.")
 }
 
 func (f *flags) bindAddress(flagSet *pflag.FlagSet) {
@@ -133,10 +127,6 @@ func (f *flags) bindGitBranch(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindHeaders(flagSet *pflag.FlagSet) {
 	flagSet.StringSliceVarP(&f.headers, "header", "H", []string{}, "Additional request headers in 'name:value' format.")
-}
-
-func (f *flags) bindIncludeBeta(flagSet *pflag.FlagSet) {
-	flagSet.BoolVar(&f.includeBeta, "include-beta", false, "Include beta packages in breaking change detection.")
 }
 
 func (f *flags) bindKeepaliveTime(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -66,15 +66,13 @@ var (
 The input directory must be relative.`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.BreakCheck(args, flags.gitBranch, flags.includeBeta, flags.allowBetaDeps)
+			return runner.BreakCheck(args, flags.gitBranch)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
-			flags.bindAllowBetaDeps(flagSet)
 			flags.bindCachePath(flagSet)
 			flags.bindConfigData(flagSet)
 			flags.bindGitBranch(flagSet)
 			flags.bindJSON(flagSet)
-			flags.bindIncludeBeta(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -60,7 +60,7 @@ type Runner interface {
 	InspectPackages(args []string) error
 	InspectPackageDeps(args []string, name string) error
 	InspectPackageImporters(args []string, name string) error
-	BreakCheck(args []string, gitBranch string, includeBeta bool, allowBetaDeps bool) error
+	BreakCheck(args []string, gitBranch string) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -354,6 +354,10 @@ func externalConfigToConfig(develMode bool, e ExternalConfig, dirPath string) (C
 			JavaPackagePrefix:   e.Lint.JavaPackagePrefix,
 			AllowSuppression:    e.Lint.AllowSuppression,
 		},
+		Break: BreakConfig{
+			IncludeBeta:   e.Break.IncludeBeta,
+			AllowBetaDeps: e.Break.AllowBetaDeps,
+		},
 		Gen: GenConfig{
 			GoPluginOptions: GenGoPluginOptions{
 				ImportPath:     e.Generate.GoOptions.ImportPath,

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -141,6 +141,8 @@ type Config struct {
 	// or Group/IncludeIDs/ExcludeIDs can be set, but not both. There can be no overlap
 	// between IncludeIDs and ExcludeIDs.
 	Lint LintConfig
+	// The break config.
+	Break BreakConfig
 	// The gen config.
 	Gen GenConfig
 }
@@ -206,6 +208,15 @@ type LintConfig struct {
 	JavaPackagePrefix string
 	// AllowSuppression says to honor @suppresswarnings annotations.
 	AllowSuppression bool
+}
+
+// BreakConfig is the break config.
+type BreakConfig struct {
+	// Include beta packages in breaking change detection.
+	IncludeBeta bool
+	// Allow stable packages to depend on beta packages.
+	// This is implicitly set if IncludeBeta is set.
+	AllowBetaDeps bool
 }
 
 // GenConfig is the gen config.
@@ -300,8 +311,8 @@ type ExternalConfig struct {
 		} `json:"ignores,omitempty" yaml:"ignores,omitempty"`
 		Rules struct {
 			NoDefault bool     `json:"no_default,omitempty" yaml:"no_default,omitempty"`
-			Add       []string `json:"add" yaml:"add"`
-			Remove    []string `json:"remove" yaml:"remove"`
+			Add       []string `json:"add,omitempty" yaml:"add,omitempty"`
+			Remove    []string `json:"remove,omitempty" yaml:"remove,omitempty"`
 		} `json:"rules,omitempty" yaml:"rules,omitempty"`
 		FileHeader struct {
 			Path        string `json:"path,omitempty" yaml:"path,omitempty"`
@@ -312,6 +323,10 @@ type ExternalConfig struct {
 		// devel-mode only
 		AllowSuppression bool `json:"allow_suppression,omitempty" yaml:"allow_suppression,omitempty"`
 	} `json:"lint,omitempty" yaml:"lint,omitempty"`
+	Break struct {
+		IncludeBeta   bool `json:"include_beta,omitempty" yaml:"include_beta,omitempty"`
+		AllowBetaDeps bool `json:"allow_beta_deps,omitempty" yaml:"allow_beta_deps,omitempty"`
+	}
 	Generate struct {
 		GoOptions struct {
 			ImportPath     string            `json:"import_path,omitempty" yaml:"import_path,omitempty"`


### PR DESCRIPTION
These flags are something you want to decide for the entire set of Protobuf files at configuration time, not at runtime, so these are better done as configuration, not flags.

Fixes #372.