### PR TITLE
Add prototool x descriptor-set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `descriptor_set` plugin.
 - Add `cache` top-level command to allow management of the `protoc` cache.
 - Add `x` top-level command for experimental functionality.
+- Add `descriptor-set` command under `x` to output a merged FileDescriptorSet
+  with all files compiled to either stdout, a given file, or a temporary file.
+  Useful with external tools that use FileDescriptorSets.
 - Add `inspect` command under `x` with Protobuf inspection capabilities.
 - Add `--error-format` flag to allow specific error fields to be printed.
 - Add file locking around the `protoc` downloader to eliminate concurrency

--- a/internal/cmd/BUILD.bazel
+++ b/internal/cmd/BUILD.bazel
@@ -29,8 +29,10 @@ go_test(
         "//internal/lint:go_default_library",
         "//internal/settings:go_default_library",
         "//internal/vars:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -118,6 +118,7 @@ func getRootCommand(develMode bool, exitCodeAddr *int, args []string, stdin io.R
 	breakCmd.AddCommand(breakCheckCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	rootCmd.AddCommand(breakCmd)
 	experimentalCmd := &cobra.Command{Use: "x", Short: "Top-level command for experimental commands. These may change between minor versions."}
+	experimentalCmd.AddCommand(descriptorSetCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	inspectCmd := &cobra.Command{Use: "inspect", Short: "Top-level command for inspection commands."}
 	inspectCmd.AddCommand(inspectPackagesCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	inspectCmd.AddCommand(inspectPackageDepsCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -43,8 +43,10 @@ type flags struct {
 	fix               bool
 	gitBranch         string
 	headers           []string
-	keepaliveTime     string
+	includeImports    bool
+	includeSourceInfo bool
 	json              bool
+	keepaliveTime     string
 	listAllLinters    bool
 	listLinters       bool
 	listAllLintGroups bool
@@ -57,7 +59,9 @@ type flags struct {
 	protocBinPath     string
 	protocWKTPath     string
 	protocURL         string
+	outputPath        string
 	stdin             bool
+	tmp               bool
 	uncomment         bool
 }
 
@@ -121,6 +125,10 @@ func (f *flags) bindErrorFormat(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.errorFormat, "error-format", "filename:line:column:message", `The colon-separated fields to print out on error. Valid values are "filename:line:column:id:message".`)
 }
 
+func (f *flags) bindFix(flagSet *pflag.FlagSet) {
+	flagSet.BoolVarP(&f.fix, "fix", "f", false, "Fix the file according to the Style Guide.")
+}
+
 func (f *flags) bindGitBranch(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.gitBranch, "git-branch", "", "The git branch or tag to check against. The default is the default branch.")
 }
@@ -129,12 +137,20 @@ func (f *flags) bindHeaders(flagSet *pflag.FlagSet) {
 	flagSet.StringSliceVarP(&f.headers, "header", "H", []string{}, "Additional request headers in 'name:value' format.")
 }
 
-func (f *flags) bindKeepaliveTime(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.keepaliveTime, "keepalive-time", "", "The maximum idle time after which a keepalive probe is sent.")
+func (f *flags) bindIncludeImports(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.includeImports, "include-imports", false, "Include all dependencies of the input files in the set, so that the set is self-contained.")
+}
+
+func (f *flags) bindIncludeSourceInfo(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.includeSourceInfo, "include-source-info", false, "Do not strip SourceCodeInfo from the FileDescriptorProto. This results in vastly larger descriptors that include information about the original location of each decl in the source file as well as surrounding comments.")
 }
 
 func (f *flags) bindJSON(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.json, "json", false, "Output as JSON.")
+}
+
+func (f *flags) bindKeepaliveTime(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.keepaliveTime, "keepalive-time", "", "The maximum idle time after which a keepalive probe is sent.")
 }
 
 func (f *flags) bindLintMode(flagSet *pflag.FlagSet) {
@@ -165,6 +181,10 @@ func (f *flags) bindName(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.name, "name", "", "The package name. This is required.")
 }
 
+func (f *flags) bindOutputPath(flagSet *pflag.FlagSet) {
+	flagSet.StringVarP(&f.outputPath, "output-path", "o", "", "Write the FileDescriptorSet to the given file path instead of outputting to stdout.")
+}
+
 func (f *flags) bindOverwrite(flagSet *pflag.FlagSet) {
 	flagSet.BoolVarP(&f.overwrite, "overwrite", "w", false, "Overwrite the existing file instead of writing the formatted file to stdout.")
 }
@@ -193,6 +213,6 @@ func (f *flags) bindUncomment(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.uncomment, "uncomment", false, "Uncomment the example config settings. Automatically sets --document.")
 }
 
-func (f *flags) bindFix(flagSet *pflag.FlagSet) {
-	flagSet.BoolVarP(&f.fix, "fix", "f", false, "Fix the file according to the Style Guide.")
+func (f *flags) bindTmp(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&f.tmp, "tmp", false, "Write the FileDescriptorSet to a temporary file and print the file path instead of outputting to stdout.")
 }

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -213,6 +213,28 @@ If Vim integration is set up, files will be generated when you open a new Protob
 		},
 	}
 
+	descriptorSetCmdTemplate = &cmdTemplate{
+		Use:   "descriptor-set [dirOrFile]",
+		Short: "Generate a FileDescriptorSet containing all files.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(runner exec.Runner, args []string, flags *flags) error {
+			return runner.DescriptorSet(args, flags.includeImports, flags.includeSourceInfo, flags.outputPath, flags.tmp)
+		},
+		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindCachePath(flagSet)
+			flags.bindConfigData(flagSet)
+			flags.bindErrorFormat(flagSet)
+			flags.bindIncludeImports(flagSet)
+			flags.bindIncludeSourceInfo(flagSet)
+			flags.bindJSON(flagSet)
+			flags.bindProtocURL(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
+			flags.bindOutputPath(flagSet)
+			flags.bindTmp(flagSet)
+		},
+	}
+
 	filesCmdTemplate = &cmdTemplate{
 		Use:   "files [dirOrFile]",
 		Short: "Print all files that match the input arguments.",

--- a/internal/desc/BUILD.bazel
+++ b/internal/desc/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["desc.go"],
     importpath = "github.com/uber/prototool/internal/desc",
     visibility = ["//:__subpackages__"],
-    deps = ["@io_bazel_rules_go//proto/wkt:descriptor_go_proto"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+    ],
 )

--- a/internal/desc/desc.go
+++ b/internal/desc/desc.go
@@ -54,3 +54,12 @@ func SortFileDescriptorSet(fileDescriptorSet *descriptor.FileDescriptorSet, file
 	newFileDescriptorSet.File = append(newFileDescriptorSet.File, fileDescriptorProto)
 	return newFileDescriptorSet, nil
 }
+
+// MergeFileDescriptorSets merges the given FileDescriptorSets, checking that files
+// with the same name have the same content.
+func MergeFileDescriptorSets(fileDescriptorSets []*descriptor.FileDescriptorSet) (*descriptor.FileDescriptorSet, error) {
+	if len(fileDescriptorSets) == 0 {
+		return nil, nil
+	}
+	return nil, nil
+}

--- a/internal/exec/BUILD.bazel
+++ b/internal/exec/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/breaking:go_default_library",
         "//internal/cfginit:go_default_library",
         "//internal/create:go_default_library",
+        "//internal/desc:go_default_library",
         "//internal/diff:go_default_library",
         "//internal/extract:go_default_library",
         "//internal/file:go_default_library",
@@ -24,6 +25,9 @@ go_library(
         "//internal/settings:go_default_library",
         "//internal/text:go_default_library",
         "//internal/vars:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_uber_go_multierr//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -61,6 +61,7 @@ type Runner interface {
 	InspectPackageDeps(args []string, name string) error
 	InspectPackageImporters(args []string, name string) error
 	BreakCheck(args []string, gitBranch string) error
+	DescriptorSet(args []string, includeImports bool, includeSourceInfo bool, outputPath string, tmp bool) error
 }
 
 // RunnerOption is an option for a new Runner.

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -37,9 +37,12 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/uber/prototool/internal/breaking"
 	"github.com/uber/prototool/internal/cfginit"
 	"github.com/uber/prototool/internal/create"
+	"github.com/uber/prototool/internal/desc"
 	"github.com/uber/prototool/internal/diff"
 	"github.com/uber/prototool/internal/extract"
 	"github.com/uber/prototool/internal/file"
@@ -52,8 +55,11 @@ import (
 	"github.com/uber/prototool/internal/settings"
 	"github.com/uber/prototool/internal/text"
 	"github.com/uber/prototool/internal/vars"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
+
+var jsonpbMarshaler = &jsonpb.Marshaler{}
 
 type runner struct {
 	protoSetProvider file.ProtoSetProvider
@@ -280,7 +286,6 @@ func (r *runner) doCompile(compiler protoc.Compiler, meta *meta) (protoc.FileDes
 	if len(compileResult.Failures) > 0 {
 		return nil, newExitErrorf(255, "")
 	}
-	r.logger.Debug("protoc command exited without errors")
 	return compileResult.FileDescriptorSets, nil
 }
 
@@ -584,7 +589,58 @@ func (r *runner) GRPC(args, headers []string, address, method, data, callTimeout
 	).Invoke(fileDescriptorSets.Unwrap(), address, method, reader, r.output)
 }
 
-func (r *runner) DescriptorSet(args []string, includeImports bool, includeSourceInfo bool, outputPath string, tmp bool) error {
+func (r *runner) DescriptorSet(args []string, includeImports bool, includeSourceInfo bool, outputPath string, tmp bool) (retErr error) {
+	if outputPath != "" && tmp {
+		return newExitErrorf(255, "can only set one of output-path, tmp")
+	}
+	meta, err := r.getMeta(args)
+	if err != nil {
+		return err
+	}
+	r.printAffectedFiles(meta)
+	fileDescriptorSets, err := r.compileFullControl(includeImports, includeSourceInfo, meta)
+	if err != nil {
+		return err
+	}
+	fileDescriptorSet, err := desc.MergeFileDescriptorSets(fileDescriptorSets.Unwrap())
+	if err != nil {
+		return err
+	}
+	var data []byte
+	if r.json {
+		buffer := bytes.NewBuffer(nil)
+		err = jsonpbMarshaler.Marshal(buffer, fileDescriptorSet)
+		data = buffer.Bytes()
+	} else {
+		data, err = proto.Marshal(fileDescriptorSet)
+	}
+	if err != nil {
+		return err
+	}
+	if outputPath == "" && !tmp {
+		_, err := r.output.Write(data)
+		return err
+	}
+	var file *os.File
+	if outputPath != "" {
+		file, err = os.Create(outputPath)
+	} else { // if tmp
+		file, err = ioutil.TempFile("", "prototool")
+	}
+	if err != nil {
+		return err
+	}
+	defer func() {
+		retErr = multierr.Append(retErr, file.Close())
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if tmp {
+		if err := r.println(file.Name()); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -565,6 +565,10 @@ func (r *runner) GRPC(args, headers []string, address, method, data, callTimeout
 	).Invoke(fileDescriptorSets.Unwrap(), address, method, reader, r.output)
 }
 
+func (r *runner) DescriptorSet(args []string, includeImports bool, includeSourceInfo bool, outputPath string, tmp bool) error {
+	return nil
+}
+
 func (r *runner) InspectPackages(args []string) error {
 	packageSet, _, err := r.getPackageSetAndConfig(args)
 	if err != nil {

--- a/internal/protoc/protoc.go
+++ b/internal/protoc/protoc.go
@@ -235,6 +235,19 @@ func CompilerWithFileDescriptorSet() CompilerOption {
 	}
 }
 
+// CompilerWithFileDescriptorSetFullControl says to also return the FileDescriptorSet but
+// with extra controls.
+//
+// This is added for backwards compatibility within the codebase.
+func CompilerWithFileDescriptorSetFullControl(includeImports bool, includeSourceInfo bool) CompilerOption {
+	return func(compiler *compiler) {
+		compiler.doFileDescriptorSet = true
+		compiler.fileDescriptorSetFullControl = true
+		compiler.fileDescriptorSetIncludeImports = includeImports
+		compiler.fileDescriptorSetIncludeSourceInfo = includeSourceInfo
+	}
+}
+
 // NewCompiler returns a new Compiler.
 func NewCompiler(options ...CompilerOption) Compiler {
 	return newCompiler(options...)


### PR DESCRIPTION
This adds a command `prototool x descriptor-set` that will compile all files under the search path, get the FileDescriptorSet for each package, merge the FileDescriptorSets into a single FileDescriptorSet while verifying that FileDescriptorProtos of the same name have the same content, and then output the FileDescriptorSet to either stdout, a given file, or a temporary file, in either binary or JSON format.

The primary motivation for this is for use in external gRPC CLI tools in cases with the gRPC Reflection API is not available and/or the tool does not support the gRPC reflection API. This will allow e.g.:

https://github.com/bojand/ghz

```
ghz -protoset $(prototool x descriptor-set --tmp) ...
```

https://github.com/fullstorydev/grpcurl

```
grpcurl -protoset $(prototool x descriptor-set --tmp) ...
```

This allows other tools to handle gRPC going forward. The `prototool grpc` command was always put on at the end, and if I could go back in time, I would do this instead. We'll keep it around for existing users, but this will allow those tools to concentrate on what they are good at (calling gRPC) and Prototool to concentrate on what it is good at (compiling Protobuf files).

We'll still take PRs for `prototool grpc` and any cleanups, but we'll document how to use `prototool x descriptor-set` before v1.4.0.

I'm putting this in `x` so we can do some testing, and expect to promote it to stable within the next few months. There's a few outstanding questions, the biggest of which is what to do about compile errors - currently `prototool` prints them to stdout, but we're using stdout to print out the serialized FileDescriptorSet as well. We could just say that you have to specify `-o` or `--tmp`, and we do not output to stdout.

Fixes #378.