### PR TITLE
Allow the breaking change detector to check against a FileDescriptorSet file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   rules.
 - Add `--diff-lint-groups` flag to the `lint` command to print the diff
   between two lint groups.
-- Breaking change detector added as the `break check` command.
+- Add `descriptor-set` command to output a merged `FileDescriptorSet`
+  with all files compiled to either stdout, a given file, or a temporary file.
+  Useful with external tools that use FileDescriptorSets, and also useful for
+  inspection if the `--json` flag is given.
+- Add breaking change detector as the `break check` command. By default, this
+  compiles your existing Protobuf definitions, and then does a shallow clone
+  of your git repository against the default branch and compiles the
+  definitions on that branch, and compares the existing versus the branch.
+  The branch can be controlled with the `--git-branch` flag, and one can
+  use a `FileDescriptorSet` instead of a shallow clone by generating a
+  file with `break descriptor-set` and then passing the path to this file
+  to `break check` with the `--descriptor-set-path` flag.
 - A Docker image is now provided on Docker Hub as [uber/prototool](https://hub.docker.com/r/uber/prototool)
   which provides an environment with commonly-used plugins.
 - Switch to Golang Modules for dependency management.
@@ -38,9 +49,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `descriptor_set` plugin.
 - Add `cache` top-level command to allow management of the `protoc` cache.
 - Add `x` top-level command for experimental functionality.
-- Add `descriptor-set` command under `x` to output a merged FileDescriptorSet
-  with all files compiled to either stdout, a given file, or a temporary file.
-  Useful with external tools that use FileDescriptorSets.
 - Add `inspect` command under `x` with Protobuf inspection capabilities.
 - Add `--error-format` flag to allow specific error fields to be printed.
 - Add file locking around the `protoc` downloader to eliminate concurrency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   version of our lint rules. These rules are almost entirely a superset of the
   V1 Style guide lint rules. If `lint.group` is set to `uber2`, this also will
   affect the `create` and `format` commands, as the `uber2` lint group adds
-  more file options to more closely match the [Google Cloud APIs File Structure](https://cloud.google.com/apis/design/file_structure).
+  more file options to more closely match the [Google Cloud APIs File Structure](https://cloud.google.com/apis/design/file_structure)
+  and changes the value of `go_package` to take versions into account.
   In total, 39 lint rules have been added as compared to the `uber1` lint
   group.
-  and changes the value of `go_package` to take versions into account.
 - New `google` lint group representing Google's minimal [Style Guide](https://developers.google.com/protocol-buffers/docs/style).
 - Add `--list-lint-group` flag to the `lint` command to list a lint group's
   rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `x` top-level command for experimental functionality.
 - Add `inspect` command under `x` with Protobuf inspection capabilities.
 - Add `--error-format` flag to allow specific error fields to be printed.
+- Allow the `protoc` binary and WKT paths to be controlled by the environment
+  variables `PROTOTOOL_PROTOC_BIN_PATH` and `PROTOTOOL_PROTOC_WKT_PATH` in
+  addition to the existing `--protoc-bin-path` and `--protoc-wkt-path` flags.
+  The flags take precedence. This is especially useful for Docker images.
 - Add file locking around the `protoc` downloader to eliminate concurrency
   issues where multiple `prototool` invocations may be accessing the cache
   at the same time.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -105,6 +105,7 @@ func getRootCommand(develMode bool, exitCodeAddr *int, args []string, stdin io.R
 	rootCmd.AddCommand(formatCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	rootCmd.AddCommand(generateCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	rootCmd.AddCommand(grpcCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
+	rootCmd.AddCommand(descriptorSetCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	configCmd := &cobra.Command{Use: "config", Short: "Interact with configuration files."}
 	configCmd.AddCommand(configInitCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	rootCmd.AddCommand(configCmd)
@@ -116,9 +117,10 @@ func getRootCommand(develMode bool, exitCodeAddr *int, args []string, stdin io.R
 	rootCmd.AddCommand(cacheCmd)
 	breakCmd := &cobra.Command{Use: "break", Short: "Top-level command for breaking change commands."}
 	breakCmd.AddCommand(breakCheckCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
+	breakCmd.AddCommand(breakDescriptorSetCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	rootCmd.AddCommand(breakCmd)
+
 	experimentalCmd := &cobra.Command{Use: "x", Short: "Top-level command for experimental commands. These may change between minor versions."}
-	experimentalCmd.AddCommand(descriptorSetCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	inspectCmd := &cobra.Command{Use: "inspect", Short: "Top-level command for inspection commands."}
 	inspectCmd.AddCommand(inspectPackagesCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))
 	inspectCmd.AddCommand(inspectPackageDepsCmdTemplate.Build(develMode, exitCodeAddr, stdin, stdout, stderr, flags))

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1412,7 +1412,7 @@ func assertGoldenFormat(t *testing.T, expectSuccess bool, fix bool, filePath str
 }
 
 func assertDescriptorSet(t *testing.T, expectSuccess bool, dirOrFile string, includeImports bool, includeSourceInfo bool, expectedNames ...string) {
-	args := []string{"x", "descriptor-set"}
+	args := []string{"descriptor-set"}
 	if includeImports {
 		args = append(args, "--include-imports")
 	}

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -32,6 +32,7 @@ type flags struct {
 	connectTimeout    string
 	data              string
 	debug             bool
+	descriptorSetPath string
 	details           bool
 	diffLintGroups    string
 	diffMode          bool
@@ -91,6 +92,10 @@ func (f *flags) bindData(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindDebug(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&f.debug, "debug", false, "Run in debug mode, which will print out debug logging.")
+}
+
+func (f *flags) bindDescriptorSetPath(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.descriptorSetPath, "descriptor-set-path", "", "The path to the file containing a serialized FileDescriptorSet to check against.\nFileDescriptorSet files can be produced using the descriptor-set sub-command.\nThe default behavior is to check against a git branch or tag. This cannot be used with the --git-branch flag.")
 }
 
 func (f *flags) bindDetails(flagSet *pflag.FlagSet) {
@@ -183,6 +188,10 @@ func (f *flags) bindName(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindOutputPath(flagSet *pflag.FlagSet) {
 	flagSet.StringVarP(&f.outputPath, "output-path", "o", "", "Write the FileDescriptorSet to the given file path instead of outputting to stdout.")
+}
+
+func (f *flags) bindOutputPathBreakDescriptorSet(flagSet *pflag.FlagSet) {
+	flagSet.StringVarP(&f.outputPath, "output-path", "o", "", "The file path to write the FileDescriptorSet to. This is required.")
 }
 
 func (f *flags) bindOverwrite(flagSet *pflag.FlagSet) {

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -95,7 +95,7 @@ func (f *flags) bindDebug(flagSet *pflag.FlagSet) {
 }
 
 func (f *flags) bindDescriptorSetPath(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&f.descriptorSetPath, "descriptor-set-path", "", "The path to the file containing a serialized FileDescriptorSet to check against.\nFileDescriptorSet files can be produced using the descriptor-set sub-command.\nThe default behavior is to check against a git branch or tag. This cannot be used with the --git-branch flag.")
+	flagSet.StringVarP(&f.descriptorSetPath, "descriptor-set-path", "f", "", "The path to the file containing a serialized FileDescriptorSet to check against.\nFileDescriptorSet files can be produced using the descriptor-set sub-command.\nThe default behavior is to check against a git branch or tag. This cannot be used with the --git-branch flag.")
 }
 
 func (f *flags) bindDetails(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -61,21 +61,39 @@ var (
 	breakCheckCmdTemplate = &cmdTemplate{
 		Use:   "check [dir]",
 		Short: "Check for breaking changes.",
-		Long: `This command must be run from the root of a git repository.
-
-The input directory must be relative.`,
-		Args: cobra.MaximumNArgs(1),
+		Long:  `This command must be run from the root of a git repository, and the input directory must be relative, unless --descriptor-set-path is specified.`,
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.BreakCheck(args, flags.gitBranch)
+			return runner.BreakCheck(args, flags.gitBranch, flags.descriptorSetPath)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindCachePath(flagSet)
 			flags.bindConfigData(flagSet)
+			flags.bindDescriptorSetPath(flagSet)
 			flags.bindGitBranch(flagSet)
 			flags.bindJSON(flagSet)
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+		},
+	}
+
+	breakDescriptorSetCmdTemplate = &cmdTemplate{
+		Use:   "descriptor-set [dir]",
+		Short: "Generate a FileDescriptorSet file that stores the current state of your Protobuf definitions for use with break check --descriptor-set-path. The -o flag is required.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(runner exec.Runner, args []string, flags *flags) error {
+			return runner.BreakDescriptorSet(args, flags.outputPath)
+		},
+		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
+			flags.bindCachePath(flagSet)
+			flags.bindConfigData(flagSet)
+			flags.bindErrorFormat(flagSet)
+			flags.bindJSON(flagSet)
+			flags.bindProtocURL(flagSet)
+			flags.bindProtocBinPath(flagSet)
+			flags.bindProtocWKTPath(flagSet)
+			flags.bindOutputPathBreakDescriptorSet(flagSet)
 		},
 	}
 

--- a/internal/exec/BUILD.bazel
+++ b/internal/exec/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//internal/vars:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_uber_go_multierr//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -60,7 +60,8 @@ type Runner interface {
 	InspectPackages(args []string) error
 	InspectPackageDeps(args []string, name string) error
 	InspectPackageImporters(args []string, name string) error
-	BreakCheck(args []string, gitBranch string) error
+	BreakCheck(args []string, gitBranch string, descriptorSetPath string) error
+	BreakDescriptorSet(args []string, outputPath string) error
 	DescriptorSet(args []string, includeImports bool, includeSourceInfo bool, outputPath string, tmp bool) error
 }
 


### PR DESCRIPTION
This PR does a few things:

- Moves the `descriptor-set` command out of `x`. In #381, I said there were unanswered questions about whether to print to stdout, but having used this more this morning, this feature is too valuable to leave in `x`. Being able to do things like `prototool descriptor-set path/to/proto/root --json | jq '.file[] | select(.messageType != null) | .messageType[] | .name' | sort | uniq` is very nice.
- Adds a `--descriptor-set-path` flag (aliased as `-f`) to `break check` that allows the breaking change detector to check against a file containing a serialized `FileDescriptorSet` (analogous to `proto.lock` in github.com/nilslice/protolock). This removes any `git` operations from `break check` if specified. This allows someone to generate a `FileDescriptorSet` file and check it in, instead of relying on `git`. Not only is this faster, it's useful when a `git` repository is not present.
- Adds a `break descriptor-set` sub-command that generates serialized `FileDescriptorSet` files. This is an alias for `descriptor-set --include-imports`, where `-o` is required.

The result is the ability to do the following workflow:

```
# on check-in
prototool break descriptor-set path/to/proto/root -o descriptor.bin
# when you want to check if there are breaking changes at your current state
prototool break check path/to/proto/root -f descriptor.bin
```

This is in addition to the existing default workflow:

```
# clone the default branch, compile the definitions in path/to/proto/root at that point, compare
prototool break check path/to/proto/root
# alternatively, check against a non-default branch or tag
prototool break check path/to/proto/root --git-branch v1.0.0
```

The result is a compelling tool that covers more use cases:

- One can check against a git branch or tag, cloning and compiling on the fly.
- One can check against a `FileDescriptorSet`.

The other benefit of this breaking change detector, namely that as opposed to other tools, `break check` checks on a per-package basis instead of a per-file basis (so that one can move definitions between files as long as they are in the same Protobuf package, as should be allowed), is still present.

I've manually tested this works as I didn't have integration testing for `break check` previously, but the workflow is tested up to the actual point of the CLI.