### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12.0-alpine3.9 as builder
 
-RUN apk add --update --no-cache build-base curl git && \
+RUN apk add --update --no-cache build-base curl git upx && \
   rm -rf /var/cache/apk/*
 
 ENV GOLANG_PROTOBUF_VERSION=1.3.0 \
@@ -60,6 +60,8 @@ COPY internal /tmp/prototool/internal
 RUN cd /tmp/prototool && \
   go install ./cmd/prototool && \
   mv /go/bin/prototool /usr/local/bin/prototool
+
+RUN upx --lzma /usr/local/bin/*
 
 FROM alpine:edge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN GO111MODULE=on go get \
   github.com/gogo/protobuf/protoc-gen-gogofast@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogoslick@v${GOGO_PROTOBUF_VERSION} && \
-  cp /go/bin/protoc-gen-go* /usr/local/bin/
+  mv /go/bin/protoc-gen-go* /usr/local/bin/
 
 ENV GRPC_GATEWAY_VERSION=1.8.2
 RUN curl -sSL \
@@ -35,13 +35,13 @@ RUN git clone --depth 1 -b v${YARPC_VERSION} https://github.com/yarpc/yarpc-go.g
     cd /go/src/go.uber.org/yarpc && \
     GO111MODULE=on go mod init && \
     GO111MODULE=on go install ./encoding/protobuf/protoc-gen-yarpc-go && \
-    cp /go/bin/protoc-gen-yarpc-go /usr/local/bin/
+    mv /go/bin/protoc-gen-yarpc-go /usr/local/bin/
 
 ENV TWIRP_VERSION=5.5.2
 RUN git clone --depth 1 -b v${TWIRP_VERSION} https://github.com/twitchtv/twirp.git /go/src/github.com/twitchtv/twirp && \
   cd /go/src/github.com/twitchtv/twirp && \
   go install ./protoc-gen-twirp ./protoc-gen-twirp_python && \
-  cp /go/bin/protoc-gen-twirp* /usr/local/bin/
+  mv /go/bin/protoc-gen-twirp* /usr/local/bin/
 
 ENV PROTOBUF_VERSION=3.6.1
 RUN mkdir -p /tmp/protoc && \
@@ -50,7 +50,7 @@ RUN mkdir -p /tmp/protoc && \
   -o /tmp/protoc/protoc.zip && \
   cd /tmp/protoc && \
   unzip protoc.zip && \
-  cp -R /tmp/protoc/include /usr/local/include
+  mv /tmp/protoc/include /usr/local/include
 
 RUN mkdir -p /tmp/prototool
 COPY go.mod go.sum /tmp/prototool/
@@ -59,7 +59,7 @@ COPY cmd /tmp/prototool/cmd
 COPY internal /tmp/prototool/internal
 RUN cd /tmp/prototool && \
   go install ./cmd/prototool && \
-  cp /go/bin/prototool /usr/local/bin/prototool
+  mv /go/bin/prototool /usr/local/bin/prototool
 
 FROM alpine:edge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,91 +1,88 @@
 FROM golang:1.12.0-alpine3.9 as builder
 
-RUN mkdir -p /tmp/bin
-ENV PATH=/tmp/bin:${PATH}
+RUN apk add --update --no-cache build-base curl git && \
+  rm -rf /var/cache/apk/*
 
-RUN apk add --update --no-cache build-base curl git
-
-ENV GOLANG_PROTOBUF_VERSION=1.3.0
-RUN GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION}
-RUN cp /go/bin/protoc-gen-go /usr/local/bin/
-
-ENV GOGO_PROTOBUF_VERSION=1.2.1
+ENV GOLANG_PROTOBUF_VERSION=1.3.0 \
+  GOGO_PROTOBUF_VERSION=1.2.1
 RUN GO111MODULE=on go get \
+  github.com/golang/protobuf/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gofast@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogo@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogofast@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION} \
-  github.com/gogo/protobuf/protoc-gen-gogoslick@v${GOGO_PROTOBUF_VERSION}
-RUN cp /go/bin/protoc-gen-gofast /usr/local/bin/
-RUN cp /go/bin/protoc-gen-gogo /usr/local/bin/
-RUN cp /go/bin/protoc-gen-gogofast /usr/local/bin/
-RUN cp /go/bin/protoc-gen-gogofaster /usr/local/bin/
-RUN cp /go/bin/protoc-gen-gogoslick /usr/local/bin/
+  github.com/gogo/protobuf/protoc-gen-gogoslick@v${GOGO_PROTOBUF_VERSION} && \
+  cp /go/bin/protoc-gen-go* /usr/local/bin/
 
-ENV GRPC_GATEWAY_VERSION=1.8.1
+ENV GRPC_GATEWAY_VERSION=1.8.2
 RUN curl -sSL \
   https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v${GRPC_GATEWAY_VERSION}/protoc-gen-grpc-gateway-v${GRPC_GATEWAY_VERSION}-linux-x86_64 \
-  -o /usr/local/bin/protoc-gen-grpc-gateway
-RUN chmod +x /usr/local/bin/protoc-gen-grpc-gateway
-RUN curl -sSL \
+  -o /usr/local/bin/protoc-gen-grpc-gateway && \
+  curl -sSL \
   https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v${GRPC_GATEWAY_VERSION}/protoc-gen-swagger-v${GRPC_GATEWAY_VERSION}-linux-x86_64 \
-  -o /usr/local/bin/protoc-gen-swagger
-RUN chmod +x /usr/local/bin/protoc-gen-swagger
+  -o /usr/local/bin/protoc-gen-swagger && \
+  chmod +x /usr/local/bin/protoc-gen-grpc-gateway && \
+  chmod +x /usr/local/bin/protoc-gen-swagger
 
 ENV GRPC_WEB_VERSION=1.0.3
 RUN curl -sSL \
   https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB_VERSION}/protoc-gen-grpc-web-${GRPC_WEB_VERSION}-linux-x86_64 \
-  -o /usr/local/bin/protoc-gen-grpc-web
-RUN chmod +x /usr/local/bin/protoc-gen-grpc-web
+  -o /usr/local/bin/protoc-gen-grpc-web && \
+  chmod +x /usr/local/bin/protoc-gen-grpc-web
 
 ENV YARPC_VERSION=1.36.2
-RUN git clone --depth 1 -b v${YARPC_VERSION} https://github.com/yarpc/yarpc-go.git /go/src/go.uber.org/yarpc
-RUN cd /go/src/go.uber.org/yarpc && GO111MODULE=on go mod init && GO111MODULE=on go install ./encoding/protobuf/protoc-gen-yarpc-go
-RUN cp /go/bin/protoc-gen-yarpc-go /usr/local/bin/
+RUN git clone --depth 1 -b v${YARPC_VERSION} https://github.com/yarpc/yarpc-go.git /go/src/go.uber.org/yarpc && \
+    cd /go/src/go.uber.org/yarpc && \
+    GO111MODULE=on go mod init && \
+    GO111MODULE=on go install ./encoding/protobuf/protoc-gen-yarpc-go && \
+    cp /go/bin/protoc-gen-yarpc-go /usr/local/bin/
 
 ENV TWIRP_VERSION=5.5.2
-RUN git clone --depth 1 -b v${TWIRP_VERSION} https://github.com/twitchtv/twirp.git /go/src/github.com/twitchtv/twirp
-RUN cd /go/src/github.com/twitchtv/twirp && go install ./protoc-gen-twirp ./protoc-gen-twirp_python
-RUN cp /go/bin/protoc-gen-twirp /usr/local/bin/
-RUN cp /go/bin/protoc-gen-twirp_python /usr/local/bin/
+RUN git clone --depth 1 -b v${TWIRP_VERSION} https://github.com/twitchtv/twirp.git /go/src/github.com/twitchtv/twirp && \
+  cd /go/src/github.com/twitchtv/twirp && \
+  go install ./protoc-gen-twirp ./protoc-gen-twirp_python && \
+  cp /go/bin/protoc-gen-twirp* /usr/local/bin/
 
 ENV PROTOBUF_VERSION=3.6.1
-RUN mkdir -p /tmp/protoc
-RUN curl -sSL \
-  https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip -o /tmp/protoc/protoc.zip
-RUN cd /tmp/protoc && unzip protoc.zip
-RUN cp -R /tmp/protoc/include /usr/local/include
+RUN mkdir -p /tmp/protoc && \
+  curl -sSL \
+  https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip \
+  -o /tmp/protoc/protoc.zip && \
+  cd /tmp/protoc && \
+  unzip protoc.zip && \
+  cp -R /tmp/protoc/include /usr/local/include
 
 RUN mkdir -p /tmp/prototool
 COPY go.mod go.sum /tmp/prototool/
 RUN cd /tmp/prototool && go mod download
 COPY cmd /tmp/prototool/cmd
 COPY internal /tmp/prototool/internal
-RUN cd /tmp/prototool && go install ./cmd/prototool
-RUN cp /go/bin/prototool /usr/local/bin/prototool
+RUN cd /tmp/prototool && \
+  go install ./cmd/prototool && \
+  cp /go/bin/prototool /usr/local/bin/prototool
 
 FROM alpine:edge
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
+WORKDIR /work
 
-ENV PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc
-ENV PROTOTOOL_PROTOC_WKT_PATH=/usr/include
+ENV \
+  PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc \
+  PROTOTOOL_PROTOC_WKT_PATH=/usr/include \
+  GRPC_VERSION=1.18.0 \
+  PROTOBUF_VERSION=3.6.1 \
+  ALPINE_GRPC_VERSION_SUFFIX=r0 \
+  ALPINE_PROTOBUF_VERSION_SUFFIX=r1
 
-ENV GRPC_VERSION=1.18.0
-ENV PROTOBUF_VERSION=3.6.1
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
+  apk add --update --no-cache bash curl git grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} && \
+  rm -rf /var/cache/apk/*
 
-ENV ALPINE_GRPC_VERSION_SUFFIX=r0
-ENV ALPINE_PROTOBUF_VERSION_SUFFIX=r1
-
-RUN apk add --update --no-cache bash curl git grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX}
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/include /usr/include
 
-ENV GOGO_PROTOBUF_VERSION=1.2.1
-ENV GOLANG_PROTOBUF_VERSION=1.3.0
-ENV GRPC_GATEWAY_VERSION=1.8.1
-ENV GRPC_WEB_VERSION=1.0.3
-ENV TWIRP_VERSION=5.5.2
-ENV YARPC_VERSION=1.36.2
-
-WORKDIR /work
+ENV GOGO_PROTOBUF_VERSION=1.2.1 \
+  GOLANG_PROTOBUF_VERSION=1.3.0 \
+  GRPC_GATEWAY_VERSION=1.8.2 \
+  GRPC_WEB_VERSION=1.0.3 \
+  TWIRP_VERSION=5.5.2 \
+  YARPC_VERSION=1.36.2

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,8 +1,8 @@
 # Prototool Docker Image
 
-We provide a Docker image with `prototool`, `protoc`, and common Protobuf plugins pre-installed. As of
-this writing, the resulting image is around 141MB. This provides a consistent environment to generate your Protobuf
-stubs.
+We provide a Docker image with `prototool`, `protoc`, and common Protobuf plugins pre-installed.
+All plugins are compressed with [UPX](https://github.com/upx/upx). As of this writing, the resulting
+image is around 79MB. This provides a consistent environment to generate your Protobuf stubs.
 
 This is in early development.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,7 +33,7 @@ a GitHub issue and we will evaluate it.
 | [grpc] | 1.18.0 | grpc_cpp_plugin<br>grpc_csharp_plugin<br>grpc_node_plugin<br>grpc_objective_c_plugin<br>grpc_php_plugin<br>grpc_python_plugin<br>grpc_ruby_plugin |
 | [golang/protobuf] | 1.3.0 | protoc-gen-go |
 | [gogo/protobuf] | 1.2.1 | protoc-gen-gofast<br>protoc-gen-gogo<br>protoc-gen-gogofast<br>protoc-gen-gogofaster<br>protoc-gen-gogoslick |
-| [grpc-gateway] | 1.8.1 | protoc-gen-grpc-gateway<br>protoc-gen-swagger |
+| [grpc-gateway] | 1.8.2 | protoc-gen-grpc-gateway<br>protoc-gen-swagger |
 | [grpc-web] | 1.0.3 | protoc-gen-grpc-web |
 | [twirp] | 5.5.2 | protoc-gen-twirp<br>protoc-gen-twirp_python |
 | [yarpc] | 1.36.2 | protoc-gen-yarpc-go |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,7 +1,7 @@
 # Prototool Docker Image
 
 We provide a Docker image with `prototool`, `protoc`, and common Protobuf plugins pre-installed.
-All plugins are compressed with [UPX](https://github.com/upx/upx). As of this writing, the resulting
+Most plugins are compressed with [UPX](https://github.com/upx/upx). As of this writing, the resulting
 image is around 79MB. This provides a consistent environment to generate your Protobuf stubs.
 
 This is in early development.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -23,8 +23,7 @@ You can build on top of this image as well if you have custom requirements.
 ## Included
 
 The following libraries are included. This is not meant to be exhaustive - these represent our view of the most
-commonly-used, stable, maintained libraries. If you think another library should be included, propose it in
-a GitHub issue and we will evaluate it.
+commonly-used, stable, maintained libraries.
 
 | Name | Version | Binaries |
 | --- | --- | --- |
@@ -40,6 +39,8 @@ a GitHub issue and we will evaluate it.
 
 The Well-Known Types are copied to `/usr/include`. The packages `bash`, `curl`, and `git` are also installed.
 
+If you think another library should be included, propose it in a GitHub issue and we will evaluate it.
+
 ## Versioning
 
 Images are pushed for every commit to the dev branch as the tags `uber/prototool:dev, uber:prototool:latest`, and
@@ -47,6 +48,29 @@ every minor release starting with `v1.4.0` will have a tag e.g. `uber/prototool:
 to the rest of Prototool, there is no breaking change guarantee between minor releases - we do not account
 for breaking changes in libraries we provide within this image, and will update them regularly on `dev`.
 We recommend pinning to one of the minor release Docker image tags once they are available.
+
+## Development
+
+To update the Docker image, edit the [Dockerfile](../Dockerfile).
+
+Note that for version changes, the versions are copied in four places: once for each layer in the
+Dockerfile (sharing these is harder than you think), once in [etc/docker/testing/bin/test.sh](../etc/docker/testing/bin/test.sh),
+and once in this documentation.
+
+Updates of `protobuf` and `grpc` must match the current versions for `alpine:edge` for now. See [here](https://pkgs.alpinelinux.org/packages?name=protobuf&branch=edge&repo=main&arch=x86_64) and [here](https://pkgs.alpinelinux.org/packages?name=grpc&branch=edge&repo=testing&arch=x86_64) for the current versions.
+
+Local development commands:
+
+```
+# build the docker image
+make dockerbuild
+# test a built docker image
+make dockertest
+# build and then test
+make dockerall
+```
+
+The test files are in [etc/docker/testing](../etc/docker/testing).
 
 [protoc]: https://github.com/protocolbuffers/protobuf
 [grpc]: https://github.com/grpc/grpc

--- a/etc/docker/testing/bin/test.sh
+++ b/etc/docker/testing/bin/test.sh
@@ -46,7 +46,7 @@ check_dir_not_exists() {
 check_env GOGO_PROTOBUF_VERSION 1.2.1
 check_env GOLANG_PROTOBUF_VERSION 1.3.0
 check_env GRPC_VERSION 1.18.0
-check_env GRPC_GATEWAY_VERSION 1.8.1
+check_env GRPC_GATEWAY_VERSION 1.8.2
 check_env GRPC_WEB_VERSION 1.0.3
 check_env PROTOBUF_VERSION 3.6.1
 check_env TWIRP_VERSION 5.5.2

--- a/etc/docker/testing/bin/test.sh
+++ b/etc/docker/testing/bin/test.sh
@@ -26,6 +26,17 @@ check_command_output() {
   fi
 }
 
+check_command_output_file() {
+  tmp_file="$(mktemp)"
+  trap 'rm -rf "${tmp_file}"' EXIT
+  echo "Checking that '${*:2}' results in the contents of '${1}'"
+  "${@:2}" > "${tmp_file}"
+  if ! diff "${1}" "${tmp_file}"; then
+    echo "Diff detected" >&2
+    exit 1
+  fi
+}
+
 
 check_command_success() {
   echo "Checking that '${*}' is successful"
@@ -54,6 +65,7 @@ check_env YARPC_VERSION 1.36.2
 check_env PROTOTOOL_PROTOC_BIN_PATH /usr/bin/protoc
 check_env PROTOTOOL_PROTOC_WKT_PATH /usr/include
 check_command_output "libprotoc 3.6.1" protoc --version
+check_command_output_file etc/wkt.txt find /usr/include -type f
 check_which /usr/bin/protoc
 check_which /usr/bin/grpc_cpp_plugin
 check_which /usr/bin/grpc_csharp_plugin

--- a/etc/docker/testing/etc/wkt.txt
+++ b/etc/docker/testing/etc/wkt.txt
@@ -1,0 +1,12 @@
+/usr/include/google/protobuf/duration.proto
+/usr/include/google/protobuf/empty.proto
+/usr/include/google/protobuf/descriptor.proto
+/usr/include/google/protobuf/any.proto
+/usr/include/google/protobuf/field_mask.proto
+/usr/include/google/protobuf/source_context.proto
+/usr/include/google/protobuf/struct.proto
+/usr/include/google/protobuf/timestamp.proto
+/usr/include/google/protobuf/type.proto
+/usr/include/google/protobuf/compiler/plugin.proto
+/usr/include/google/protobuf/api.proto
+/usr/include/google/protobuf/wrappers.proto


### PR DESCRIPTION
This brings the time down to about 3 1/2 mins on my local computer, which means it will probably be around 7-8 mins on https://hub.docker.com/r/uber/prototool.

Update: The build is now using [UPX](https://github.com/upx/upx) which brings the image size down to around 79MB from 161MB previously (the docs said 141MB but the size was higher). This results in a build around 4m45s, but given that people are pulling this image constantly, that tradeoff is worth it. The time is around the same as it was now, but with around half the image size.