### PR TITLE
Update codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,8 +12,12 @@ coverage:
         enabled: yes
         target: 50%
 ignore:
+  - /cmd/prototool
   - /example/cmd/excited
-  - /example/gen/go/uber/foo/v1
   - /example/gen/go/uber/bar/v1
+  - /example/gen/go/uber/foo/v1
+  - /internal/cmd/gen-prototool-bash-completion
+  - /internal/cmd/gen-prototool-manpages
+  - /internal/cmd/gen-prototool-zsh-completion
   - /internal/cmd/testdata/grpc/gen/grpcpb
   - /internal/reflect/gen/uber/proto/reflect/v1


### PR DESCRIPTION
This hasn't been updated to reflect the packages we want to ignore for a while. This ignores the simple binary wrappers (which are not meant to be tested), and alphabetizes the packages.