### PR TITLE
Added missing back-quote

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -1004,7 +1004,7 @@ and there is no cost to having a message be unnested.
 
 Services should always be `PascalCase`. RPCs should always be `PascalCase.`
 
-Services should always be suffixed with `API`. For example, `TripAPI` or `UserAPI. This is for
+Services should always be suffixed with `API`. For example, `TripAPI` or `UserAPI`. This is for
 consistency.
 
 All services and RPCs require a comment that contains at least one complete sentence. See the


### PR DESCRIPTION
UserAPI was clearly meant to be in code-font.

Thanks for your pull request! We really appreciate all OSS efforts, big or small.

Before submitting, make sure to:

- Review the issue template at https://github.com/uber/prototool/blob/dev/.github/ISSUE_TEMPLATE.md for
  general guidance on filing Prototool requests.
- Run `make` to make sure all tests pass. This is functionally equivalent to the tests run on CI.

PRs will not be properly evaluated until they pass CI - we've done what we can to make this easy
to replicate locally, and we apologize if this comes across as impersonal. Our goal is to streamline
Prototool development and make sure everyone is on the same page here.

Please do not @ individual maintainers in the description! We appreciate it.
