### PR TITLE
Fix typo in directory traversal error message

### DIFF
--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -235,7 +235,7 @@ func (c *protoSetProvider) walkAndGetAllProtoFiles(absWorkDirPath string, absDir
 				}
 				numWalkedFiles++
 				if timedOut {
-					return fmt.Errorf("walking the diectory structure looking for proto files "+
+					return fmt.Errorf("walking the directory structure looking for proto files "+
 						"timed out after %v and having seen %d files, are you sure you are operating "+
 						"in the right context?", c.walkTimeout, numWalkedFiles)
 				}


### PR DESCRIPTION
Fixes a minor typo in the word `directory` (misspelled as `diectory`) in the error message displayed after a directory-traversal timeout:

```
walking the diectory structure looking for proto files timed out after 3s and having seen 66990 files, are you sure you are operating in the right context?
```
