### PR TITLE
Add test for downloading logic

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -59,10 +59,10 @@ func TestDownload(t *testing.T) {
 		_ = os.RemoveAll(tmpDir)
 	}()
 	assertExact(t, false, 0, ``, "cache", "update", "--cache-path", tmpDir, "testdata/foo")
-	fileInfo, err := os.Stat(filepath.Join(tmpDir, "protobuf", "3.7.1"))
+	fileInfo, err := os.Stat(filepath.Join(tmpDir, "protobuf", vars.DefaultProtocVersion))
 	assert.NoError(t, err)
 	assert.True(t, fileInfo.IsDir())
-	fileInfo, err = os.Stat(filepath.Join(tmpDir, "protobuf", "3.7.1.lock"))
+	fileInfo, err = os.Stat(filepath.Join(tmpDir, "protobuf", vars.DefaultProtocVersion+".lock"))
 	assert.NoError(t, err)
 	assert.False(t, fileInfo.IsDir())
 }


### PR DESCRIPTION
This adds a test for the downloading logic. This also cleans up the command test file a little by adding `t.Parallel()` where appropriate and removing an `os.Chdir` call.