### PR TITLE
Add protoc-gen-swift to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN cd /tmp/prototool && \
 RUN upx --lzma /usr/local/bin/*
 
 FROM swift:5.1 AS swift-builder
-ENV SWIFT_PROTO_VERSION=1.7.0
+ENV SWIFT_PROTO_VERSION=1.8.0
 RUN set -ex; \
   mkdir -p /tmp/swift-proto; \
   git clone -c advice.detachedHead=false --depth 1 -b ${SWIFT_PROTO_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,8 @@ ENV \
   PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc \
   PROTOTOOL_PROTOC_WKT_PATH=/usr/include \
   GRPC_VERSION=1.21.3 \
-  PROTOBUF_VERSION=3.8.0 \
-  ALPINE_GRPC_VERSION_SUFFIX=r0 \
+  PROTOBUF_VERSION=3.9.2 \
+  ALPINE_GRPC_VERSION_SUFFIX=r1 \
   ALPINE_PROTOBUF_VERSION_SUFFIX=r0
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM golang:1.12.4-alpine3.9 as builder
+ARG GOLANG_PROTOBUF_VERSION=1.3.1
+ARG GOGO_PROTOBUF_VERSION=1.2.1
+ARG GRPC_GATEWAY_VERSION=1.8.5
+ARG GRPC_WEB_VERSION=1.0.4
+ARG YARPC_VERSION=1.37.3
+ARG TWIRP_VERSION=5.7.0
+ARG SWIFT_PROTO_VERSION=1.8.0
+ARG GRPC_VERSION=1.25.0
+ARG ALPINE_GRPC_VERSION_SUFFIX=r1
+ARG PROTOBUF_VERSION=3.11.2
+ARG ALPINE_PROTOBUF_VERSION_SUFFIX=r1
 
-RUN apk add --update --no-cache build-base curl git upx && \
-  rm -rf /var/cache/apk/*
+# Base image contains all the protoc plugins included with prototool
+FROM golang:1.13.8-alpine3.11 as base
 
-ENV GOLANG_PROTOBUF_VERSION=1.3.1 \
-  GOGO_PROTOBUF_VERSION=1.2.1
+RUN apk add --update --no-cache build-base curl git upx
+
+ARG GOLANG_PROTOBUF_VERSION
+ARG GOGO_PROTOBUF_VERSION
 RUN GO111MODULE=on go get \
   github.com/golang/protobuf/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gofast@v${GOGO_PROTOBUF_VERSION} \
@@ -14,7 +26,7 @@ RUN GO111MODULE=on go get \
   github.com/gogo/protobuf/protoc-gen-gogoslick@v${GOGO_PROTOBUF_VERSION} && \
   mv /go/bin/protoc-gen-go* /usr/local/bin/
 
-ENV GRPC_GATEWAY_VERSION=1.8.5
+ARG GRPC_GATEWAY_VERSION
 RUN curl -sSL \
   https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v${GRPC_GATEWAY_VERSION}/protoc-gen-grpc-gateway-v${GRPC_GATEWAY_VERSION}-linux-x86_64 \
   -o /usr/local/bin/protoc-gen-grpc-gateway && \
@@ -24,20 +36,20 @@ RUN curl -sSL \
   chmod +x /usr/local/bin/protoc-gen-grpc-gateway && \
   chmod +x /usr/local/bin/protoc-gen-swagger
 
-ENV GRPC_WEB_VERSION=1.0.4
+ARG GRPC_WEB_VERSION
 RUN curl -sSL \
   https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB_VERSION}/protoc-gen-grpc-web-${GRPC_WEB_VERSION}-linux-x86_64 \
   -o /usr/local/bin/protoc-gen-grpc-web && \
   chmod +x /usr/local/bin/protoc-gen-grpc-web
 
-ENV YARPC_VERSION=1.37.3
+ARG YARPC_VERSION
 RUN git clone --depth 1 -b v${YARPC_VERSION} https://github.com/yarpc/yarpc-go.git /go/src/go.uber.org/yarpc && \
-    cd /go/src/go.uber.org/yarpc && \
-    GO111MODULE=on go mod init && \
-    GO111MODULE=on go install ./encoding/protobuf/protoc-gen-yarpc-go && \
-    mv /go/bin/protoc-gen-yarpc-go /usr/local/bin/
+  cd /go/src/go.uber.org/yarpc && \
+  GO111MODULE=on go mod init && \
+  GO111MODULE=on go install ./encoding/protobuf/protoc-gen-yarpc-go && \
+  mv /go/bin/protoc-gen-yarpc-go /usr/local/bin/
 
-ENV TWIRP_VERSION=5.7.0
+ARG TWIRP_VERSION
 RUN curl -sSL \
   https://github.com/twitchtv/twirp/releases/download/v${TWIRP_VERSION}/protoc-gen-twirp-Linux-x86_64 \
   -o /usr/local/bin/protoc-gen-twirp && \
@@ -47,7 +59,7 @@ RUN curl -sSL \
   chmod +x /usr/local/bin/protoc-gen-twirp && \
   chmod +x /usr/local/bin/protoc-gen-twirp_python
 
-ENV PROTOBUF_VERSION=3.6.1
+ARG PROTOBUF_VERSION
 RUN mkdir -p /tmp/protoc && \
   curl -sSL \
   https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip \
@@ -56,22 +68,12 @@ RUN mkdir -p /tmp/protoc && \
   unzip protoc.zip && \
   mv /tmp/protoc/include /usr/local/include
 
-RUN mkdir -p /tmp/prototool
-COPY go.mod go.sum /tmp/prototool/
-RUN cd /tmp/prototool && go mod download
-COPY cmd /tmp/prototool/cmd
-COPY internal /tmp/prototool/internal
-RUN cd /tmp/prototool && \
-  go install ./cmd/prototool && \
-  mv /go/bin/prototool /usr/local/bin/prototool
-
-RUN upx --lzma /usr/local/bin/*
-
+# Swift image must be built separately
 FROM swift:5.1 AS swift-builder
-ENV SWIFT_PROTO_VERSION=1.8.0
+ARG SWIFT_PROTO_VERSION
 WORKDIR /swift-proto
 RUN git clone -c advice.detachedHead=false --depth 1 -b ${SWIFT_PROTO_VERSION} https://github.com/apple/swift-protobuf.git .
-RUN swift build --static-swift-stdlib --configuration release
+RUN swift build --configuration release
 # Copy release binary to distribution folder
 WORKDIR /dist
 RUN install -TD /swift-proto/.build/release/protoc-gen-swift ./usr/local/bin/protoc-gen-swift
@@ -80,29 +82,53 @@ RUN ldd /dist/usr/local/bin/protoc-gen-swift | awk '{ print $3 }' | sort | uniq 
 # Explicitely copy dynamic linker since it is filtered out by awk
 RUN install -TD /lib64/ld-linux-x86-64.so.2 ./lib64/ld-linux-x86-64.so.2
 
-FROM alpine:latest
+# Build & install prototool
+FROM base AS builder
+WORKDIR /tmp/prototool
+COPY go.mod go.sum ./
+RUN  go mod download
+COPY cmd cmd
+COPY internal internal
+RUN go install -mod=readonly ./cmd/prototool
+RUN mv /go/bin/prototool /usr/local/bin/prototool
+RUN upx --lzma /usr/local/bin/*
+
+# Final image containing only binaries
+FROM alpine:3.11
 
 WORKDIR /work
 
-ENV \
-  PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc \
-  PROTOTOOL_PROTOC_WKT_PATH=/usr/include \
-  GRPC_VERSION=1.21.3 \
-  PROTOBUF_VERSION=3.9.2 \
-  ALPINE_GRPC_VERSION_SUFFIX=r1 \
-  ALPINE_PROTOBUF_VERSION_SUFFIX=r0
+ARG GOLANG_PROTOBUF_VERSION
+ARG GOGO_PROTOBUF_VERSION
+ARG GRPC_GATEWAY_VERSION
+ARG GRPC_WEB_VERSION
+ARG YARPC_VERSION
+ARG TWIRP_VERSION
+ARG PROTOBUF_VERSION
+ARG SWIFT_PROTO_VERSION
+ARG GRPC_VERSION
+ARG ALPINE_GRPC_VERSION_SUFFIX
+ARG PROTOBUF_VERSION
+ARG ALPINE_PROTOBUF_VERSION_SUFFIX
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
-  apk add --update --no-cache bash curl git grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} && \
-  rm -rf /var/cache/apk/*
+ENV \
+  GOLANG_PROTOBUF_VERSION=${GOLANG_PROTOBUF_VERSION} \
+  GOGO_PROTOBUF_VERSION=${GOGO_PROTOBUF_VERSION} \
+  GRPC_GATEWAY_VERSION=${GRPC_GATEWAY_VERSION} \
+  GRPC_WEB_VERSION=${GRPC_WEB_VERSION} \
+  YARPC_VERSION=${YARPC_VERSION} \
+  TWIRP_VERSION=${TWIRP_VERSION} \
+  PROTOBUF_VERSION=${PROTOBUF_VERSION} \
+  SWIFT_PROTO_VERSION=${SWIFT_PROTO_VERSION} \
+  GRPC_VERSION=${GRPC_VERSION} \
+  PROTOBUF_VERSION=${PROTOBUF_VERSION} \
+  PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc \
+  PROTOTOOL_PROTOC_WKT_PATH=/usr/include
+
+RUN apk add --update --no-cache bash curl git \
+  grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} \
+  protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX}
 
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/include /usr/include
 COPY --from=swift-builder /dist /
-
-ENV GOGO_PROTOBUF_VERSION=1.2.1 \
-  GOLANG_PROTOBUF_VERSION=1.3.1 \
-  GRPC_GATEWAY_VERSION=1.8.5 \
-  GRPC_WEB_VERSION=1.0.4 \
-  TWIRP_VERSION=5.7.0 \
-  YARPC_VERSION=1.37.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,40 @@ RUN cd /tmp/prototool && \
 
 RUN upx --lzma /usr/local/bin/*
 
+FROM swift:5.1 AS swift-builder
+ENV SWIFT_PROTO_VERSION=1.7.0
+RUN set -ex; \
+  mkdir -p /tmp/swift-proto; \
+  git clone -c advice.detachedHead=false --depth 1 -b ${SWIFT_PROTO_VERSION} \
+    https://github.com/apple/swift-protobuf.git /tmp/swift-proto; \
+  cd /tmp/swift-proto; \
+  swift build -c release; \
+  mv .build/release/protoc-gen-swift /usr/local/bin/protoc-gen-swift
+
+FROM scratch AS swift-dist
+# This list of files is generated using `ldd /usr/local/bin/protoc-gen-swift`
+# Static linking is not yet supported by swiftc https://bugs.swift.org/browse/SR-648
+COPY --from=swift-builder /usr/local/bin/protoc-gen-swift /usr/local/bin/protoc-gen-swift
+COPY --from=swift-builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=swift-builder /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=swift-builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=swift-builder /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=swift-builder /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=swift-builder /lib/x86_64-linux-gnu/librt.so.1 /lib/x86_64-linux-gnu/librt.so.1
+COPY --from=swift-builder /lib/x86_64-linux-gnu/libutil.so.1 /lib/x86_64-linux-gnu/libutil.so.1
+COPY --from=swift-builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=swift-builder /usr/lib/swift/linux/libBlocksRuntime.so /usr/lib/swift/linux/libBlocksRuntime.so
+COPY --from=swift-builder /usr/lib/swift/linux/libdispatch.so /usr/lib/swift/linux/libdispatch.so
+COPY --from=swift-builder /usr/lib/swift/linux/libFoundation.so /usr/lib/swift/linux/libFoundation.so
+COPY --from=swift-builder /usr/lib/swift/linux/libicudataswift.so.61 /usr/lib/swift/linux/libicudataswift.so.61
+COPY --from=swift-builder /usr/lib/swift/linux/libicui18nswift.so.61 /usr/lib/swift/linux/libicui18nswift.so.61
+COPY --from=swift-builder /usr/lib/swift/linux/libicuucswift.so.61 /usr/lib/swift/linux/libicuucswift.so.61
+COPY --from=swift-builder /usr/lib/swift/linux/libswiftCore.so /usr/lib/swift/linux/libswiftCore.so
+COPY --from=swift-builder /usr/lib/swift/linux/libswiftDispatch.so /usr/lib/swift/linux/libswiftDispatch.so
+COPY --from=swift-builder /usr/lib/swift/linux/libswiftGlibc.so /usr/lib/swift/linux/libswiftGlibc.so
+COPY --from=swift-builder /usr/lib/x86_64-linux-gnu/libatomic.so.1 /usr/lib/x86_64-linux-gnu/libatomic.so.1
+COPY --from=swift-builder /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+
 FROM alpine:latest
 
 WORKDIR /work
@@ -85,6 +119,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/reposit
 
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/include /usr/include
+COPY --from=swift-dist / /
 
 ENV GOGO_PROTOBUF_VERSION=1.2.1 \
   GOLANG_PROTOBUF_VERSION=1.3.1 \

--- a/Makefile
+++ b/Makefile
@@ -260,11 +260,11 @@ dockerbuild:
 
 .PHONY: dockertest
 dockertest:
-	docker run -v $(CURDIR):/work $(DOCKER_IMAGE) bash etc/docker/testing/bin/test.sh
+	docker run --rm -v $(CURDIR):/work $(DOCKER_IMAGE) bash etc/docker/testing/bin/test.sh
 
 .PHONY: dockershell
 dockershell: dockerbuild
-	docker run -it -v $(CURDIR):/work $(DOCKER_IMAGE) bash
+	docker run --rm -it -v $(CURDIR):/work $(DOCKER_IMAGE) bash
 
 .PHONY: dockerall
 dockerall: dockerbuild dockertest

--- a/etc/docker/testing/bin/test.sh
+++ b/etc/docker/testing/bin/test.sh
@@ -59,15 +59,15 @@ check_dir_not_exists() {
 
 check_env GOGO_PROTOBUF_VERSION 1.2.1
 check_env GOLANG_PROTOBUF_VERSION 1.3.1
-check_env GRPC_VERSION 1.19.1
+check_env GRPC_VERSION 1.25.0
 check_env GRPC_GATEWAY_VERSION 1.8.5
 check_env GRPC_WEB_VERSION 1.0.4
-check_env PROTOBUF_VERSION 3.6.1
+check_env PROTOBUF_VERSION 3.11.2
 check_env TWIRP_VERSION 5.7.0
 check_env YARPC_VERSION 1.37.3
 check_env PROTOTOOL_PROTOC_BIN_PATH /usr/bin/protoc
 check_env PROTOTOOL_PROTOC_WKT_PATH /usr/include
-check_command_output "libprotoc 3.6.1" protoc --version
+check_command_output "libprotoc ${PROTOBUF_VERSION}" protoc --version
 check_command_output_file etc/wkt.txt find /usr/include -type f
 check_which /usr/bin/protoc
 check_which /usr/bin/grpc_cpp_plugin
@@ -89,6 +89,7 @@ check_which /usr/local/bin/protoc-gen-swagger
 check_which /usr/local/bin/protoc-gen-twirp
 check_which /usr/local/bin/protoc-gen-twirp_python
 check_which /usr/local/bin/protoc-gen-yarpc-go
+check_which /usr/local/bin/protoc-gen-swift
 check_which /usr/local/bin/prototool
 check_command_success protoc -o /dev/null $(find proto -name '*.proto')
 check_command_success rm -rf gen

--- a/etc/docker/testing/proto/prototool.yaml
+++ b/etc/docker/testing/proto/prototool.yaml
@@ -75,3 +75,5 @@ generate:
     - name: yarpc-go
       type: gogo
       output: ../gen/yarpc-go
+    - name: swift
+      output: ../gen/swift


### PR DESCRIPTION
This PR adds `protoc-gen-swift` tool from https://github.com/apple/swift-protobuf to the docker image. Since swift does not support static linking, I had to explicitly copy all .so dependencies into the final image. Since all other tools are statically linked, copying over glibc works.

I have tested locally by adding generate clause in `prototool.yaml`:
```yaml
generate:
  plugins:
    - name: swift
      output: swift
```
Please let me know if any explicit tests have to be added.

I understand this PR may be rejected because of future conflicts with glibc. However, this will help someone who is using prototool and needs to generate swift bindings.
