### PR TITLE
Better parsing for release candidates with protoc URL

### DIFF
--- a/internal/protoc/downloader.go
+++ b/internal/protoc/downloader.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -310,9 +311,14 @@ func (d *downloader) getProtocURL(goos string, goarch string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	// Protoc download URLs for release candidates don't use the hyphen in the version part of the URL
+	re := regexp.MustCompile(`(rc)-(\d+$)`)
+	version := re.ReplaceAllString(d.config.Compile.ProtobufVersion, "$1$2")
+
 	return fmt.Sprintf(
 		"https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s-%s.zip",
-		d.config.Compile.ProtobufVersion,
+		version,
 		d.config.Compile.ProtobufVersion,
 		protocS,
 		unameM,

--- a/internal/protoc/downloader_test.go
+++ b/internal/protoc/downloader_test.go
@@ -190,6 +190,77 @@ func TestNewDownloaderProtocValidation(t *testing.T) {
 	}
 }
 
+func TestNewDownloaderProtocURL(t *testing.T) {
+	tests := []struct {
+		desc            string
+		expectedURL     string
+		expectError     bool
+		goarch          string
+		goos            string
+		protobufVersion string
+	}{
+		{
+			protobufVersion: "3.10.0",
+			goos:            "linux",
+			goarch:          "amd64",
+			expectedURL:     "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip",
+			desc:            "linux amd64 official version",
+		},
+		{
+			protobufVersion: "3.10.0-rc-1",
+			goos:            "linux",
+			goarch:          "amd64",
+			expectedURL:     "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0-rc1/protoc-3.10.0-rc-1-linux-x86_64.zip",
+			desc:            "linux amd64 release candidate",
+		},
+		{
+			protobufVersion: "3.10.0",
+			goos:            "darwin",
+			goarch:          "amd64",
+			expectedURL:     "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-osx-x86_64.zip",
+			desc:            "darwin amd64 official version",
+		},
+		{
+			protobufVersion: "3.10.0-rc-1",
+			goos:            "darwin",
+			goarch:          "amd64",
+			expectedURL:     "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0-rc1/protoc-3.10.0-rc-1-osx-x86_64.zip",
+			desc:            "darwin amd64 release candidate",
+		},
+		{
+			goos:        "foo",
+			goarch:      "amd64",
+			expectError: true,
+			desc:        "invalid goos",
+		},
+		{
+			goos:        "linux",
+			goarch:      "foo",
+			expectError: true,
+			desc:        "invalid goarch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			dl, err := newDownloader(
+				settings.Config{
+					Compile: settings.CompileConfig{
+						ProtobufVersion: tt.protobufVersion,
+					},
+				},
+			)
+
+			url, err := dl.getProtocURL(tt.goos, tt.goarch)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, url, tt.expectedURL)
+			}
+		})
+	}
+}
+
 func newTestGetenvFunc(xdgCacheHome string, home string) func(string) string {
 	m := make(map[string]string)
 	if xdgCacheHome != "" {


### PR DESCRIPTION
 Added a regex check for a release candidate syntax in the protobuf version portion of the download URL.