### PR TITLE
Add config file path

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -31,6 +31,7 @@ type flags struct {
 	cacert            string
 	cert              string
 	configData        string
+	configFilePath    string
 	connectTimeout    string
 	data              string
 	debug             bool
@@ -87,6 +88,10 @@ func (f *flags) bindCallTimeout(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindConfigData(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.configData, "config-data", "", "The configuration data to use instead of reading prototool.yaml or prototool.json files.\nThis will act as if there is a configuration file with the given data in the current directory, and no other configuration files recursively.\nThis is an advanced feature and is not recommended to be generally used.")
+}
+
+func (f *flags) bindConfigFilePath(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.configFilePath, "config-file-path", "", "The path to the prototool.{yaml,yml,json} file. Prototool won't scan for other configuration files.")
 }
 
 func (f *flags) bindConnectTimeout(flagSet *pflag.FlagSet) {

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -303,6 +303,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindConfigFilePath(flagSet)
 		},
 	}
 
@@ -592,6 +593,12 @@ func getRunner(develMode bool, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		runnerOptions = append(
 			runnerOptions,
 			exec.RunnerWithConfigData(flags.configData),
+		)
+	}
+	if flags.configFilePath != "" {
+		runnerOptions = append(
+			runnerOptions,
+			exec.RunnerWithConfigFilePath(flags.configFilePath),
 		)
 	}
 	if flags.json {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -98,6 +98,13 @@ func RunnerWithConfigData(configData string) RunnerOption {
 	}
 }
 
+// RunnerWithConfigFilePath returns a RunnerOption that uses the given config file path.
+func RunnerWithConfigFilePath(configFilePath string) RunnerOption {
+	return func(runner *runner) {
+		runner.configFilePath = configFilePath
+	}
+}
+
 // RunnerWithJSON returns a RunnerOption that will print failures as JSON.
 func RunnerWithJSON() RunnerOption {
 	return func(runner *runner) {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -70,15 +70,16 @@ type runner struct {
 	input       io.Reader
 	output      io.Writer
 
-	logger        *zap.Logger
-	develMode     bool
-	cachePath     string
-	configData    string
-	protocBinPath string
-	protocWKTPath string
-	protocURL     string
-	errorFormat   string
-	json          bool
+	logger         *zap.Logger
+	develMode      bool
+	cachePath      string
+	configData     string
+	configFilePath string
+	protocBinPath  string
+	protocWKTPath  string
+	protocURL      string
+	errorFormat    string
+	json           bool
 }
 
 func newRunner(workDirPath string, input io.Reader, output io.Writer, options ...RunnerOption) *runner {
@@ -97,6 +98,12 @@ func newRunner(workDirPath string, input io.Reader, output io.Writer, options ..
 		protoSetProviderOptions = append(
 			protoSetProviderOptions,
 			file.ProtoSetProviderWithConfigData(runner.configData),
+		)
+	}
+	if runner.configFilePath != "" {
+		protoSetProviderOptions = append(
+			protoSetProviderOptions,
+			file.ProtoSetProviderWithConfigFilePath(runner.configFilePath),
 		)
 	}
 	if runner.develMode {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -117,6 +117,14 @@ func ProtoSetProviderWithConfigData(configData string) ProtoSetProviderOption {
 	}
 }
 
+// ProtoSetProviderWithConfigFilePath returns a ProtoSetProviderOption that uses the given configuration
+// file instead of searching for other configuration files.
+func ProtoSetProviderWithConfigFilePath(configFilePath string) ProtoSetProviderOption {
+	return func(protoSetProvider *protoSetProvider) {
+		protoSetProvider.configFilePath = configFilePath
+	}
+}
+
 // ProtoSetProviderWithWalkTimeout returns a ProtoSetProviderOption will timeout after walking
 // a directory structure when searching for Protobuf files after the given amount of time.
 //

--- a/internal/protoc/downloader_test.go
+++ b/internal/protoc/downloader_test.go
@@ -249,6 +249,7 @@ func TestNewDownloaderProtocURL(t *testing.T) {
 					},
 				},
 			)
+			require.NoError(t, err)
 
 			url, err := dl.getProtocURL(tt.goos, tt.goarch)
 			if tt.expectError {


### PR DESCRIPTION
Since prototool does its best to find configuration files inside included dirs (why does it do that in the first place?), specifying the config file path makes it possible to use prototool in projects that have the following hierarchy:

1) protobuf definitions git repo
2) SDK for X language that includes `1)` as git submodule
3) project using `2`.

P.S The contribution flow is not entirely clear. Is this supposed to be against `dev`? I've based my base on `dev`. What's your release flow?