### PR TITLE
Add protoc-gen-mypy to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,13 +74,12 @@ WORKDIR /work
 ENV \
   PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc \
   PROTOTOOL_PROTOC_WKT_PATH=/usr/include \
-  GRPC_VERSION=1.21.3 \
-  PROTOBUF_VERSION=3.8.0 \
+  GRPC_VERSION=1.25.0 \
+  PROTOBUF_VERSION=3.10.1 \
   ALPINE_GRPC_VERSION_SUFFIX=r0 \
   ALPINE_PROTOBUF_VERSION_SUFFIX=r0
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
-  apk add --update --no-cache bash curl git grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} && \
+RUN apk add --update --no-cache bash curl git grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} && \
   rm -rf /var/cache/apk/*
 
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,17 @@ RUN apk add --update --no-cache build-base curl git upx && \
   rm -rf /var/cache/apk/*
 
 ENV GOLANG_PROTOBUF_VERSION=1.3.1 \
-  GOGO_PROTOBUF_VERSION=1.2.1
+  GOGO_PROTOBUF_VERSION=1.2.1 \
+  MYPY_PROTOBUF_VERSION=master
 RUN GO111MODULE=on go get \
   github.com/golang/protobuf/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gofast@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogo@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogofast@v${GOGO_PROTOBUF_VERSION} \
   github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION} \
-  github.com/gogo/protobuf/protoc-gen-gogoslick@v${GOGO_PROTOBUF_VERSION} && \
-  mv /go/bin/protoc-gen-go* /usr/local/bin/
+  github.com/gogo/protobuf/protoc-gen-gogoslick@v${GOGO_PROTOBUF_VERSION} \
+  github.com/dropbox/mypy-protobuf/go/src/protoc-gen-mypy@${MYPY_PROTOBUF_VERSION} && \
+  mv /go/bin/protoc-gen-go* /go/bin/protoc-gen-mypy /usr/local/bin/
 
 ENV GRPC_GATEWAY_VERSION=1.8.5
 RUN curl -sSL \


### PR DESCRIPTION
The mypy compiler (https://github.com/dropbox/mypy-protobuf/) generates typing information, which is very useful for IDEs and static analysis.

Also upgrading to newest versions of dependencies in Alpine in separate commit, because pinned versions are not available anymore, so the image can't be built currently.

