### PR TITLE
Fix docker image file modes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN mkdir -p /tmp/protoc && \
   -o /tmp/protoc/protoc.zip && \
   cd /tmp/protoc && \
   unzip protoc.zip && \
+  chmod -R o+r /tmp/protoc/include && \
   mv /tmp/protoc/include /usr/local/include
 
 RUN mkdir -p /tmp/prototool

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.4-alpine3.9 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 RUN apk add --update --no-cache build-base curl git upx && \
   rm -rf /var/cache/apk/*
@@ -75,10 +75,10 @@ WORKDIR /work
 ENV \
   PROTOTOOL_PROTOC_BIN_PATH=/usr/bin/protoc \
   PROTOTOOL_PROTOC_WKT_PATH=/usr/include \
-  GRPC_VERSION=1.21.3 \
-  PROTOBUF_VERSION=3.8.0 \
-  ALPINE_GRPC_VERSION_SUFFIX=r0 \
-  ALPINE_PROTOBUF_VERSION_SUFFIX=r0
+  GRPC_VERSION=1.25.0 \
+  PROTOBUF_VERSION=3.11.2 \
+  ALPINE_GRPC_VERSION_SUFFIX=r1 \
+  ALPINE_PROTOBUF_VERSION_SUFFIX=r1
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
   apk add --update --no-cache bash curl git grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} && \

--- a/etc/docker/testing/bin/test.sh
+++ b/etc/docker/testing/bin/test.sh
@@ -59,15 +59,15 @@ check_dir_not_exists() {
 
 check_env GOGO_PROTOBUF_VERSION 1.2.1
 check_env GOLANG_PROTOBUF_VERSION 1.3.1
-check_env GRPC_VERSION 1.19.1
+check_env GRPC_VERSION 1.25.0
 check_env GRPC_GATEWAY_VERSION 1.8.5
 check_env GRPC_WEB_VERSION 1.0.4
-check_env PROTOBUF_VERSION 3.6.1
+check_env PROTOBUF_VERSION 3.10.1
 check_env TWIRP_VERSION 5.7.0
 check_env YARPC_VERSION 1.37.3
 check_env PROTOTOOL_PROTOC_BIN_PATH /usr/bin/protoc
 check_env PROTOTOOL_PROTOC_WKT_PATH /usr/include
-check_command_output "libprotoc 3.6.1" protoc --version
+check_command_output "libprotoc 3.10.1" protoc --version
 check_command_output_file etc/wkt.txt find /usr/include -type f
 check_which /usr/bin/protoc
 check_which /usr/bin/grpc_cpp_plugin


### PR DESCRIPTION
Make files in `/usr/include/google/protobuf` world readable in the docker image.

Also update gRPC and Protobuf versions that are installed, to fix the docker image build.