### PR TITLE
Add support of ENV vars in the config-provider

### DIFF
--- a/internal/settings/BUILD.bazel
+++ b/internal/settings/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,4 +13,11 @@ go_library(
         "@in_gopkg_yaml_v2//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_provider_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/internal/settings/config_provider_test.go
+++ b/internal/settings/config_provider_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func envVar(name string) string {
+	switch name {
+	case "PWD":
+		return "/root"
+	case "USER":
+		return "user"
+	}
+	return ""
+}
+
+func TestProcessEnvVariables(t *testing.T) {
+	assert.Equal(t, "/root/home/user/", processEnvVariables("${PWD}/home/${USER}/", envVar))
+	assert.Equal(t, "${PWD}/home/user/", processEnvVariables("$${PWD}/home/${USER}/", envVar))
+	assert.Equal(t, "$/root/home/user/", processEnvVariables("$$${PWD}/home/${USER}/", envVar))
+	assert.Equal(t, "$${PWD}/home/user/", processEnvVariables("$$$${PWD}/home/${USER}/", envVar))
+	assert.Equal(t, "$$/root/home/user/", processEnvVariables("$$$$${PWD}/home/${USER}/", envVar))
+	assert.Equal(t, "$$${PWD}/home/user/", processEnvVariables("$$$$$${PWD}/home/${USER}/", envVar))
+}


### PR DESCRIPTION
To be able to use more flexible file paths was added support of ENV vars in the config-provider.

The main idea is the possibility to use the include paths from the system environment.

For example:

```yml
protoc:
  version: 3.8.0

  includes:
    - ".."
    - ${GOPATH}/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.12.1/third_party/googleapis
    - ${GOPATH}/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.12.1

lint:
  file_header:
    content: |
      // ${USER} - Document generation
    is_commented: true
```

Also, was extended `generate.go_options.import_path`, `lint.file_header.path`, `lint.file_header.content` and `lint.ignores.files` with the same reason.

NOTE: Originally it was implemented only for several fields of config but can be extended for the whole config file.
