### PR TITLE
Add walk-timeout command line flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea
 /.tmp
 /.vscode
+/prototool
 /bazel-*
 /brew
 /etc/docker/testing/gen

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,6 @@ install:
 .PHONy: bins
 bins:
 	go build ./cmd/prototool
-	cp ./prototool ../proto-sandbox/
 
 .PHONY: license
 license: __eval_srcs $(UPDATE_LICENSE)

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,11 @@ all: lint cover bazeltest bazelbuild
 install:
 	go install ./cmd/prototool
 
+.PHONy: bins
+bins:
+	go build ./cmd/prototool
+	cp ./prototool ../proto-sandbox/
+
 .PHONY: license
 license: __eval_srcs $(UPDATE_LICENSE)
 	update-license $(SRCS)

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -71,6 +71,7 @@ type flags struct {
 	tmp               bool
 	uncomment         bool
 	generateIgnores   bool
+	walkTimeout       string
 }
 
 func (f *flags) bindAddress(flagSet *pflag.FlagSet) {
@@ -259,4 +260,8 @@ func (f *flags) bindKey(flagSet *pflag.FlagSet) {
 
 func (f *flags) bindServerName(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.serverName, "server-name", "", "Override expected server \"Common Name\" when validating TLS certificate. Should usually be set if using a HTTP proxy or an IP for the --address. If set, --tls is required.")
+}
+
+func (f *flags) bindWalkTimeout(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.walkTimeout, "walk-timeout", "3s", "The maximum time to allow for walking the directory structure looking for proto files.")
 }

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -125,6 +125,7 @@ Artifacts are downloaded to the following directories based on flags and environ
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindCachePath(flagSet)
 			flags.bindConfigData(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -406,6 +407,7 @@ $ prototool grpc example \
 			flags.bindCert(flagSet)
 			flags.bindKey(flagSet)
 			flags.bindServerName(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -423,6 +425,7 @@ $ prototool grpc example \
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -441,6 +444,7 @@ $ prototool grpc example \
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -459,6 +463,7 @@ $ prototool grpc example \
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -56,6 +56,7 @@ var (
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -76,6 +77,7 @@ var (
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -95,6 +97,7 @@ var (
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
 			flags.bindOutputPathBreakDescriptorSet(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -158,6 +161,7 @@ Artifacts are downloaded to the following directories based on flags and environ
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -251,6 +255,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindProtocWKTPath(flagSet)
 			flags.bindOutputPath(flagSet)
 			flags.bindTmp(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -263,6 +268,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindConfigData(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -285,6 +291,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -304,6 +311,7 @@ If Vim integration is set up, files will be generated when you open a new Protob
 			flags.bindProtocURL(flagSet)
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -473,7 +481,7 @@ $ prototool grpc example \
 		Short: "Lint proto files and compile with protoc to check for failures.",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.Lint(args, flags.listAllLinters, flags.listLinters, flags.listAllLintGroups, flags.listLintGroup, flags.diffLintGroups, flags.generateIgnores, flags.walkTimeout)
+			return runner.Lint(args, flags.listAllLinters, flags.listLinters, flags.listAllLintGroups, flags.listLintGroup, flags.diffLintGroups, flags.generateIgnores)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindCachePath(flagSet)

--- a/internal/cmd/templates.go
+++ b/internal/cmd/templates.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	wordwrap "github.com/mitchellh/go-wordwrap"
 	"github.com/spf13/cobra"
@@ -472,7 +473,7 @@ $ prototool grpc example \
 		Short: "Lint proto files and compile with protoc to check for failures.",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(runner exec.Runner, args []string, flags *flags) error {
-			return runner.Lint(args, flags.listAllLinters, flags.listLinters, flags.listAllLintGroups, flags.listLintGroup, flags.diffLintGroups, flags.generateIgnores)
+			return runner.Lint(args, flags.listAllLinters, flags.listLinters, flags.listAllLintGroups, flags.listLintGroup, flags.diffLintGroups, flags.generateIgnores, flags.walkTimeout)
 		},
 		BindFlags: func(flagSet *pflag.FlagSet, flags *flags) {
 			flags.bindCachePath(flagSet)
@@ -488,6 +489,7 @@ $ prototool grpc example \
 			flags.bindProtocBinPath(flagSet)
 			flags.bindProtocWKTPath(flagSet)
 			flags.bindGenerateIgnores(flagSet)
+			flags.bindWalkTimeout(flagSet)
 		},
 	}
 
@@ -632,6 +634,16 @@ func getRunner(develMode bool, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		runnerOptions = append(
 			runnerOptions,
 			exec.RunnerWithProtocURL(flags.protocURL),
+		)
+	}
+	if flags.walkTimeout != "" {
+		parsedWalkTimeout, err := time.ParseDuration(flags.walkTimeout)
+		if err != nil {
+			return nil, err
+		}
+		runnerOptions = append(
+			runnerOptions,
+			exec.RunnerWithWalkTimeout(parsedWalkTimeout),
 		)
 	}
 	if develMode {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -54,7 +54,7 @@ type Runner interface {
 	Files(args []string) error
 	Compile(args []string, dryRun bool) error
 	Gen(args []string, dryRun bool) error
-	Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool, walkTimeout string) error
+	Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool) error
 	Format(args []string, overwrite, diffMode, lintMode, fix bool) error
 	All(args []string, disableFormat, disableLint, fix bool) error
 	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime string, stdin bool, details bool, tls bool, insecure bool, cacert string, cert string, key string, serverName string) error

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -25,6 +25,7 @@ package exec
 
 import (
 	"io"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -53,7 +54,7 @@ type Runner interface {
 	Files(args []string) error
 	Compile(args []string, dryRun bool) error
 	Gen(args []string, dryRun bool) error
-	Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool) error
+	Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool, walkTimeout string) error
 	Format(args []string, overwrite, diffMode, lintMode, fix bool) error
 	All(args []string, disableFormat, disableLint, fix bool) error
 	GRPC(args, headers []string, address, method, data, callTimeout, connectTimeout, keepaliveTime string, stdin bool, details bool, tls bool, insecure bool, cacert string, cert string, key string, serverName string) error
@@ -131,6 +132,13 @@ func RunnerWithProtocWKTPath(protocWKTPath string) RunnerOption {
 func RunnerWithProtocURL(protocURL string) RunnerOption {
 	return func(runner *runner) {
 		runner.protocURL = protocURL
+	}
+}
+
+// RunnerWithWalkTimeout returns a RunnerOption that sets a given walk timeout
+func RunnerWithWalkTimeout(walkTimeout time.Duration) RunnerOption {
+	return func(runner *runner) {
+		runner.walkTimeout = walkTimeout
 	}
 }
 

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -311,7 +311,7 @@ func (r *runner) doProtocCommands(compiler protoc.Compiler, meta *meta) error {
 	return nil
 }
 
-func (r *runner) Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool, walkTimeout string) error {
+func (r *runner) Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool) error {
 	if moreThanOneSet(listAllLinters, listLinters, listAllLintGroups, listLintGroup != "", diffLintGroups != "", generateIgnores) {
 		return newExitErrorf(255, "can only set one of list-all-linters, list-linters, list-all-lint-groups, list-lint-group, diff-lint-groups, update-ignores")
 	}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -79,6 +79,7 @@ type runner struct {
 	protocURL     string
 	errorFormat   string
 	json          bool
+	walkTimeout   time.Duration
 }
 
 func newRunner(workDirPath string, input io.Reader, output io.Writer, options ...RunnerOption) *runner {
@@ -97,6 +98,12 @@ func newRunner(workDirPath string, input io.Reader, output io.Writer, options ..
 		protoSetProviderOptions = append(
 			protoSetProviderOptions,
 			file.ProtoSetProviderWithConfigData(runner.configData),
+		)
+	}
+	if runner.walkTimeout != 0 {
+		protoSetProviderOptions = append(
+			protoSetProviderOptions,
+			file.ProtoSetProviderWithWalkTimeout(runner.walkTimeout),
 		)
 	}
 	if runner.develMode {
@@ -309,7 +316,7 @@ func (r *runner) doProtocCommands(compiler protoc.Compiler, meta *meta) error {
 	return nil
 }
 
-func (r *runner) Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool) error {
+func (r *runner) Lint(args []string, listAllLinters bool, listLinters bool, listAllLintGroups bool, listLintGroup string, diffLintGroups string, generateIgnores bool, walkTimeout string) error {
 	if moreThanOneSet(listAllLinters, listLinters, listAllLintGroups, listLintGroup != "", diffLintGroups != "", generateIgnores) {
 		return newExitErrorf(255, "can only set one of list-all-linters, list-linters, list-all-lint-groups, list-lint-group, diff-lint-groups, update-ignores")
 	}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -93,17 +93,12 @@ func newRunner(workDirPath string, input io.Reader, output io.Writer, options ..
 	}
 	protoSetProviderOptions := []file.ProtoSetProviderOption{
 		file.ProtoSetProviderWithLogger(runner.logger),
+		file.ProtoSetProviderWithWalkTimeout(runner.walkTimeout),
 	}
 	if runner.configData != "" {
 		protoSetProviderOptions = append(
 			protoSetProviderOptions,
 			file.ProtoSetProviderWithConfigData(runner.configData),
-		)
-	}
-	if runner.walkTimeout != 0 {
-		protoSetProviderOptions = append(
-			protoSetProviderOptions,
-			file.ProtoSetProviderWithWalkTimeout(runner.walkTimeout),
 		)
 	}
 	if runner.develMode {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -29,9 +29,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// DefaultWalkTimeout is the default walk timeout.
-const DefaultWalkTimeout time.Duration = 3 * time.Second
-
 var rootDirPath = filepath.Dir(string(filepath.Separator))
 
 // ProtoSet represents a set of .proto files and an associated config.

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -42,8 +42,7 @@ type protoSetProvider struct {
 
 func newProtoSetProvider(options ...ProtoSetProviderOption) *protoSetProvider {
 	protoSetProvider := &protoSetProvider{
-		logger:      zap.NewNop(),
-		walkTimeout: DefaultWalkTimeout,
+		logger: zap.NewNop(),
 	}
 	for _, option := range options {
 		option(protoSetProvider)

--- a/internal/file/proto_set_provider.go
+++ b/internal/file/proto_set_provider.go
@@ -225,6 +225,9 @@ func (c *protoSetProvider) walkAndGetAllProtoFiles(absWorkDirPath string, absDir
 			return nil, err
 		}
 	}
+
+	c.logger.Debug("walking the directory structure", zap.Duration("walkTimeout", c.walkTimeout))
+
 	walkErrC := make(chan error)
 	go func() {
 		walkErrC <- filepath.Walk(


### PR DESCRIPTION
Adds a `walk-timeout` flag to certain commands that involve walking the directory structure.

If no `walk-timeout` is specified where applicable, 3 seconds (`3s`) will be used as the default which is the current default.  Therefore, this maintains backwards compatibility with current walk timeout and allows users to override at a command-level.

Fixes #516