### PR TITLE
Expose prototool as a Bazel rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,8 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("//:def.bzl", "prototool")
 
 # gazelle:prefix github.com/uber/prototool
 # gazelle:proto disable_global
 gazelle(name = "gazelle")
+
+prototool(name = "prototool")

--- a/def.bzl
+++ b/def.bzl
@@ -1,0 +1,36 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _prototool_impl(ctx):
+    commands = []
+
+    # Prototool works better from relative paths, so cd to the directroy where
+    # the action was invoked.
+    commands.append("cd \"$BUILD_WORKING_DIRECTORY\"")
+
+    # Invoke prototool with the user arguments.
+    abs_prototool_path = paths.join("\"$BUILD_WORKSPACE_DIRECTORY\"", ctx.executable._prototool_executable.path)
+    commands.append("{0} $@".format(abs_prototool_path))
+
+    ctx.actions.run_shell(
+        outputs = [ctx.outputs.executable],
+        command = "echo '{commands}' > {output}".format(
+            commands = " && ".join(commands),
+            output = ctx.outputs.executable.path,
+        ),
+        arguments = ["$@"],
+        tools = [ctx.executable._prototool_executable],
+    )
+
+    return DefaultInfo(executable = ctx.outputs.executable)
+
+prototool = rule(
+    implementation = _prototool_impl,
+    executable = True,
+    attrs = {
+        "_prototool_executable": attr.label(
+            cfg = "host",
+            default = Label("//cmd/prototool"),
+            executable = True,
+        ),
+    },
+)

--- a/def.bzl
+++ b/def.bzl
@@ -8,7 +8,7 @@ def _prototool_impl(ctx):
     commands.append("cd \"$BUILD_WORKING_DIRECTORY\"")
 
     # Invoke prototool with the user arguments.
-    abs_prototool_path = paths.join("\"$BUILD_WORKSPACE_DIRECTORY\"", ctx.executable._prototool_executable.path)
+    abs_prototool_path = paths.join("\"$BUILD_WORKSPACE_DIRECTORY\"", ctx.executable._prototool.path)
     commands.append("{0} $@".format(abs_prototool_path))
 
     ctx.actions.run_shell(
@@ -18,7 +18,7 @@ def _prototool_impl(ctx):
             output = ctx.outputs.executable.path,
         ),
         arguments = ["$@"],
-        tools = [ctx.executable._prototool_executable],
+        tools = [ctx.executable._prototool],
     )
 
     return DefaultInfo(executable = ctx.outputs.executable)
@@ -27,7 +27,7 @@ prototool = rule(
     implementation = _prototool_impl,
     executable = True,
     attrs = {
-        "_prototool_executable": attr.label(
+        "_prototool": attr.label(
             cfg = "host",
             default = Label("//cmd/prototool"),
             executable = True,

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ Protobuf file, or under a second for a larger number (500+) of Protobuf files.
     * [prototool descriptor-set](#prototool-descriptor-set)
     * [prototool grpc](#prototool-grpc)
   * [Tips and Tricks](#tips-and-tricks)
+  * [Bazel Integration](#bazel-integration)
   * [Vim Integration](#vim-integration)
   * [Stability](#stability)
   * [Development](#development)
@@ -337,6 +338,46 @@ should follow some basic rules:
 - Have all Protobuf files in the same directory use the same `package`.
 - Do not use long-form `go_package` values, ie use `foopb`, not `github.com/bar/baz/foo;foopb`.
   This helps `prototool generate` do the best job.
+
+## Bazel Integration
+
+Prototool can also be invoked via Bazel. 
+
+##### Setup
+In your `WORKSAPCE`:
+
+```python
+PROTOTOOL_VERSION = "<desired version from github.com/uber/prototool/releases>"
+
+http_archive(
+    name = "com_uber_prototool",
+    strip_prefix = "prototool-" + PROTOTOOL_VERSION,
+    url = "https://github.com/uber/prototool/archive/v" + PROTOTOOL_VERSION + ".tar.gz",
+)
+
+load("@com_uber_prototool//bazel:deps.bzl", "prototool_deps")
+
+prototool_deps()
+```
+
+In your `BUILD.bazel`:
+
+```python
+load("@com_uber_prototool//:def.bzl", "prototool")
+
+prototool(name = "prototool")
+```
+
+##### Usage
+
+Prototool can now be invoked similar to the CLI tool. Note that you must pass arguments preceding "--".
+
+```bash
+> bazel run //:prototool -- version
+> bazel run //:prototool -- lint protobuf/grpc/health/v1/health.proto
+> bazel run //:prototool -- format protobuf/grpc/health/v1/health.proto
+> bazel run //:prototool -- break check --git-branch master protobuf
+```
 
 ## Vim Integration
 


### PR DESCRIPTION
In this PR we create a rule that allows prototool to be invoked by a Bazel run command. Much of the inspiration came from [buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier).

Although we can currently invoke prototool using the provided binary, it requires all arguments to be absolute:
```bash
> bazel run @com_uber_prototool//cmd/prototool -- lint $PWD/protobuf/grpc/health/v1/health.proto
../../../../../../../../../../../../../../../../../Users/appleseed/protobuf/grpc/health/v1/health.proto:26:1:Expected "healthv1" for option "go_package" but was "google.golang.org/grpc/health/grpc_health_v1".
```
As you can see, the output isn't that elegant either. Compare that to the new rule:

```bash
> bazel run //:prototool -- lint protobuf/grpc/health/v1/health.proto
protobuf/grpc/health/v1/health.proto:26:1:Expected "healthv1" for option "go_package" but was "google.golang.org/grpc/health/grpc_health_v1".
```