### PR TITLE
vim: fix ale integration

### DIFF
--- a/vim/prototool/ale_linters/proto/prototool.vim
+++ b/vim/prototool/ale_linters/proto/prototool.vim
@@ -27,6 +27,6 @@ call ale#linter#Define('proto', {
     \   'lint_file': 1,
     \   'output_stream': 'stdout',
     \   'executable': 'prototool',
-    \   'command_callback': 'ale_linters#proto#prototool#GetCommand',
+    \   'command': function('ale_linters#proto#prototool#GetCommand'),
     \   'callback': 'ale#handlers#unix#HandleAsError',
     \})

--- a/vim/prototool/ale_linters/proto/prototool_all.vim
+++ b/vim/prototool/ale_linters/proto/prototool_all.vim
@@ -9,6 +9,6 @@ call ale#linter#Define('proto', {
     \   'lint_file': 1,
     \   'output_stream': 'stdout',
     \   'executable': 'prototool',
-    \   'command_callback': 'ale_linters#proto#prototool_all#GetCommand',
+    \   'command': function('ale_linters#proto#prototool_all#GetCommand'),
     \   'callback': 'ale#handlers#unix#HandleAsError',
     \})

--- a/vim/prototool/ale_linters/proto/prototool_compile.vim
+++ b/vim/prototool/ale_linters/proto/prototool_compile.vim
@@ -9,6 +9,6 @@ call ale#linter#Define('proto', {
     \   'lint_file': 1,
     \   'output_stream': 'stdout',
     \   'executable': 'prototool',
-    \   'command_callback': 'ale_linters#proto#prototool_compile#GetCommand',
+    \   'command': function('ale_linters#proto#prototool_compile#GetCommand'),
     \   'callback': 'ale#handlers#unix#HandleAsError',
     \})

--- a/vim/prototool/ale_linters/proto/prototool_lint.vim
+++ b/vim/prototool/ale_linters/proto/prototool_lint.vim
@@ -9,6 +9,6 @@ call ale#linter#Define('proto', {
     \   'lint_file': 1,
     \   'output_stream': 'stdout',
     \   'executable': 'prototool',
-    \   'command_callback': 'ale_linters#proto#prototool_lint#GetCommand',
+    \   'command': function('ale_linters#proto#prototool_lint#GetCommand'),
     \   'callback': 'ale#handlers#unix#HandleAsError',
     \})


### PR DESCRIPTION
With latest [ALE](https://github.com/dense-analysis/ale/releases), `command_callback` is no longer available.
Instead, we have to use the `command` field. So this migrates deprecated `command_callback` to `command` + `funcref`.