### PR TITLE
substitute environment variables in config files

### DIFF
--- a/internal/settings/config_provider.go
+++ b/internal/settings/config_provider.go
@@ -177,15 +177,16 @@ func getExternalConfig(filePath string) (ExternalConfig, error) {
 	if len(data) == 0 {
 		return ExternalConfig{}, nil
 	}
+	expandedData := os.ExpandEnv(string(data))
 	externalConfig := ExternalConfig{}
 	switch filepath.Ext(filePath) {
 	case ".json":
-		if err := jsonUnmarshalStrict(data, &externalConfig); err != nil {
+		if err := jsonUnmarshalStrict([]byte(expandedData), &externalConfig); err != nil {
 			return ExternalConfig{}, err
 		}
 		return externalConfig, nil
 	case ".yaml":
-		if err := yaml.UnmarshalStrict(data, &externalConfig); err != nil {
+		if err := yaml.UnmarshalStrict([]byte(expandedData), &externalConfig); err != nil {
 			return ExternalConfig{}, err
 		}
 		return externalConfig, nil


### PR DESCRIPTION
Hi! This PR fixes #529 #498.

The current protoc shell cmd:
```
protoc -I=. -I${GOPATH}/src -I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --go_out=plugins=grpc:../pkg/server --grpc-gateway_out=logtostderr=true:../pkg/server --openapiv2_out=. server.proto
```

The analog prototool.yml:
```
protoc:
  version: 3.11.0
  includes:
    - ".."
    - ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
    - ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway
 ...
```

There is also a way to vendor the deps using go mod vendor. But unfortunately the .proto imported files do not get vendored.
 



